### PR TITLE
fix: issue edit datepicker bug

### DIFF
--- a/shell/app/common/__tests__/components/edit-field.test.tsx
+++ b/shell/app/common/__tests__/components/edit-field.test.tsx
@@ -64,7 +64,6 @@ describe('EditField', () => {
     expect(changeFn).toHaveBeenCalledTimes(1);
     wrapper.find('input').simulate('blur');
     expect(changeCbFn).toHaveBeenLastCalledWith({ name: 'erda cloud' });
-    expect(wrapper.find('.edit-comp-text')).toExist();
     // wrapper.find('.edit-comp-text').simulate('click');
     // wrapper.update();
     // console.log(wrapper.find('.common-edit-field').html());

--- a/shell/app/common/components/edit-field.tsx
+++ b/shell/app/common/components/edit-field.tsx
@@ -271,12 +271,6 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
       break;
   }
 
-  const onClick = () => {
-    if (!editMode && ((type && !['dateReadonly', 'readonly'].includes(type)) || !type)) {
-      updater.editMode(false);
-    }
-  };
-
   return (
     <div className={`common-edit-field ${className}`}>
       {label && (
@@ -292,7 +286,7 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
           {label}
         </div>
       )}
-      <div onClick={onClick} className={classnames({ 'edit-comp-text': editMode })}>
+      <div className={classnames({ 'edit-comp-text': editMode })}>
         {Comp}
         {suffix}
       </div>

--- a/shell/app/common/components/edit-field.tsx
+++ b/shell/app/common/components/edit-field.tsx
@@ -140,10 +140,9 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
   });
 
   const [state, updater] = useUpdate({
-    editMode: false,
     editValue: undefined as unknown as string,
   });
-  const { editMode, editValue } = state;
+  const { editValue } = state;
 
   React.useEffect(() => {
     updater.editValue(value || get(data, name));
@@ -164,7 +163,6 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
     if (onChangeCb) {
       onChangeCb(set({}, name, v));
     }
-    updater.editMode(true);
   };
 
   const onBlur = (v?: string, fieldType?: string) => {
@@ -176,7 +174,6 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
         onChangeCb(set({}, name, v), fieldType);
       }
     }
-    updater.editMode(true);
   };
   switch (type) {
     case 'select': {
@@ -286,7 +283,7 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
           {label}
         </div>
       )}
-      <div className={classnames({ 'edit-comp-text': editMode })}>
+      <div>
         {Comp}
         {suffix}
       </div>


### PR DESCRIPTION
## What this PR does / why we need it:
fix issue edit datepicker bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a bug where the month of the datepicker in edit-issue could not be changed.|
| 🇨🇳 中文    | 修复了事项编辑中日期选择框月份不能翻页的bug。 |


## Which versions should be patched?
release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # issue edit datepicker bug

