### PR TITLE
Fix: alarm state icon color

### DIFF
--- a/shell/app/modules/cmp/common/alarm-state.tsx
+++ b/shell/app/modules/cmp/common/alarm-state.tsx
@@ -36,7 +36,7 @@ export const AlarmState = (props: IProps) => {
 
   return (
     <span className={'inline-flex justify-between items-center'} style={{ minWidth: '50px' }}>
-      <CustomIcon type={icon} className={`rounded-full mr-1 bg-${color}`} />
+      <CustomIcon type={icon} className={`rounded-full mr-1 text-white bg-${color}`} />
       <span className={`text-${color}`}>{label}</span>
     </span>
   );

--- a/shell/app/modules/dcos/pages/cluster-dashboard/groupTabs.tsx
+++ b/shell/app/modules/dcos/pages/cluster-dashboard/groupTabs.tsx
@@ -45,10 +45,7 @@ const GroupTabs = ({ machineList, isClickState, onActiveMachine, activedGroup }:
         hostIPs,
       })),
     );
-    if (isClickState) {
-      setActiveKey('state');
-    }
-  }, [isClickState, machineList]);
+  }, [machineList]);
 
   return (
     <Tabs activeKey={activeKey} onChange={setActiveKey}>


### PR DESCRIPTION
## What this PR does / why we need it:
icon color should be white.
keep active machine list tab after click cluster in cluster overview.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/127763649-60eddcb4-19de-48ca-96b0-f081068d4980.png)
![image](https://user-images.githubusercontent.com/3955437/127763659-abb01395-fcc6-4e70-a940-28053d268ca1.png)

![image](https://user-images.githubusercontent.com/3955437/127763710-1a401ccf-f3f8-4745-b612-13d1ee6bef02.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix alarm state icon color is dark |
| 🇨🇳 中文    |修复告警列表图标颜色为黑色的问题 |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

