### PR TITLE
fix: fix click on the addon menu item that is already in view

### DIFF
--- a/shell/app/modules/addonPlatform/pages/common/components/addon-card-list.tsx
+++ b/shell/app/modules/addonPlatform/pages/common/components/addon-card-list.tsx
@@ -118,8 +118,8 @@ const AddonCardList = (props: IProps) => {
     if (!isEmpty(addonList)) {
       setDataSource(addonList.filter((addon: ADDON.Instance) => {
         const isOtherFilter = (addon.workspace === env || env === 'ALL') &&
-        searchFilter(addon, searchKey, searchProps) &&
-        searchFilter(addon, name, searchProps);
+          searchFilter(addon, searchKey, searchProps) &&
+          searchFilter(addon, name, searchProps);
 
         if (dataSourceType === 'custom') {
           const isCustomDataSource = CustomDataSourceMap.includes(addon.displayName);
@@ -172,6 +172,7 @@ const AddonCardList = (props: IProps) => {
     if (activeCategory === targetCategory) {
       return;
     }
+    setActiveCategory(targetCategory)
     scrollToTarget(targetCategory);
   };
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
the menu item already in view could not be selected before,  fixed it now

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
the menu item already in view could not be selected before,  fixed it now

## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


