### PR TITLE
fix: trace debug body textarea style bug

### DIFF
--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.scss
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.scss
@@ -42,6 +42,7 @@ $border-style: 1px solid $color-border;
 
   .request-editor {
     padding: 20px 0;
+    overflow: auto;
 
     .request-edit-body-form {
       color: $orange;


### PR DESCRIPTION
## What this PR does / why we need it:
fix trace debug body textarea style bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/127851554-8edaedd7-9dc9-4a85-8f5d-7de4173d7646.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The Textarea of the trace debug body is too long to see the Tab.  |
| 🇨🇳 中文    | 链路调试body的文本域过长时看不见上面的标签页。  |


## Which versions should be patched?
release/1.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # trace debug body textarea style bug

