### PR TITLE
fix: case-table some rows beyond the right

### DIFF
--- a/shell/app/modules/project/pages/test-manage/components/case-table/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-table/index.tsx
@@ -176,7 +176,7 @@ const CaseTable = ({ query: queryProp, columns, onClickRow, scope, onChange, tes
           return {
             children: <Ellipsis className="color-text-desc" title={record.directory} />,
             props: {
-              colSpan: 6,
+              colSpan: 5,
             },
           };
         },


### PR DESCRIPTION
## What this PR does / why we need it:
fix case-table some rows beyond the right bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/127443864-73edf4f5-1451-4a2a-aef2-085353a8e7c7.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | case-table some rows beyond the right. |
| 🇨🇳 中文    | 测试用例表格中某些行超出右侧。 |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # case-table some rows beyond the right.

