### PR TITLE
fix: display number zero in table of config-page

### DIFF
--- a/shell/app/config-page/components/table/render-types.tsx
+++ b/shell/app/config-page/components/table/render-types.tsx
@@ -320,7 +320,7 @@ export const getRender = (val: any, record: CP_TABLE.RowData, extra: any) => {
       }
       break;
     default:
-      Comp = val || val === 0 ? <Ellipsis title={`${val}`}>{`${val}`}</Ellipsis> : null;
+      Comp = (val || val === 0) ? <Ellipsis title={`${val}`}>{`${val}`}</Ellipsis> : null;
       break;
   }
   return Comp;

--- a/shell/app/config-page/components/table/render-types.tsx
+++ b/shell/app/config-page/components/table/render-types.tsx
@@ -320,7 +320,7 @@ export const getRender = (val: any, record: CP_TABLE.RowData, extra: any) => {
       }
       break;
     default:
-      Comp = val ? <Ellipsis title={`${val}`}>{`${val}`}</Ellipsis> : null;
+      Comp = val || val === 0 ? <Ellipsis title={`${val}`}>{`${val}`}</Ellipsis> : null;
       break;
   }
   return Comp;


### PR DESCRIPTION
## What this PR does / why we need it:
zero cannot display normally 
before:
![image](https://user-images.githubusercontent.com/30014895/125883415-d677d313-b670-4db9-b2f4-5ab81814ecda.png)

now:
![image](https://user-images.githubusercontent.com/30014895/125883434-9717a6e8-d96b-44ae-9936-282c40d95229.png)



## Does this PR introduce a user interface change?
- [ ] Yes(screenshot is required)
- [ ] No


## Which versions should be patched?
master & release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

