### PR TITLE
fix: test-case tree expand bug

### DIFF
--- a/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-tree/index.tsx
@@ -322,7 +322,7 @@ const TestSet = ({
     }));
     const nextActiveKey = firstBuild.current && query.eventKey && needActiveKey ? query.eventKey : rootKey;
     setActiveKey(nextActiveKey);
-    setExpandedKeys([rootKey]);
+    expandedKeys.length === 0 && setExpandedKeys([rootKey]);
     setTreeData([
       {
         title: projectInfo.name,
@@ -636,19 +636,10 @@ const TestSet = ({
         eventPath.push(window);
       }
     }
-    let clickInSwitcher = false;
-    const nodes = Array.from(eventPath);
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i] as HTMLElement;
-      if (node.nodeName === 'SPAN' && node.className.includes('ant-tree-switcher')) {
-        clickInSwitcher = true;
-      }
-    }
-    if (clickInSwitcher) {
-      nativeEvent.stopPropagation();
-      remove(nextExpandedKeys, (key) => includes(key, TEMP_MARK));
-      setExpandedKeys(nextExpandedKeys);
-    }
+
+    nativeEvent.stopPropagation();
+    remove(nextExpandedKeys, (key) => includes(key, TEMP_MARK));
+    setExpandedKeys(nextExpandedKeys);
   };
 
   const onSelect = (selectedKeys: string[], _extra?: any) => {


### PR DESCRIPTION
## What this PR does / why we need it:
fix test-case tree expand bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/127310297-05502dac-f753-469b-9289-782f6950f125.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed bugs where the left arrow is not facing the right side when the left tree of the test-case is expanded, and when the child node is clicked, the parent node occasionally collapses..  |
| 🇨🇳 中文    | 解决了测试用例左侧树展开时左侧箭头朝向不对，以及点击子节点时，父节点偶尔会收起的bug。 |


## Which versions should be patched?
release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # test-case tree expand bug.

