### PR TITLE
fix: register module which have router data first

### DIFF
--- a/shell/app/App.tsx
+++ b/shell/app/App.tsx
@@ -46,24 +46,26 @@ const start = (userData: ILoginUser) => {
   };
 
   startApp().then(async (App) => {
-    [
-      import('layout/entry'),
-      import('app/org-home/entry'),
-      import('workBench/entry'),
-      import('runtime/entry'),
-      import('publisher/entry'),
-      import('project/entry'),
-      import('apiManagePlatform/entry'),
-      import('microService/entry'),
-      import('app/modules/edge/entry'),
-      import('application/entry'),
-      import('dataCenter/entry'),
-      import('user/entry'),
-      import('dcos/entry'),
-      import('org/entry'),
-      import('addonPlatform/entry'),
-      ...Object.values(modules),
-    ].forEach((p) => p.then(m => m.default(registerModule)));
+    import('app/org-home/entry').then(m => {
+      m.default(registerModule);
+      [
+        import('layout/entry'),
+        import('org/entry'),
+        import('workBench/entry'),
+        import('runtime/entry'),
+        import('publisher/entry'),
+        import('project/entry'),
+        import('apiManagePlatform/entry'),
+        import('microService/entry'),
+        import('app/modules/edge/entry'),
+        import('application/entry'),
+        import('dataCenter/entry'),
+        import('user/entry'),
+        import('dcos/entry'),
+        import('addonPlatform/entry'),
+        ...Object.values(modules),
+      ].forEach((p) => p.then(m => m.default(registerModule)));
+    })
     userStore.reducers.setLoginUser(userData); // 需要在app start之前初始化用户信息
     if (!userData.isSysAdmin) {
       const orgName = get(location.pathname.split('/'), '[1]');


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
Register module with router data will init routeInfo at first of all, otherwise routeInfo will be old data when get in subscription.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [x] No


## Special notes for your reviewer:


