### PR TITLE
Hotfix: jump to personal home page after joining it

### DIFF
--- a/shell/app/layout/common/invite-to-org.tsx
+++ b/shell/app/layout/common/invite-to-org.tsx
@@ -40,7 +40,7 @@ export default () => {
     if (domain.startsWith('local')) {
       domain = domain.split('.').slice(1).join('.');
     }
-    
+
     getOrgByDomain({ domain, orgName }).then((res: any) => {
       res.success && !isEmpty(res.data) && updater.domainData(res.data);
     });
@@ -58,7 +58,7 @@ export default () => {
     }).then(() => {
       message.success(i18n.t('join org success'));
       setTimeout(() => {
-        window.location.reload();
+        location.href = `/${orgName}`;
       }, 200);
     });
   };

--- a/shell/app/org-home/stores/org.tsx
+++ b/shell/app/org-home/stores/org.tsx
@@ -89,6 +89,12 @@ const org = createStore({
       } else {
         const currentOrg = resOrg || {};
         const orgId = currentOrg.id;
+        if (curPathname.startsWith(`/${orgName}/inviteToOrg`)) {
+          if (orgs?.list?.find((x) => x.name === currentOrg.name)) {
+            location.href = `/${currentOrg.name}`;
+          }
+          return;
+        }
         // user doesn't joined the public org, go to workBench
         // temporary solution, it will removed until new solution is proposed by PD
         if (resOrg?.isPublic && curPathname?.split('/')[2] !== 'workBench') {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
1. if the user joined the organization, it will redirect personal home page(current organization) when the user enter /orgName/inviteToOrg
2. if the user don't joined the organization, it will jump to personal home page(just joined organiztion) after joining successfully

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


