### PR TITLE
fix: table rowClick add cursor pointer

### DIFF
--- a/core/src/nusi/wrapped-table.tsx
+++ b/core/src/nusi/wrapped-table.tsx
@@ -38,12 +38,19 @@ interface IProps<T extends object = any> extends TableProps<T> {
   columns: Array<ColumnProps<T>>;
 }
 
-function WrappedTable<T extends object = any>({ columns, ...props }: IProps<T>) {
+function WrappedTable<T extends object = any>({ columns, rowClassName, ...props }: IProps<T>) {
   const newColumns = columns?.map(({ ...args }: ColumnProps<T>) => ({
     ellipsis: true,
     ...args,
   }));
-  return <Table scroll={{ x: '100%' }} columns={newColumns} {...props} />;
+  return (
+    <Table
+      scroll={{ x: '100%' }}
+      columns={newColumns}
+      rowClassName={props.onRow ? `cursor-pointer ${rowClassName}` : rowClassName}
+      {...props}
+    />
+  );
 }
 
 export default WrappedTable;

--- a/core/src/nusi/wrapped-table.tsx
+++ b/core/src/nusi/wrapped-table.tsx
@@ -47,7 +47,7 @@ function WrappedTable<T extends object = any>({ columns, rowClassName, ...props 
     <Table
       scroll={{ x: '100%' }}
       columns={newColumns}
-      rowClassName={props.onRow ? `cursor-pointer ${rowClassName}` : rowClassName}
+      rowClassName={props.onRow ? `cursor-pointer ${rowClassName || ''}` : rowClassName}
       {...props}
     />
   );


### PR DESCRIPTION
## What this PR does / why we need it:
table rowClick add cursor pointer.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Adds a mouse over table row style to a table with row click events. |
| 🇨🇳 中文    | 给有行点击事件的表格加上鼠标移入表格行的样式。 |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # table rowClick add cursor pointer.

