### PR TITLE
fix: hide icon that jump to personal home when the user is admin

### DIFF
--- a/shell/app/layout/pages/page-container/components/sidebar.tsx
+++ b/shell/app/layout/pages/page-container/components/sidebar.tsx
@@ -214,6 +214,7 @@ const SideBar = () => {
     <GlobalNavigation
       layout="vertical"
       verticalBrandIcon={
+        loginUser.isSysAdmin ? null :
         <img
           className="mr0 pointer"
           src={Logo}
@@ -294,7 +295,7 @@ const PopoverSelector = (props: IPopoverSelectorProps) => {
       <CustomIcon type='appstore' className='fz20 ml4' />
     </div>
   );
-  
+
   const onClick = (e: any) => {
     e.domEvent.stopPropagation();
   };


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
hide icon that jump to personal home when the user is admin
![image](https://user-images.githubusercontent.com/30014895/123762283-3dc77100-d8f5-11eb-89df-5b1ed91895ab.png)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


