### PR TITLE
fix: show test set after first adding it

### DIFF
--- a/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
@@ -109,7 +109,7 @@ const TestSet = ({
     caseModal: modalTestSet,
     temp: tempTestSet,
   };
-  const currentTestSet: TEST_SET.TestSet[] = React.useMemo(() => testSet[mode], [mode])
+  const currentTestSet: TEST_SET.TestSet[] = React.useMemo(() => testSet[mode], [mode]);
 
   useMount(() => {
     getProjectTestSets({ testPlanID, mode, recycled: false, parentID: rootId, forceUpdate: true });

--- a/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
@@ -109,7 +109,7 @@ const TestSet = ({
     caseModal: modalTestSet,
     temp: tempTestSet,
   };
-  const currentTestSet: TEST_SET.TestSet[] = testSet[mode];
+  const currentTestSet: TEST_SET.TestSet[] = React.useMemo(() => testSet[mode], [mode])
 
   useMount(() => {
     getProjectTestSets({ testPlanID, mode, recycled: false, parentID: rootId, forceUpdate: true });

--- a/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
@@ -109,7 +109,8 @@ const TestSet = ({
     caseModal: modalTestSet,
     temp: tempTestSet,
   };
-  const currentTestSet: TEST_SET.TestSet[] = React.useMemo(() => testSet[mode], [mode]);
+  const setRef = React.useRef(testSet);
+  const currentTestSet: TEST_SET.TestSet[] = React.useMemo(() => setRef.current[mode], [setRef, mode]);
 
   useMount(() => {
     getProjectTestSets({ testPlanID, mode, recycled: false, parentID: rootId, forceUpdate: true });


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
Fixed setting up test set the first time and showing it

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Fixed setting up test set the first time and showing it

## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:
currentTestSet is reassigned with the same value, causing the TreeData to be incorrectly overwritten after the rerender

