### PR TITLE
fix: display tab normally in container monitor

### DIFF
--- a/shell/app/modules/runtime/common/components/slide-panel-tabs.scss
+++ b/shell/app/modules/runtime/common/components/slide-panel-tabs.scss
@@ -17,7 +17,7 @@
 
       .ant-tabs-content {
         position: absolute;
-        top: 60px;
+        top: 120px;
         right: 0;
         bottom: 0;
         left: 0;


### PR DESCRIPTION
## What this PR does / why we need it:
**before:**
![image](https://user-images.githubusercontent.com/30014895/126597973-6d965642-1786-482a-8857-cf956615a4ca.png)

**current**
![image](https://user-images.githubusercontent.com/30014895/126597847-0495cd14-b9cc-45ab-949e-5a1c49b70ff5.png)


## Does this PR introduce a user interface change?
- [x] Yes(screenshot is required)
- [ ] No


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

