### PR TITLE
feat: keep displaying issue form after saving related issue

### DIFF
--- a/shell/app/modules/project/common/components/issue/issue-relation.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-relation.tsx
@@ -119,7 +119,7 @@ export const IssueRelation = React.forwardRef((props: IProps, ref: any) => {
       title: i18n.t('status'),
       dataIndex: 'state',
       width: 100,
-      render: (v: number, record:any) => {
+      render: (v: number, record: any) => {
         const currentState = find(record?.issueButton, item => item.stateID === v);
         return currentState ? <div className='v-align'>{ISSUE_ICON.state[currentState.stateBelong]}{currentState.stateName}</div> : undefined;
       },
@@ -380,7 +380,7 @@ const AddIssueRelation = ({ onSave, editAuth, projectId, iterationID, currentIss
           onClick={() => {
             if (chosenIssue) {
               onSave(chosenIssue);
-              onClose();
+              updater.chosenIssue(undefined);
             }
           }}
         >
@@ -411,15 +411,15 @@ const AddNewIssue = ({ onSaveRelation, iterationID, onCancel, defaultIssueType }
       className="mt12"
       onCancel={onCancel}
       defaultIssueType={defaultIssueType}
-      onOk={(val: ISSUE.BacklogIssueCreateBody) => {
-        createIssue({ // 创建事件
+      onOk={async (val: ISSUE.BacklogIssueCreateBody) => {
+          return await createIssue({ // 创建事件
           projectID: +projectId,
           iterationID: +iterationID,
           priority: 'LOW',
           ...val,
         }).then((res: number) => {
           onSaveRelation(res); // 添加关联
-        }).finally(onCancel);
+        })
       }}
     />
   );

--- a/shell/app/modules/project/common/components/issue/issue-relation.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-relation.tsx
@@ -411,8 +411,8 @@ const AddNewIssue = ({ onSaveRelation, iterationID, onCancel, defaultIssueType }
       className="mt12"
       onCancel={onCancel}
       defaultIssueType={defaultIssueType}
-      onOk={async (val: ISSUE.BacklogIssueCreateBody) => {
-          return await createIssue({ // 创建事件
+      onOk={(val: ISSUE.BacklogIssueCreateBody) => {
+        return createIssue({ // 创建事件
           projectID: +projectId,
           iterationID: +iterationID,
           priority: 'LOW',


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
1.The view related with the task in the requirement can remain the original view after clicking OK, and only refresh the list below, keeping the query criteria area 

![image](https://user-images.githubusercontent.com/30014895/117623606-935d8800-b1a6-11eb-8e1e-5d070a677453.png)
![image](https://user-images.githubusercontent.com/30014895/117623724-b720ce00-b1a6-11eb-90c2-caa19cb121f7.png)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:
![image](https://user-images.githubusercontent.com/30014895/117624151-2d253500-b1a7-11eb-800b-fae0229b9b42.png)
![image](https://user-images.githubusercontent.com/30014895/117624259-4fb74e00-b1a7-11eb-88c3-0ef5f2fb9b8c.png)

onOk(val) is not a Promise, so use async ... await wrapped it

