### PR TITLE
Feature: show info of public organization in personal homepage when the user doesn't  join it

### DIFF
--- a/shell/app/config-page/components/dropdown-select/dropdown-select.spec.d.ts
+++ b/shell/app/config-page/components/dropdown-select/dropdown-select.spec.d.ts
@@ -29,6 +29,7 @@ declare namespace CP_DROPDOWN_SELECT {
 
   interface IState {
     value: string;
+    label: string;
   }
 
   interface IOptionItem {

--- a/shell/app/config-page/components/dropdown-select/dropdown-select.tsx
+++ b/shell/app/config-page/components/dropdown-select/dropdown-select.tsx
@@ -22,11 +22,11 @@ const DropdownSelect = (props: CP_DROPDOWN_SELECT.Props) => {
   const { execOperation, props: configProps, state: propsState } = props;
   const { options, quickSelect = [], overlay, trigger, visible, ...restProps } = configProps;
   let _overlay = overlay;
-  const [value, setValue] = React.useState(propsState.value)
+  const [value, setValue] = React.useState(propsState.value);
   const [filterValue, setFilterValue] = React.useState('');
-  const [active, setActive] = React.useState(false)
+  const [active, setActive] = React.useState(false);
 
-  const label = React.useMemo(() => get(options?.find(item => item.value === value), 'label', ''), [value])
+  const label = React.useMemo(() => get(options?.find(item => item.value === value), 'label', ''), [value]);
 
   const gotoSpecificPage = (item: CP_DROPDOWN_SELECT.IQuickSelect) => {
     item?.operations && item?.operations?.click && execOperation(item.operations.click)
@@ -130,8 +130,10 @@ const DropdownSelect = (props: CP_DROPDOWN_SELECT.Props) => {
       {...restProps}
     >
       <span
-        className='dropdown-select-button hover-active' onClick={() => setActive(!active)}>
-        {label}
+        className='dropdown-select-button hover-active'
+        onClick={() => setActive(!active)}
+      >
+        {propsState?.label || label}
         <CustomIcon style={{ color: 'inherit' }} type="caret-down" />
       </span>
 

--- a/shell/app/org-home/pages/personal-home.mock.ts
+++ b/shell/app/org-home/pages/personal-home.mock.ts
@@ -197,7 +197,8 @@ export const mockSidebar: CONFIG_PAGE.RenderConfig = {
           ],
         },
         state: {
-          value: 'organizeA',
+          value: 'organizeC',
+          label: '组织C',
         }
       },
       joinedBrief: {
@@ -599,9 +600,11 @@ export const mockContent: CONFIG_PAGE.RenderConfig = {
       root: 'page',
       structure: {
         page: ['content'],
-        content: ['title', 'emptyOrgTip', 'emptyProjectTip', 'emptyProjectIssue', 'tableGroup'],
+        content: ['title', 'emptyOrgTip', 'emptyPublicOrgTip', 'emptyProjectTip', 'emptyProjectIssue', 'tableGroup'],
         emptyOrgTip: { left: 'erdaLogo', right: 'emptyOrgText' },
         emptyOrgText: ['emptyOrgTitle', 'emptyOrgContent'],
+        emptyPublicOrgTip: { left: 'orgLogo', right: 'emptyPublicOrgText' },
+        emptyPublicOrgText: ['emptyPublicOrgTitle', 'emptyPublicOrgContent'],
         emptyProjectTip: { left: 'orgLogo', right: 'emptyProjectText' },
         emptyProjectText: ['emptyProjectTitle', 'emptyProjectContent'],
       },
@@ -748,6 +751,114 @@ export const mockContent: CONFIG_PAGE.RenderConfig = {
             reload: false,
             show: false,
           },
+        },
+      },
+      emptyPublicOrgTip: {
+        type: 'LRContainer',
+        props: {
+          visible: true,
+          whiteBg: true,
+          startAlign: true,
+          contentSetting: 'start',
+        },
+      },
+      emptyPublicOrgText: {
+        type: 'Container',
+        props: {
+          visible: true,
+        },
+      },
+      emptyPublicOrgTitle: {
+        type: 'Title',
+        props: {
+          visible: true,
+          title: '你当前正在浏览公开组织 XXXX',
+          level: 2,
+        },
+      },
+      emptyPublicOrgContent: {
+        type: 'TextGroup',
+        props: {
+          visible: true,
+          value: [
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '以下是作为平台新成员的一些快速入门知识：',
+              },
+              gapSize: 'large',
+            },
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '* 切换组织',
+                styleConfig: {
+                  bold: true
+                },
+              },
+              gapSize: 'small',
+            },
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '使用此屏幕上左上角的组织切换，快速进行组织之间切换',
+              },
+              gapSize: 'large',
+            },
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '* 公开项目浏览',
+                styleConfig: {
+                  bold: true
+                },
+              },
+              gapSize: 'small',
+            },
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '可以在左侧项目下公开项目信息进行浏览',
+              },
+              gapSize: 'large',
+            },
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '* 加入组织',
+                styleConfig: {
+                  bold: true,
+                }
+              },
+              gapSize: 'small',
+            },
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '组织当前都是受邀机制，需要线下联系企业所有者进行邀请加入',
+              },
+              gapSize: 'large',
+            },
+            {
+              props: {
+                renderType: 'text',
+                visible: true,
+                value: '当你已经加入到该公开组织后，此框将不再显示',
+                textStyleName: {
+                  'fz12': true,
+                  'color-text-desc': true,
+                },
+              },
+              gapSize: 'normal',
+            },
+          ],
         },
       },
       emptyProjectTip: {


### PR DESCRIPTION
…user doesn't join it

## What type of PR is this?

- [x] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
show info of public organization in personal homepage when the user doesn't join it.
![image](https://user-images.githubusercontent.com/30014895/120305800-c4dbf600-c303-11eb-8f63-f9d6a10fb1b2.png)

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


