### PR TITLE
Fix: get yml when switch releaseId

### DIFF
--- a/shell/app/modules/application/pages/release/components/release-detail-yml.tsx
+++ b/shell/app/modules/application/pages/release/components/release-detail-yml.tsx
@@ -15,7 +15,6 @@ import * as React from 'react';
 import FileContainer from 'application/common/components/file-container';
 import { IF, FileEditor } from 'common';
 import releaseStore from 'app/modules/application/stores/release';
-import { useMount } from 'react-use';
 
 interface IProps {
   releaseId: string;
@@ -24,12 +23,12 @@ interface IProps {
 const ReleaseDetailYml = ({ releaseId }: IProps) => {
   const [yml, setYml] = React.useState('');
 
-  useMount(() => {
+  React.useEffect(() => {
     const { getDiceYml } = releaseStore.effects;
     getDiceYml(releaseId).then((diceYml) => {
       setYml(diceYml);
     });
-  });
+  }, [releaseId]);
 
   return (
     <div className="release-detail-page">

--- a/shell/app/modules/application/pages/release/release-list.tsx
+++ b/shell/app/modules/application/pages/release/release-list.tsx
@@ -158,7 +158,17 @@ const ReleaseList = () => {
             <span>{i18n.t('org:No results found? Please try other keywords to search.')}</span>
           </div>
           <ELSE />
-          <Pagination className="release-pagination" simple defaultCurrent={1} total={total} onChange={changePage} />
+          <>
+            {total && (
+              <Pagination
+                className="release-pagination"
+                simple
+                defaultCurrent={1}
+                total={total}
+                onChange={changePage}
+              />
+            )}
+          </>
         </IF>
       </div>
       <div className="release-detail-container">

--- a/shell/app/modules/cmp/pages/alarm-report/report-records/index.tsx
+++ b/shell/app/modules/cmp/pages/alarm-report/report-records/index.tsx
@@ -167,13 +167,15 @@ export default () => {
                   </li>
                 ))}
               </ul>
-              <Pagination
-                className="text-center mt12"
-                simple
-                defaultCurrent={1}
-                total={total}
-                onChange={(no) => handleChange(no)}
-              />
+              {total && (
+                <Pagination
+                  className="text-center mt12"
+                  simple
+                  defaultCurrent={1}
+                  total={total}
+                  onChange={(no) => handleChange(no)}
+                />
+              )}
             </Holder>
           </Spin>
         </div>

--- a/shell/app/modules/msp/monitor/project-report/pages/project-report.tsx
+++ b/shell/app/modules/msp/monitor/project-report/pages/project-report.tsx
@@ -201,13 +201,15 @@ const ProjectReport = ({ type }: IProps) => {
                     </li>
                   ))}
                 </ul>
-                <Pagination
-                  className="project-report-pagination text-right mt12"
-                  simple
-                  defaultCurrent={1}
-                  total={total}
-                  onChange={handleChangePage}
-                />
+                {total && (
+                  <Pagination
+                    className="project-report-pagination text-right mt12"
+                    simple
+                    defaultCurrent={1}
+                    total={total}
+                    onChange={handleChangePage}
+                  />
+                )}
               </Holder>
             </Spin>
           </div>

--- a/shell/app/modules/project/pages/backlog/iteration-item.tsx
+++ b/shell/app/modules/project/pages/backlog/iteration-item.tsx
@@ -132,16 +132,18 @@ export const IterationItem = (props: IProps) => {
           )}
         </Spin>
         <div>
-          <Pagination
-            className="right-flex-box pt8"
-            simple
-            defaultCurrent={1}
-            total={total}
-            pageSize={20}
-            onChange={(_page: number) => {
-              update({ pageNo: _page });
-            }}
-          />
+          {total && (
+            <Pagination
+              className="right-flex-box pt8"
+              simple
+              defaultCurrent={1}
+              total={total}
+              pageSize={20}
+              onChange={(_page: number) => {
+                update({ pageNo: _page });
+              }}
+            />
+          )}
         </div>
       </div>
       {drawerVisible ? (


### PR DESCRIPTION
## What this PR does / why we need it:
1. get yml when switching releaseId
2. fix init total is 0 results in current page is 0
![image](https://user-images.githubusercontent.com/30014895/126580939-af4ff60d-ddec-4c3a-b697-3d8a2baa1af0.png)


## Does this PR introduce a user interface change?
- [ ] Yes(screenshot is required)
- [ ] No


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

