### PR TITLE
fix: deploy create releaseId select style bug

### DIFF
--- a/shell/app/common/components/details-panel.tsx
+++ b/shell/app/common/components/details-panel.tsx
@@ -109,7 +109,7 @@ const DetailsPanel = (props: IProps) => {
       </IF>
       {children}
       <IF check={!isEmpty(linkList)}>
-        <Anchor getContainer={() => container.current}>
+        <Anchor getContainer={() => container?.current || document.body}>
           {map(linkList, (item) => {
             const { linkProps, crossLine, titleProps, showTitle, panelProps, getComp, key } = item;
             const { icon, title } = linkProps;

--- a/shell/app/common/components/load-more-selector.tsx
+++ b/shell/app/common/components/load-more-selector.tsx
@@ -387,7 +387,7 @@ const PureLoadMoreSelector = (props: IProps) => {
       <Dropdown
         overlay={getOverlay()}
         visible={visible}
-        overlayClassName={`load-more-selector-dropdown ${dropdownClassName}`}
+        overlayClassName={`${visible ? 'load-more-selector-dropdown' : ''} ${dropdownClassName}`}
         onVisibleChange={(visible) => onVisibleChange?.(visible, innerValue)}
       >
         <div

--- a/shell/app/common/components/log/log-content.tsx
+++ b/shell/app/common/components/log/log-content.tsx
@@ -30,7 +30,7 @@ interface IItemProps {
 }
 const DefaultLogItem = ({ log, transformContent }: IItemProps) => {
   const { content, timestamp } = log;
-  let reContent = AU.ansi_to_html(content).replaceAll('&quot;', '"'); // restore escaped quotes
+  let reContent = AU.ansi_to_html(content).replace(/&quot;/g, '"'); // restore escaped quotes
   let suffix = null;
   if (typeof transformContent === 'function') {
     const result = transformContent(reContent);

--- a/shell/app/common/components/runtime/simple-log-roller.tsx
+++ b/shell/app/common/components/runtime/simple-log-roller.tsx
@@ -33,7 +33,7 @@ export const LogItem = ({ log }: { log: COMMON.LogItem }) => {
     showContent = `[${serviceName}] --- ${content.split(parent).join('')}`;
   }
 
-  const reContent = AU.ansi_to_html(showContent).replaceAll('&quot;', '"');
+  const reContent = AU.ansi_to_html(showContent).replace(/&quot;/g, '"');
   return (
     <div className="log-insight-item">
       <span className="log-item-logtime">{time}</span>


### PR DESCRIPTION
## What this PR does / why we need it:
fix deploy create releaseId select style bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/127978829-3af090aa-fe57-4692-895b-f7e82f2d83ed.png)
->
![image](https://user-images.githubusercontent.com/82502479/127992405-cc4de702-5412-4f77-8e36-1d57b0266d32.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed the width bug of the deploy center artifact ID select. |
| 🇨🇳 中文    | 修复了部署中心创建时制品id选择框下拉的宽度bug。 |


## Which versions should be patched?
release/1.2

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # deploy create releaseId select style bug.

