### PR TITLE
feat(cmp): edas cluster form add introduce config & remove 2 fields

### DIFF
--- a/shell/app/modules/cmp/pages/cluster-manage/add-cluster-forms/cluster-form.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/add-cluster-forms/cluster-form.tsx
@@ -128,10 +128,8 @@ const ClusterBasicForm = ({
       { label: i18n.t('org:cluster ID'), name: ['scheduler', 'clusterID'] },
       { label: 'Region ID', name: ['scheduler', 'regionID'] },
       { label: i18n.t('org:namespace'), name: ['scheduler', 'logicalRegionID'] },
-      { label: i18n.t('org:cluster address'), name: ['scheduler', 'k8sAddr'] },
-      { label: 'Registry Address', name: ['scheduler', 'regAddr'] },
     ]),
-    ...insertWhen(clusterType === 'k8s', [
+    ...insertWhen(clusterType === 'k8s' || clusterType === 'edas', [
       {
         label: i18n.t('cmp:verification method'),
         name: 'credentialType',

--- a/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
@@ -408,7 +408,7 @@ const ClusterList = ({ dataSource, onEdit }: IProps) => {
           title={i18n.t('org:Please enter the cluster name to confirm to go offline.')}
           onConfirm={() => submitDelete({ clusterName: state.deleteClusterName })}
           secondTitle={i18n.t('org:Please enter {name}, to confirm the cluster to go offline', {
-            name: state.curDeleteCluster?.displayName,
+            name: state.curDeleteCluster?.displayName || state.curDeleteCluster?.name,
           })}
           onCancel={() => toggleDeleteModal()}
           disabledConfirm={state.deleteClusterName !== state.curDeleteCluster?.displayName}

--- a/shell/app/modules/cmp/pages/cluster-manage/index.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/index.tsx
@@ -114,7 +114,7 @@ const ClusterManage = () => {
       updateCluster({ ...values, credential });
     } else {
       addCluster({ ...restData, credential });
-      if (restData.credentialType === 'proxy' && restData.type === 'k8s') {
+      if (restData.credentialType === 'proxy') {
         setSearch({ autoOpenCmd: true, clusterName: restData.name }, [], true);
       }
     }


### PR DESCRIPTION
## What this PR does / why we need it:
edas cluster form add verification method field just like k8s
removed cluster address & Registry Address field

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/5175455/126954209-5650a768-b56f-470a-b6a7-fc994c740b0b.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | edas cluster form add verification method field |
| 🇨🇳 中文    | edas 集群表单添加认证方式字段 |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

