### PR TITLE
fix: add new state to restore total workflow data

### DIFF
--- a/shell/app/modules/project/common/components/issue-workflow.tsx
+++ b/shell/app/modules/project/common/components/issue-workflow.tsx
@@ -27,7 +27,7 @@ import './issue-workflow.scss';
 const IssueWorkflow = () => {
   const { projectId: projectID } = routeInfoStore.getState(s => s.params);
 
-  const [issueList, workflowStateList] = issueWorkflowStore.useStore(s => [s.issueList, s.workflowStateList]);
+  const [issueList, totalWorkflowStateList] = issueWorkflowStore.useStore(s => [s.issueList, s.totalWorkflowStateList]);
   const { getStatesByIssue, getIssueList, clearIssueList } = issueWorkflowStore;
 
   useEffectOnce(() => {
@@ -70,7 +70,7 @@ const IssueWorkflow = () => {
                     </div>
                   </div>
                   <div className="sub">
-                    <span>{i18n.t('admin:status')}：</span>
+                    <span>{i18n.t('common:state')}：</span>
                     <div>
                       {
                         map(Object.entries(issueStateMap[item.issueType]), (data:string[]) => {
@@ -84,7 +84,7 @@ const IssueWorkflow = () => {
                     <div className='default-workflow-content'>
                       {
                         map(item.state, (name:string) => {
-                          const curStateBelong = get(find(workflowStateList, { stateName: name }), 'stateBelong');
+                          const curStateBelong = get(find(totalWorkflowStateList, { stateName: name }), 'stateBelong');
                           return <div className='v-align mr12 mb8'>{ISSUE_STATE_MAP[curStateBelong]?.icon}{name}</div>;
                         })
                       }

--- a/shell/app/modules/project/stores/issue-workflow.ts
+++ b/shell/app/modules/project/stores/issue-workflow.ts
@@ -25,11 +25,13 @@ import {
 interface IState {
   issueList: ISSUE_WORKFLOW.IIssueItem[];
   workflowStateList: ISSUE_WORKFLOW.IIssueStateItem[];
+  totalWorkflowStateList: ISSUE_WORKFLOW.IIssueStateItem[];
 }
 
 const initState: IState = {
   issueList: [],
   workflowStateList: [],
+  totalWorkflowStateList: [],
 };
 
 const issueWorkflowStore = createFlatStore({
@@ -42,7 +44,12 @@ const issueWorkflowStore = createFlatStore({
     },
     async getStatesByIssue({ call, update }, payload: ISSUE_WORKFLOW.IStateQuery) {
       const workflowStateList = await call(getStatesByIssue, payload);
-      update({ workflowStateList });
+      if (!payload.issueType) {
+        update({ totalWorkflowStateList: workflowStateList });
+      } else {
+        update({ workflowStateList });
+      }
+
       return workflowStateList;
     },
     async batchUpdateIssueState({ call }, payload: ISSUE_WORKFLOW.IUpdateQuery) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
when page inits, we all get total workflow state data and save it in cube state. When we click each issue panel, we will refetch this data again, but with the contain issueType. So the data of workflowStateList will change every time when we click the issue panel, which cause the error map of state icon.
So I add "totalWorkflowStateList" to store the full data.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [x] No


## Special notes for your reviewer:


