### PR TITLE
fix: get clusterList and leftResources when edit project Modal

### DIFF
--- a/shell/app/modules/org/pages/projects/create-project.tsx
+++ b/shell/app/modules/org/pages/projects/create-project.tsx
@@ -60,8 +60,10 @@ export const useQuotaFields = (
   const [isLoading] = useLoading(projectStore, ['getLeftResources']);
 
   React.useEffect(() => {
-    canGetClusterListAndResources && clusterStore.effects.getClusterList();
-    canGetClusterListAndResources && getLeftResources();
+    if (canGetClusterListAndResources) {
+      clusterStore.effects.getClusterList();
+      getLeftResources();
+    }
     return () => {
       clearLeftResources();
     };

--- a/shell/app/modules/org/pages/projects/create-project.tsx
+++ b/shell/app/modules/org/pages/projects/create-project.tsx
@@ -52,18 +52,20 @@ export const useQuotaFields = (
   canEdit: boolean,
   showTip: boolean,
   usedResource: { cpuQuota: number; memQuota: number },
+  canGetClusterListAndResources = true,
 ) => {
   const leftResource = projectStore.useStore((s) => s.leftResources);
   const { getLeftResources } = projectStore.effects;
   const { clearLeftResources } = projectStore.reducers;
   const [isLoading] = useLoading(projectStore, ['getLeftResources']);
-  useEffectOnce(() => {
-    clusterStore.effects.getClusterList();
-    getLeftResources();
+
+  React.useEffect(() => {
+    canGetClusterListAndResources && clusterStore.effects.getClusterList();
+    canGetClusterListAndResources && getLeftResources();
     return () => {
       clearLeftResources();
     };
-  });
+  }, [canGetClusterListAndResources, clearLeftResources, getLeftResources]);
 
   const leftCpu = Math.round((get(leftResource, 'availableCpu') || 0) + usedResource.cpuQuota); // 编辑时，可用值需要加上当前项目已经占用的
   const leftMem = Math.round((get(leftResource, 'availableMem') || 0) + usedResource.memQuota);

--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -28,6 +28,7 @@ interface IProps {
   readonlyForm?: JSX.Element;
   extraSections?: any[];
   updateInfo: (data: any) => Promise<any> | void;
+  setCanGetClusterListAndResources?: (value: boolean) => void;
 }
 interface IField {
   label?: string;
@@ -54,6 +55,8 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
 
   toggleModal = () => {
     this.setState({ modalVisible: !this.state.modalVisible });
+    this.props.setCanGetClusterListAndResources &&
+      this.props.setCanGetClusterListAndResources(!this.state.modalVisible);
   };
 
   handleSubmit = (values: object) => {

--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -55,9 +55,7 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
 
   toggleModal = () => {
     this.setState({ modalVisible: !this.state.modalVisible });
-    if (this.props.setCanGetClusterListAndResources) {
-      this.props.setCanGetClusterListAndResources(!this.state.modalVisible);
-    }
+    this.props.setCanGetClusterListAndResources?.(!this.state.modalVisible);
   };
 
   handleSubmit = (values: object) => {

--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -55,8 +55,9 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
 
   toggleModal = () => {
     this.setState({ modalVisible: !this.state.modalVisible });
-    this.props.setCanGetClusterListAndResources &&
+    if (this.props.setCanGetClusterListAndResources) {
       this.props.setCanGetClusterListAndResources(!this.state.modalVisible);
+    }
   };
 
   handleSubmit = (values: object) => {

--- a/shell/app/modules/project/pages/settings/components/project-info.tsx
+++ b/shell/app/modules/project/pages/settings/components/project-info.tsx
@@ -53,6 +53,7 @@ export default ({ canEdit, canDelete, canEditQuota, showQuotaTip }: IProps) => {
   const orgName = routeInfoStore.useStore((s) => s.params.orgName);
   const info = projectStore.useStore((s) => s.info);
   const [confirmProjectName, setConfirmProjectName] = React.useState('');
+  const [canGetClusterListAndResources, setCanGetClusterListAndResources] = React.useState(false);
   const updatePrj = (values: Obj) => {
     const { cpuQuota, memQuota, isPublic } = values;
     updateProject({ ...values, cpuQuota: +cpuQuota, memQuota: +memQuota, isPublic: isPublic === 'true' }).then(() => {
@@ -101,7 +102,12 @@ export default ({ canEdit, canDelete, canEditQuota, showQuotaTip }: IProps) => {
       required: false,
       itemProps: { rows: 4, maxLength: 200 },
     },
-    ...useQuotaFields(canEditQuota, showQuotaTip, { cpuQuota: info.cpuQuota, memQuota: info.memQuota }),
+    ...useQuotaFields(
+      canEditQuota,
+      showQuotaTip,
+      { cpuQuota: info.cpuQuota, memQuota: info.memQuota },
+      canGetClusterListAndResources,
+    ),
     // {
     //   label: i18n.t('project:DingTalk notification address'),
     //   name: 'ddHook',
@@ -176,6 +182,7 @@ export default ({ canEdit, canDelete, canEditQuota, showQuotaTip }: IProps) => {
   return (
     <SectionInfoEdit
       hasAuth={canEdit}
+      setCanGetClusterListAndResources={setCanGetClusterListAndResources}
       data={{ ...info, isPublic: `${info.isPublic || 'false'}` }}
       fieldsList={fieldsList}
       updateInfo={updatePrj}


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
When the user enters the project settings page，it shouldn't trigger the interface request about getClusterList and getLeftResources, when the user edit project(Modal), it can trigger it

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


