### PR TITLE
fix: restore escaped quotes in log content

### DIFF
--- a/shell/app/common/components/log/log-content.tsx
+++ b/shell/app/common/components/log/log-content.tsx
@@ -30,7 +30,7 @@ interface IItemProps {
 }
 const DefaultLogItem = ({ log, transformContent }: IItemProps) => {
   const { content, timestamp } = log;
-  let reContent = AU.ansi_to_html(content);
+  let reContent = AU.ansi_to_html(content).replaceAll('&quot;', '"'); // restore escaped quotes
   let suffix = null;
   if (typeof transformContent === 'function') {
     const result = transformContent(reContent);

--- a/shell/app/common/components/runtime/simple-log-roller.tsx
+++ b/shell/app/common/components/runtime/simple-log-roller.tsx
@@ -33,7 +33,7 @@ export const LogItem = ({ log }: { log: COMMON.LogItem }) => {
     showContent = `[${serviceName}] --- ${content.split(parent).join('')}`;
   }
 
-  const reContent = AU.ansi_to_html(showContent);
+  const reContent = AU.ansi_to_html(showContent).replaceAll('&quot;', '"');
   return (
     <div className="log-insight-item">
       <span className="log-item-logtime">{time}</span>

--- a/shell/app/interface/global.d.ts
+++ b/shell/app/interface/global.d.ts
@@ -14,7 +14,6 @@
 // no import or export statement in this file
 
 declare module 'path';
-declare module 'ansi_up';
 declare module 'lodash/_stringToPath';
 declare module '@erda-ui/dashboard-configurator';
 

--- a/shell/app/modules/runtime/common/logs/components/container-log.jsx
+++ b/shell/app/modules/runtime/common/logs/components/container-log.jsx
@@ -57,7 +57,7 @@ const getLogItem =
       level = _level;
     }
 
-    const reContent = parseLinkInContent(AU.ansi_to_html(content), pushSlideComp);
+    const reContent = parseLinkInContent(AU.ansi_to_html(content).replaceAll('&quot;', '"'), pushSlideComp);
     return (
       <div className="container-log-item">
         {time && <span className="log-item-logtime">{time}</span>}


### PR DESCRIPTION
## What this PR does / why we need it:
ansi_up will escapes any unsafe HTML characters, which cause the mismatch bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Which versions should be patched?


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

