### PR TITLE
fix: backlog table pagination style bug

### DIFF
--- a/shell/app/modules/project/pages/backlog/backlog.scss
+++ b/shell/app/modules/project/pages/backlog/backlog.scss
@@ -22,6 +22,10 @@
         height: calc(100% - 40px);
         overflow: auto;
       }
+
+      .ant-pagination-item-link {
+        line-height: 30px;
+      }
     }
 
     .more-container {


### PR DESCRIPTION
## What this PR does / why we need it:
backlog table pagination style bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/128116187-9f8ae143-2c16-4ed2-b7a8-d463a30b0235.png)
->
![image](https://user-images.githubusercontent.com/82502479/128116539-5579855b-7a65-46ee-aff8-981532e86284.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a bug where two scrollbars appeared when the project was scrolled in the backlog table. |
| 🇨🇳 中文    | 修复了项目协同待处理列表滚动时出现两个滚动条的bug。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # backlog table pagination style bug

