### PR TITLE
fix: modify the place of action buttons in FIleEditor

### DIFF
--- a/shell/app/common/components/file-editor.scss
+++ b/shell/app/common/components/file-editor.scss
@@ -4,7 +4,7 @@
   .file-editor-actions {
     position: absolute;
     top: 0;
-    right: 0;
+    right: 20px;
     z-index: 10;
     padding: 8px;
     opacity: 0.3;


### PR DESCRIPTION
## What this PR does / why we need it:
 modify the place of action buttons in FIleEditor to avoid overlapping with the close button
![image](https://user-images.githubusercontent.com/30014895/127319204-29f81caf-57f0-4c0f-a378-6dc253d7fba7.png)
![image](https://user-images.githubusercontent.com/30014895/127319296-ff619397-1c2e-4ca0-882d-0670fe45feb2.png)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

