### PR TITLE
fix: jump out when click link and getBuildRuntimeDetail when in the page

### DIFF
--- a/shell/app/modules/application/pages/build-detail/index.tsx
+++ b/shell/app/modules/application/pages/build-detail/index.tsx
@@ -306,19 +306,19 @@ const BuildDetail = (props: IProps) => {
         const target = node.findInMeta((item: BUILD.MetaData) => item.name === 'runtimeID');
         if (target) {
           getBuildRuntimeDetail({ runtimeId: +target.value }).then((result) => {
-            !isEmpty(result) && goTo(`../../deploy/runtimes/${target.value}/overview`);
+            !isEmpty(result) && goTo(`../../deploy/runtimes/${target.value}/overview`, { jumpOut: true });
           });
         }
         break;
       }
       case 'sonar-link':
         // 跳转到代码质量页
-        goTo(`./quality/${pipelineDetail.commitId}`);
+        goTo(`./quality/${pipelineDetail.commitId}`, { jumpOut: true });
         break;
       case 'release-link': {
         const target = node.findInMeta((item: BUILD.MetaData) => item.name === 'releaseID');
         if (target) {
-          goTo(goTo.pages.release, { ...params, q: target.value });
+          goTo(goTo.pages.release, { ...params, q: target.value, jumpOut: true });
         }
         break;
       }
@@ -330,6 +330,7 @@ const BuildDetail = (props: IProps) => {
           goTo(goTo.pages.publisherContent, {
             type: typeTarget.value || 'MOBILE',
             publisherItemId: publishItemIDTarget.value,
+            jumpOut: true,
           });
         }
         break;
@@ -356,13 +357,13 @@ const BuildDetail = (props: IProps) => {
   };
 
   const onClickConfigLink = () => {
-    goTo(goTo.pages.buildDetailConfig, { projectId, appId, branch: encodeURIComponent(branch), env });
+    goTo(goTo.pages.buildDetailConfig, { projectId, appId, branch: encodeURIComponent(branch), env, jumpOut: true });
   };
 
   const onClickTestLink = (node: BUILD.PipelineNode) => {
     const qaID = node.findInMeta((item: BUILD.MetaData) => item.name === 'qaID');
     if (qaID) {
-      goTo(`../../test/${qaID.value}`);
+      goTo(`../../test/${qaID.value}`, { jumpOut: true });
     }
   };
 

--- a/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
@@ -270,7 +270,7 @@ const BuildDetail = (props: IProps) => {
         const target = node.findInMeta((item: BUILD.MetaData) => item.name === 'runtimeID');
         if (target) {
           getBuildRuntimeDetail({ runtimeId: +target.value }).then((result) => {
-            !isEmpty(result) && goTo(`../deploy/runtimes/${target.value}/overview`);
+            !isEmpty(result) && goTo(`../deploy/runtimes/${target.value}/overview`, { jumpOut: true });
           });
         }
         break;
@@ -282,7 +282,7 @@ const BuildDetail = (props: IProps) => {
       case 'release-link': {
         const target = node.findInMeta((item: BUILD.MetaData) => item.name === 'releaseID');
         if (target) {
-          goTo(goTo.pages.release, { ...params, q: target.value });
+          goTo(goTo.pages.release, { ...params, q: target.value, jumpOut: true });
         }
         break;
       }
@@ -294,6 +294,7 @@ const BuildDetail = (props: IProps) => {
           goTo(goTo.pages.publisherContent, {
             type: typeTarget.value || 'MOBILE',
             publisherItemId: publishItemIDTarget.value,
+            jumpOut: true,
           });
         }
         break;
@@ -320,13 +321,13 @@ const BuildDetail = (props: IProps) => {
   };
 
   const onClickConfigLink = () => {
-    goTo(goTo.pages.buildDetailConfig, { projectId, appId, branch: encodeURIComponent(branch), env });
+    goTo(goTo.pages.buildDetailConfig, { projectId, appId, branch: encodeURIComponent(branch), env, jumpOut: true });
   };
 
   const onClickTestLink = (node: BUILD.PipelineNode) => {
     const qaID = node.findInMeta((item: BUILD.MetaData) => item.name === 'qaID');
     if (qaID) {
-      goTo(`../test/${qaID.value}`);
+      goTo(`../test/${qaID.value}`, { jumpOut: true });
     }
   };
 

--- a/shell/app/modules/application/stores/build.ts
+++ b/shell/app/modules/application/stores/build.ts
@@ -75,11 +75,7 @@ const build = createStore({
     });
   },
   effects: {
-    async getBuildRuntimeDetail({ call, select, update }, payload: { runtimeId: number }): Promise<RUNTIME.Detail> {
-      const curRuntimeDetail = select((state) => state.runtimeDetail);
-      if (curRuntimeDetail?.id === payload.runtimeId) {
-        return curRuntimeDetail as RUNTIME.Detail;
-      }
+    async getBuildRuntimeDetail({ call, update }, payload: { runtimeId: number }): Promise<RUNTIME.Detail> {
       const runtimeDetail = await call(getRuntimeDetail, payload);
       update({ runtimeDetail });
       return runtimeDetail;


### PR DESCRIPTION
## What this PR does / why we need it:
1. jump out when clicking the link (to solve jump to another page with tooltip)
2. Re-request getBuildRuntimeDetail when entering pipeline-run-detail-page

## Does this PR introduce a user interface change?
- [ ] Yes(screenshot is required)
- [ ] No


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

