### PR TITLE
fix: get only public extension when edit erda.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,6 @@ architecture of development mode
 - [User Docs](https://docs.erda.cloud)
 - [Backend project](https://github.com/erda-project/erda)
 
-<<<<<<< HEAD
-=======
-To start using Erda, please see the documentation.
->>>>>>> docs: update README
-
 ## 🤝 Contributing [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 We welcome all contributions. Please read our [CONTRIBUTING.md](https://github.com/erda-project/erda-ui/blob/master/.github/CONTRIBUTING.md) first. You can submit any ideas as [pull requests](https://github.com/erda-project/erda-ui/pulls) or as [GitHub issues](https://github.com/erda-project/erda-ui/issues?template=bug-template). If you'd like to improve code, check out the [Development Instructions](https://github.com/erda-project/erda-ui/wiki/Development) and have a good time! :)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ For a detailed introduction, please check the [official website](https://www.erd
 Modern browsers
 
 | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Edge |
-| --- | --- | --- | --- |
-| last 2 versions | last 2 versions | last 2 versions | last 2 versions |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| last 2 versions                                                                                                                                                                                                  | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                      |
 
 ## 🚀 Quick Start
 
@@ -112,6 +112,10 @@ architecture of development mode
 - [User Docs](https://docs.erda.cloud)
 - [Backend project](https://github.com/erda-project/erda)
 
+<<<<<<< HEAD
+=======
+To start using Erda, please see the documentation.
+>>>>>>> docs: update README
 
 ## 🤝 Contributing [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ For a detailed introduction, please check the [official website](https://www.erd
 Modern browsers
 
 | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br>Edge |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| last 2 versions                                                                                                                                                                                                  | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                              | last 2 versions                                                                                                                                                                                      |
+| --- | --- | --- | --- |
+| last 2 versions | last 2 versions | last 2 versions | last 2 versions |
 
 ## 🚀 Quick Start
 
@@ -111,6 +111,7 @@ architecture of development mode
 - [Official Website](https://www.erda.cloud)
 - [User Docs](https://docs.erda.cloud)
 - [Backend project](https://github.com/erda-project/erda)
+
 
 ## 🤝 Contributing [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 

--- a/shell/app/modules/application/services/deploy.ts
+++ b/shell/app/modules/application/services/deploy.ts
@@ -25,7 +25,7 @@ export const getExtensions = (query?: {
 }): DEPLOY.ExtensionAction[] | Obj<Obj<DEPLOY.ExtensionAction[]>> => {
   return agent
     .get('/api/extensions')
-    .query({ all: true, type: 'action', ...query })
+    .query({ public: true, type: 'action', ...query })
     .then((response: any) => response.body);
 };
 


### PR DESCRIPTION
## What this PR does / why we need it:
pass `all=true` will list deprecated addon, so update the search query.

## Does this PR introduce a user interface change?
- [ ] Yes(screenshot is required)
- [x] No


## Which versions should be patched?
release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

