### PR TITLE
fix: remove redundant filters and fields in alarm record

### DIFF
--- a/shell/app/modules/cmp/common/alarm-record/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-record/index.tsx
@@ -72,42 +72,19 @@ export default ({ scope }: { scope: string }) => {
     {
       title: i18n.t('org:alarm status'),
       dataIndex: 'alertState',
-      width: 120,
+      width: 150,
       render: (alertState) => <AlarmState state={alertState} />,
     },
     {
       title: i18n.t('org:alarm type'),
       dataIndex: 'alertType',
-      width: 80,
+      width: 150,
     },
     {
       title: i18n.t('org:alarm time'),
       dataIndex: 'alertTime',
-      width: 180,
+      width: 200,
       render: (alertTime) => moment(alertTime).format('YYYY-MM-DD HH:mm:ss'),
-    },
-    {
-      title: i18n.t('org:processing status'),
-      dataIndex: 'handleState',
-      width: 100,
-      render: (handleState) => (handleState ? <IssueState state={handleState} /> : '--'),
-    },
-    {
-      title: i18n.t('org:assignee'),
-      dataIndex: 'handlerId',
-      width: 120,
-      render: (handlerId) => {
-        const userInfo = userMap[handlerId];
-        if (!userInfo) return '--';
-        const { nick, name } = userInfo;
-        return <Avatar name={nick || name} size={24} showName />;
-      },
-    },
-    {
-      title: i18n.t('org:processing time'),
-      dataIndex: 'handleTime',
-      width: 180,
-      render: (handleTime) => (handleTime ? moment(handleTime).format('YYYY-MM-DD HH:mm:ss') : '--'),
     },
   ];
 
@@ -139,31 +116,8 @@ export default ({ scope }: { scope: string }) => {
           )),
         },
       },
-      {
-        type: Select,
-        name: 'handleState',
-        customProps: {
-          mode: 'multiple',
-          placeholder: i18n.t('application:filter by handling status'),
-          options: map(alarmAttrs.handleState, ({ key, display }) => (
-            <Select.Option key={key} value={key}>
-              {display}
-            </Select.Option>
-          )),
-        },
-      },
-      {
-        type: MemberSelector,
-        name: 'handlerId',
-        customProps: {
-          mode: 'multiple',
-          valueChangeTrigger: 'onClose',
-          placeholder: i18n.t('filter by handler'),
-          scopeType: memberScopeMap[scope],
-        },
-      },
     ],
-    [alarmAttrs.alertState, alarmAttrs.alertType, alarmAttrs.handleState, scope],
+    [alarmAttrs.alertState, alarmAttrs.alertType],
   );
 
   return (

--- a/shell/app/modules/dcos/pages/cluster-dashboard/alarm-record.tsx
+++ b/shell/app/modules/dcos/pages/cluster-dashboard/alarm-record.tsx
@@ -77,29 +77,6 @@ export default ({ clusters }: { clusters: any }) => {
       width: 200,
       render: (alertTime) => moment(alertTime).format('YYYY-MM-DD HH:mm:ss'),
     },
-    {
-      title: i18n.t('org:processing status'),
-      dataIndex: 'handleState',
-      width: 150,
-      render: (handleState) => (handleState ? <IssueState state={handleState} /> : '--'),
-    },
-    {
-      title: i18n.t('org:assignee'),
-      dataIndex: 'handlerId',
-      width: 150,
-      render: (handlerId) => {
-        const userInfo = userMap[handlerId];
-        if (!userInfo) return '--';
-        const { nick, name } = userInfo;
-        return <Avatar name={nick || name} size={24} showName />;
-      },
-    },
-    {
-      title: i18n.t('org:processing time'),
-      dataIndex: 'handleTime',
-      width: 200,
-      render: (handleTime) => (handleTime ? moment(handleTime).format('YYYY-MM-DD HH:mm:ss') : '--'),
-    },
   ];
 
   const filterConfig = React.useMemo(
@@ -117,31 +94,8 @@ export default ({ clusters }: { clusters: any }) => {
           )),
         },
       },
-      {
-        type: Select,
-        name: 'handleState',
-        customProps: {
-          mode: 'multiple',
-          placeholder: i18n.t('application:filter by handling status'),
-          options: map(alarmAttrs.handleState, ({ key, display }) => (
-            <Select.Option key={key} value={key}>
-              {display}
-            </Select.Option>
-          )),
-        },
-      },
-      {
-        type: MemberSelector,
-        name: 'handlerId',
-        customProps: {
-          mode: 'multiple',
-          valueChangeTrigger: 'onClose',
-          placeholder: i18n.t('filter by handler'),
-          scopeType: 'org',
-        },
-      },
     ],
-    [alarmAttrs.alertState, alarmAttrs.handleState],
+    [alarmAttrs.alertState],
   );
 
   return (


### PR DESCRIPTION
## What this PR does / why we need it:
remove redundant filters and fields in alarm record,  remove:
1. filters: 'handle status'  & 'assignee'
2.fields in table: 'handle status' & 'assignee' & 'handle time'
![image](https://user-images.githubusercontent.com/30014895/125886925-4c72e335-e378-4f78-88ba-e76cadd48e10.png)

## Does this PR introduce a user interface change?
- [ ] Yes(screenshot is required)
- [ ] No


## Which versions should be patched?
master && release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

