### PR TITLE
feat: separate related-issue buttons

### DIFF
--- a/shell/app/modules/project/common/components/issue/issue-relation.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-relation.tsx
@@ -202,18 +202,24 @@ export const IssueRelation = React.forwardRef((props: IProps, ref: any) => {
             // )
             : (
               <>
-                <ButtonGroup>
+                <div>
                   <WithAuth pass={usePerm(s => s.project.requirement.create.pass)}>
                     <Button
                       type={activeButtonType === 'create' ? 'primary' : 'default'}
                       onClick={() => setActiveButtonType('create')}
-                    >{i18n.t('project:create and relate to the issue')}
+                    >
+                      {i18n.t('project:create and relate to the issue')}
                     </Button>
                   </WithAuth>
                   <WithAuth pass={authObj.edit.pass}>
-                    <Button type={activeButtonType === 'exist' ? 'primary' : 'default'} onClick={() => setActiveButtonType('exist')}>{i18n.t('project:relating to existing issues')}</Button>
+                    <Button
+                      type={activeButtonType === 'exist' ? 'primary' : 'default'}
+                      onClick={() => setActiveButtonType('exist')}
+                      className='ml12'
+                    >
+                      {i18n.t('project:relating to existing issues')}</Button>
                   </WithAuth>
-                </ButtonGroup>
+                </div>
                 <IF check={activeButtonType === 'create'}>
                   <AddNewIssue
                     onSaveRelation={addRelation}

--- a/shell/app/modules/project/common/components/issue/issue-relation.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-relation.tsx
@@ -217,7 +217,8 @@ export const IssueRelation = React.forwardRef((props: IProps, ref: any) => {
                       onClick={() => setActiveButtonType('exist')}
                       className='ml12'
                     >
-                      {i18n.t('project:relating to existing issues')}</Button>
+                      {i18n.t('project:relating to existing issues')}
+                    </Button>
                   </WithAuth>
                 </div>
                 <IF check={activeButtonType === 'create'}>


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [ ] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [x] Style
- [ ] Chore

## What this PR does / why we need it:
separate related-issue buttons to prevent users from treating it as a tab

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
before:
![image](https://user-images.githubusercontent.com/30014895/120580302-88231280-c45b-11eb-8bdb-5ce534e4c992.png)

current:
![image](https://user-images.githubusercontent.com/30014895/120580178-4d20df00-c45b-11eb-884b-867926e28f69.png)


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


