### PR TITLE
Hotfix: display test set after adding it in first time

### DIFF
--- a/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
@@ -109,13 +109,11 @@ const TestSet = ({
     caseModal: modalTestSet,
     temp: tempTestSet,
   };
-  const setRef = React.useRef(testSet);
-  const currentTestSet: TEST_SET.TestSet[] = React.useMemo(() => setRef.current[mode], [setRef, mode]);
+  const currentTestSet: TEST_SET.TestSet[] = testSet[mode];
 
   useMount(() => {
     getProjectTestSets({ testPlanID, mode, recycled: false, parentID: rootId, forceUpdate: true });
   });
-
 
   const loadTreeNode = (arr: string[], isInRecycleBin = false) => {
     arr.reduce(async (prev, curr) => {
@@ -618,8 +616,8 @@ const TestSet = ({
     });
     updateSearch({ pageNo: 1, recycled, testSetID, eventKey });
 
-     // 页面刚刚进来时保持当前 query 不进行更新
-     if (!_extra.keepCurrentSearch) {
+    // 页面刚刚进来时保持当前 query 不进行更新
+    if (!_extra?.keepCurrentSearch) {
       updateSearch({ pageNo: 1, recycled, testSetID, eventKey });
     }
 

--- a/shell/app/modules/project/stores/test-set.ts
+++ b/shell/app/modules/project/stores/test-set.ts
@@ -101,7 +101,7 @@ const testSetStore = createStore({
   name: 'testSet',
   state: initState,
   effects: {
-    async getProjectTestSets({ call, update, getParams }, payload: Merge<Omit<TEST_SET.GetQuery, 'projectID'>, { mode: TEST_CASE.PageScope, forceUpdate?: boolean }>) {
+    async getProjectTestSets({ call, update, getParams, select }, payload: Merge<Omit<TEST_SET.GetQuery, 'projectID'>, { mode: TEST_CASE.PageScope, forceUpdate?: boolean }>) {
       const { projectId } = getParams();
       const { mode, forceUpdate = false, ...rest } = payload;
       if (!rest.parentID) {
@@ -121,6 +121,8 @@ const testSetStore = createStore({
         } else if (mode === 'temp') {
           update({ tempTestSet: testSet });
         } else {
+          const prevProjectTestSet = select(s => s.projectTestSet);
+          if (isEmpty(prevProjectTestSet) && isEmpty(testSet)) return;
           update({ projectTestSet: testSet });
         }
         return testSet;

--- a/shell/app/modules/project/stores/test-set.ts
+++ b/shell/app/modules/project/stores/test-set.ts
@@ -121,6 +121,7 @@ const testSetStore = createStore({
         } else if (mode === 'temp') {
           update({ tempTestSet: testSet });
         } else {
+          // When projectTestSet is empty, it will trigger to execute useEffect which is unnecessary. The specific reasons mentioned above need to be investigated.
           const prevProjectTestSet = select(s => s.projectTestSet);
           if (isEmpty(prevProjectTestSet) && isEmpty(testSet)) return;
           update({ projectTestSet: testSet });


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
To optimize the fix of  [fix: show test set after first adding it #136] last time.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


