### PR TITLE
feat: add erda-ui-enterprise branch check

### DIFF
--- a/cli/bin/erda.ts
+++ b/cli/bin/erda.ts
@@ -58,6 +58,7 @@ program
   .option('-i, --image <image>', 'image sha as build base, e.g. 1.0-20210506-48bd74')
   .option('-l, --local', 'enable local mode, if image arg is given, then local mode is forcibly')
   .option('-s, --skip', 'skip the cli version check')
+  .option('-m, --enableSourceMap', 'generate source map')
   .action(async (options) => {
     await checkCliVersion(options);
     build(options);
@@ -75,7 +76,9 @@ program
   .command('release')
   .description('build & push docker image')
   .option('-i, --image <image>', 'image sha as build base, e.g. 1.0-20210506-48bd74')
+  .option('-l, --local', 'enable local mode, if image arg is given, then local mode is forcibly')
   .option('-s, --skip', 'skip the cli version check')
+  .option('-m, --enableSourceMap', 'generate source map')
   .action((options) => {
     release(options);
   });

--- a/cli/lib/build.ts
+++ b/cli/lib/build.ts
@@ -63,13 +63,11 @@ const checkBranch = async () => {
   logInfo(`Current Branch of erda-ui:【${moduleBranches[0]}】`);
 
   if (moduleBranches.length > 1) {
-    const dependentModuleBranches: string[] = [];
+    logInfo('Current Branch of dependent modules:');
     moduleList.filter(({ moduleName }) => !['core', 'shell'].includes(moduleName))
       .forEach(({ moduleName }, index) => {
-        dependentModuleBranches.push(`${moduleName}:【${moduleBranches[index + 1]}】`);
+        logInfo(`${moduleName}:【${moduleBranches[index + 1]}】`);
       });
-
-    logInfo('Current Branch of dependent modules: ', dependentModuleBranches.join(', '));
   }
 
   const isAllReleaseBranch = moduleBranches.every((branch) => {

--- a/cli/lib/release.ts
+++ b/cli/lib/release.ts
@@ -32,13 +32,15 @@ export default async ({ image: baseImage, skip, enableSourceMap, local }: Props)
   try {
     checkIsRoot();
     const rootDir = process.cwd();
-    const isSkip = skip ? '-s' : '';
-    const createSourceMap = enableSourceMap ? '-m' : '';
-    const isLocalMode = local ? '-l' : '';
+    const extraOptions = [];
+
+    skip && extraOptions.push('-s');
+    enableSourceMap && extraOptions.push('-m');
+    local && extraOptions.push('-l');
 
     const buildProcess = await spawnSync('erda-ui', baseImage
-      ? ['build', '-i', baseImage, isSkip, createSourceMap]
-      : ['build', isSkip, isLocalMode, createSourceMap], { env: process.env, cwd: rootDir, stdio: 'inherit' });
+      ? ['build', '-i', baseImage, ...extraOptions]
+      : ['build', ...extraOptions], { env: process.env, cwd: rootDir, stdio: 'inherit' });
 
     if (buildProcess.status === 1) {
       process.exit(1);

--- a/cli/lib/release.ts
+++ b/cli/lib/release.ts
@@ -21,12 +21,24 @@ const { execSync, spawnSync } = child_process;
 
 const GET_SHA_CMD = 'git rev-parse --short HEAD';
 
-export default async ({ image: baseImage, skip }: { image?: string; skip?: boolean }) => {
+interface Props {
+  image?: string;
+  skip?: boolean;
+  local?: boolean;
+  enableSourceMap?: boolean;
+}
+
+export default async ({ image: baseImage, skip, enableSourceMap, local }: Props) => {
   try {
     checkIsRoot();
     const rootDir = process.cwd();
     const isSkip = skip ? '-s' : '';
-    const buildProcess = await spawnSync('erda-ui', baseImage ? ['build', '-i', `${baseImage}`, `${isSkip}`] : ['build', `${isSkip}`], { env: process.env, cwd: rootDir, stdio: 'inherit' });
+    const createSourceMap = enableSourceMap ? '-m' : '';
+    const isLocalMode = local ? '-l' : '';
+
+    const buildProcess = await spawnSync('erda-ui', baseImage
+      ? ['build', '-i', baseImage, isSkip, createSourceMap]
+      : ['build', isSkip, isLocalMode, createSourceMap], { env: process.env, cwd: rootDir, stdio: 'inherit' });
 
     if (buildProcess.status === 1) {
       process.exit(1);


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [ ] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
1) the dependent projects like erda-ui-enterprise may not be the correct branch when executing release branch. As a result, the dists of admin and fdp will be wrong. Considering the injected modules may not be only from 'erda-ui-enterprise' in the future, we should check every branch of these modules.

2) add option of "-m --sourceMap" to skip the nonessential step;

3) add options of '-l' to command 'release' so that this command will not be limited by option "image"

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


