### PR TITLE
fix: test-case table directory row bug

### DIFF
--- a/shell/app/modules/project/pages/plan-detail/columns/index.tsx
+++ b/shell/app/modules/project/pages/plan-detail/columns/index.tsx
@@ -33,9 +33,11 @@ planDetailColumns.splice(
       const { total, passed } = record.apiCount || {};
       const percent = record.apiCount ? ((passed || 0) * 100) / total : 0;
       return (
-        <div className="mr24">
-          <Progress percent={Math.round(percent)} format={() => `${passed || 0}/${total || 0}`} />
-        </div>
+        record.id && (
+          <div className="mr24">
+            <Progress percent={Math.round(percent)} format={() => `${passed || 0}/${total || 0}`} />
+          </div>
+        )
       );
     },
   },


### PR DESCRIPTION
## What this PR does / why we need it:
fix test-case table directory row bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/127258487-56a62660-e950-49aa-b0e1-f17865ed509b.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The rows representing directory in the test-case table show one more column of interface pass rate. |
| 🇨🇳 中文    | 测试用例表格中代表文件夹的行多显示了一列接口通过率。 |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # test-case table directory row bug.

