### PR TITLE
Hotfix: keep query in manul test when refresh it

### DIFF
--- a/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
@@ -614,7 +614,6 @@ const TestSet = ({
       testSetID,
       testPlanID,
     });
-    updateSearch({ pageNo: 1, recycled, testSetID, eventKey });
 
     // 页面刚刚进来时保持当前 query 不进行更新
     if (!_extra?.keepCurrentSearch) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
This bug has been fixed before，Reason for recurrence is the operation that in feat: pick code from old release (#36)。
before:
![image](https://user-images.githubusercontent.com/30014895/120174648-e53e7e80-c237-11eb-810a-decda210bdac.png)

after misoperation:
![image](https://user-images.githubusercontent.com/30014895/120174836-22a30c00-c238-11eb-848e-7c058c61ca63.png)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


