### PR TITLE
fix: show loading status before getting runtimes in deploy page

### DIFF
--- a/shell/app/modules/application/stores/deploy.ts
+++ b/shell/app/modules/application/stores/deploy.ts
@@ -85,7 +85,8 @@ const deploy = createStore({
     });
   },
   effects: {
-    async getRunTimes({ call, getParams, update, select }) {
+    // useLoading unable to detect changes if without payload(beforeEffect didn't execute) 
+    async getRunTimes({ call, getParams, update, select }, _?: unknown) {
       const { appId } = getParams();
       const oldRuntimes = select(s => s.runtimes);
       if (appId) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
show loading status before getting runtimes in the deploy page

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
![image](https://user-images.githubusercontent.com/30014895/120573435-26a97680-c450-11eb-8abe-8d57254ad70f.png)

![image](https://user-images.githubusercontent.com/30014895/120573558-5a849c00-c450-11eb-8a6a-e04181efac54.png)

so add _ as payload to solve this bug


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


