### PR TITLE
Hotfix: hide preview button  in custom alarm modal

### DIFF
--- a/shell/app/modules/cmp/common/custom-alarm/index.tsx
+++ b/shell/app/modules/cmp/common/custom-alarm/index.tsx
@@ -489,7 +489,9 @@ export default ({ scopeType }: { scopeType: string }) => {
             >
               {i18n.t('delete')}
             </span>
-            <IF check={isPreviewing}>
+
+            {/* The interface data is returned incorrectly. The back-end suggests to hide the preview button temporarily */}
+            {/* <IF check={isPreviewing}>
               <span
                 className="table-operations-btn"
                 onClick={() => {
@@ -510,7 +512,7 @@ export default ({ scopeType }: { scopeType: string }) => {
               }}
             >
               {isPreviewing ? i18n.t('cancel') : i18n.t('preview')}
-            </span>
+            </span> */}
           </div>
         );
       },


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor
- [ ] Style
- [ ] Chore

## What this PR does / why we need it:
The interface data is returned incorrectly. The back-end suggests hiding the preview button temporarily

![image](https://user-images.githubusercontent.com/30014895/125222163-22e4fb80-e2fc-11eb-8dc0-835d78c0fc1f.png)

![image](https://user-images.githubusercontent.com/30014895/125222185-2d06fa00-e2fc-11eb-8094-ba55cc90306b.png)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user interface change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


