### PR TITLE
copywriting issue & command drawer shown when creating edas issue

### DIFF
--- a/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
@@ -303,7 +303,7 @@ const ClusterList = ({ dataSource, onEdit }: IProps) => {
       title: i18n.t('default:description'),
       dataIndex: 'description',
       ellipsis: true,
-      render: (text) => text || '_',
+      render: (text) => text || '-',
     },
     {
       title: i18n.t('application:type'),

--- a/shell/app/modules/cmp/pages/cluster-manage/index.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/index.tsx
@@ -114,7 +114,7 @@ const ClusterManage = () => {
       updateCluster({ ...values, credential });
     } else {
       addCluster({ ...restData, credential });
-      if (restData.credentialType === 'proxy') {
+      if (restData.credentialType === 'proxy' && restData.type === 'k8s') {
         setSearch({ autoOpenCmd: true, clusterName: restData.name }, [], true);
       }
     }


### PR DESCRIPTION
## What this PR does / why we need it:
copywriting issue
command drawer shown when creating edas issue

## Does this PR introduce a user interface change?
- [x] Yes(screenshot is required)
- [ ] No
![image](https://user-images.githubusercontent.com/5175455/126453332-a4145b1e-f2ac-4f68-b0ce-c1739c091dd3.png)


## Which versions should be patched?
release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

