### PR TITLE
fix: cmp-addon query text too long bug

### DIFF
--- a/shell/app/modules/cmp/pages/middleware-dashboard/index.scss
+++ b/shell/app/modules/cmp/pages/middleware-dashboard/index.scss
@@ -28,6 +28,7 @@
 
   .filter-item-content {
     flex: 1;
+    width: 0;
 
     .ant-select-selection {
       max-height: 120px;


### PR DESCRIPTION
## What this PR does / why we need it:
fix cmp-addon query text too long bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/126735533-a0ffd0a0-294a-4d63-9560-1057de2339c1.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed style problem when extended query column item name is too long. |
| 🇨🇳 中文    |  解决了扩展查询栏项目名过长时的样式问题。 |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # cmp-addon query text too long bug

