### PR TITLE
fix: some issue about that  jump to personal home

### DIFF
--- a/shell/app/layout/pages/page-container/components/sidebar.tsx
+++ b/shell/app/layout/pages/page-container/components/sidebar.tsx
@@ -183,7 +183,7 @@ const SideBar = () => {
       },
     },
     {
-      show: !loginUser.isSysAdmin && currentOrg.id,
+      show: !loginUser.isSysAdmin,
       icon: (
         <Badge dot count={unreadCount} offset={[-5, 2]} style={{ width: '4px', height: '4px', boxShadow: 'none' }}>
           <IconRemind className="mr0" size="20px" style={customIconStyle} />
@@ -229,22 +229,27 @@ const SideBar = () => {
     <GlobalNavigation
       layout="vertical"
       verticalBrandIcon={
-        <img
-          className="mr0 pointer"
-          src={Logo}
-          style={{
-            width: '19px',
-            height: '19px',
-          }}
-          onClick={() => {
-            const isIncludeOrg = !!orgs.find((x: Obj) => x.name === curOrgName);
-            if (isIncludeOrg) {
-              goTo(goTo.pages.orgRoot);
-            } else {
-              message.warning(i18n.t('default:org-jump-tip'), 2, () => goTo(goTo.pages.orgRoot, { orgName: '-' }));
-            }
-          }}
-        />
+        loginUser.isSysAdmin ? null : (
+          <img
+            className="mr0 pointer"
+            src={Logo}
+            style={{
+              width: '19px',
+              height: '19px',
+            }}
+            onClick={() => {
+              const isIncludeOrg = !!orgs.find((x: Obj) => x.name === curOrgName);
+              if (isIncludeOrg) {
+                goTo(goTo.pages.orgRoot);
+              } else if (!orgs?.length) {
+                // skipping warning when the user doesn't join any organization.
+                goTo(goTo.pages.orgRoot, { orgName: '-' });
+              } else {
+                message.warning(i18n.t('default:org-jump-tip'), 2, () => goTo(goTo.pages.orgRoot, { orgName: '-' }));
+              }
+            }}
+          />
+        )
       }
       // appName=''
       // horizontalBrandIcon={ // 横向sidebar待定


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:

it has been merged to release/1.0,  can't cherry-pick to master.
1. hide icon that jumps to personal home when the user is admin
2. prevent getting stats without organization
3. skip warning message when the user doesn't join any organization

![image](https://user-images.githubusercontent.com/30014895/123795930-1ed9d680-d917-11eb-871d-7e3ecdc9a103.png)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


