### PR TITLE
Fix: refactor deprecated get inner state by ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,6 @@ architecture of development mode
 - [User Docs](https://docs.erda.cloud)
 - [Backend project](https://github.com/erda-project/erda)
 
-<<<<<<< HEAD
-=======
-To start using Erda, please see the documentation.
->>>>>>> docs: update README
-
 ## 🤝 Contributing [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 We welcome all contributions. Please read our [CONTRIBUTING.md](https://github.com/erda-project/erda-ui/blob/master/.github/CONTRIBUTING.md) first. You can submit any ideas as [pull requests](https://github.com/erda-project/erda-ui/pulls) or as [GitHub issues](https://github.com/erda-project/erda-ui/issues?template=bug-template). If you'd like to improve code, check out the [Development Instructions](https://github.com/erda-project/erda-ui/wiki/Development) and have a good time! :)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ For a detailed introduction, please check the [official website](https://www.erd
 Modern browsers
 
 | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Edge |
-| --- | --- | --- | --- |
-| last 2 versions | last 2 versions | last 2 versions | last 2 versions |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| last 2 versions                                                                                                                                                                                                  | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                      |
 
 ## 🚀 Quick Start
 
@@ -112,6 +112,10 @@ architecture of development mode
 - [User Docs](https://docs.erda.cloud)
 - [Backend project](https://github.com/erda-project/erda)
 
+<<<<<<< HEAD
+=======
+To start using Erda, please see the documentation.
+>>>>>>> docs: update README
 
 ## 🤝 Contributing [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ For a detailed introduction, please check the [official website](https://www.erd
 Modern browsers
 
 | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Edge |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| last 2 versions                                                                                                                                                                                                  | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                      |
+| --- | --- | --- | --- |
+| last 2 versions | last 2 versions | last 2 versions | last 2 versions |
 
 ## 🚀 Quick Start
 
@@ -111,6 +111,7 @@ architecture of development mode
 - [Official Website](https://www.erda.cloud)
 - [User Docs](https://docs.erda.cloud)
 - [Backend project](https://github.com/erda-project/erda)
+
 
 ## 🤝 Contributing [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 

--- a/shell/app/layout/common/invite-to-org.tsx
+++ b/shell/app/layout/common/invite-to-org.tsx
@@ -53,7 +53,7 @@ export default () => {
     }
     domainData.id &&
       inviteToOrg({
-        verifyCode: code.trim(),
+        verifyCode: code,
         userIds: [id],
         orgId: String(domainData.id),
       }).then(() => {
@@ -74,7 +74,7 @@ export default () => {
           className="mb16"
           width="100%"
           placeholder={i18n.t('please enter verification code')}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => updater.code(e.target.value)}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => updater.code(e.target.value.trim())}
         />
         <Button style={{ width: '100%' }} loading={inviting} type="primary" disabled={!code} onClick={handleJoinOrg}>
           {domainData.displayName ? i18n.t('join {orgName}', { orgName: domainData.displayName }) : i18n.t('join org')}

--- a/shell/app/modules/application/pages/build-detail/index.tsx
+++ b/shell/app/modules/application/pages/build-detail/index.tsx
@@ -98,7 +98,7 @@ const BuildDetail = (props: IProps) => {
   const { blockStatus } = appStore.useStore((s) => s.detail);
   const appBlocked = blockStatus !== 'unblocked';
   const { blockoutConfig } = currentOrg;
-  const rejectRef = React.useRef(null);
+  const rejectContentRef = React.useRef('');
 
   const {
     cancelBuild: cancelBuildCall,
@@ -384,12 +384,18 @@ const BuildDetail = (props: IProps) => {
     if (reviewIdObj) {
       confirm({
         title: i18n.t('reason for rejection'),
-        content: <TextArea ref={rejectRef} />,
+        content: (
+          <TextArea
+            onChange={(v) => {
+              rejectContentRef.current = v.target.value;
+            }}
+          />
+        ),
         onOk() {
           updateApproval({
             id: +reviewIdObj.value,
             reject: true,
-            reason: (rejectRef.current as any) && (rejectRef.current as any).state.value,
+            reason: rejectContentRef.current,
           }).then(() => {
             getPipelineDetail({ pipelineID: pipelineDetail.id });
           });

--- a/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
@@ -76,7 +76,7 @@ const BuildDetail = (props: IProps) => {
     s.changeType,
   ]);
 
-  const rejectRef = React.useRef(null);
+  const rejectContentRef = React.useRef('');
 
   const {
     cancelBuild: cancelBuildCall,
@@ -348,12 +348,18 @@ const BuildDetail = (props: IProps) => {
     if (reviewIdObj) {
       confirm({
         title: i18n.t('reason for rejection'),
-        content: <TextArea ref={rejectRef}>ss</TextArea>,
+        content: (
+          <TextArea
+            onChange={(v) => {
+              rejectContentRef.current = v.target.value;
+            }}
+          />
+        ),
         onOk() {
           updateApproval({
             id: +reviewIdObj.value,
             reject: true,
-            reason: (rejectRef.current as any) && (rejectRef.current as any).state.value,
+            reason: rejectContentRef.current,
           }).then(() => {
             getPipelineDetail({ pipelineID: pipelineDetail.id });
           });


### PR DESCRIPTION
## What this PR does / why we need it:
* Textarea ref state no longer exist on Antd 4.x， see https://github.com/ant-design/ant-design/pull/29095
* auto trim invitation code


## Does this PR introduce a user interface change?
- [ ] Yes(screenshot is required)
- [x] No


## Which versions should be patched?
release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

