### PR TITLE
fix: jump to organization list page normally

### DIFF
--- a/shell/app/org-home/router.js
+++ b/shell/app/org-home/router.js
@@ -36,7 +36,7 @@ export default function getOrgRouter() {
         },
         {
           path: 'org-list',
-          getComp: (cb) => cb(import('app/org-home/pages/org-list'), 'OrgList'),
+          getComp: (cb) => cb(import('app/org-home/pages/org-list')),
           layout: {
             hideHeader: true,
             showSubSidebar: false,


### PR DESCRIPTION
## What this PR does / why we need it:
 Can't jump to organization list page normally, the bug due to the following changes
![image](https://user-images.githubusercontent.com/30014895/127463629-2dcbe229-8201-4795-ab1e-74e4db934124.png)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

