### PR TITLE
fix: backlog add item validate style bug

### DIFF
--- a/shell/app/modules/project/pages/backlog/issue-item.tsx
+++ b/shell/app/modules/project/pages/backlog/issue-item.tsx
@@ -21,7 +21,7 @@ import { isPromise } from 'common/utils';
 import { get } from 'lodash';
 import i18n from 'i18n';
 import { IssueIcon, getIssueTypeOption } from 'project/common/components/issue/issue-icon';
-import { Ellipsis, Menu, Dropdown, Modal } from 'app/nusi';
+import { Ellipsis, Menu, Dropdown, Modal, message } from 'app/nusi';
 import { Form } from 'dop/pages/form-editor/index';
 import './issue-item.scss';
 import routeInfoStore from 'core/stores/route';
@@ -158,7 +158,11 @@ export const IssueForm = (props: IIssueFormProps) => {
     const curForm = formRef && formRef.current;
     if (curForm) {
       curForm.onSubmit((val: ISSUE.BacklogIssueCreateBody) => {
-        onOk(val).then(() => curForm.reset('title'));
+        if (val.title) {
+          onOk(val).then(() => curForm.reset('title'));
+        } else {
+          message.warn(i18n.t('please enter {name}', { name: i18n.t('title') }));
+        }
       });
     }
   };
@@ -190,7 +194,6 @@ export const IssueForm = (props: IIssueFormProps) => {
       label: '',
       component: 'input',
       key: 'title',
-      required: true,
       wrapperProps: {
         className: 'backlog-issue-add-title-box',
       },


### PR DESCRIPTION
## What this PR does / why we need it:
fix backlog add item validate style bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/127107310-0e516b70-303f-4628-9cb6-56f6f5bb8945.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | issue-backlog add item validate style bug.  |
| 🇨🇳 中文    | 项目协同-待处理中添加事项触发校验样式问题。 |


## Which versions should be patched?
release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # backlog add item validate style bug.

