### PR TITLE
fix: prevent getting stats without organization

### DIFF
--- a/shell/app/layout/pages/page-container/components/sidebar.tsx
+++ b/shell/app/layout/pages/page-container/components/sidebar.tsx
@@ -172,7 +172,7 @@ const SideBar = () => {
       },
     },
     {
-      show: !loginUser.isSysAdmin && currentOrg.id,
+      show: !loginUser.isSysAdmin,
       icon: (
         <Badge dot count={unreadCount} offset={[-5, 2]} style={{ width: '4px', height: '4px', boxShadow: 'none' }}>
           <Icon type="bell" style={customIconStyle} />


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
1. keep the bell icon (personal notification) in the sidebar
![image](https://user-images.githubusercontent.com/30014895/123725612-ef987a80-d8c0-11eb-8967-1122506116b6.png)

2. don't trigger interface of mbox without organization

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


