### PR TITLE
add edas cluster operations & fix inline form wrap issue

### DIFF
--- a/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
@@ -226,7 +226,14 @@ const ClusterList = ({ dataSource, onEdit }: IProps) => {
       },
     };
     const clusterOpsMap = {
-      edas: [edit, deleteClusterCall],
+      edas: [
+        edit,
+        deleteClusterCall,
+        ...insertWhen(get(clusterDetail, 'basic.manageType.value') === 'agent', [showRegisterCommand]),
+        ...insertWhen(['initialize error', 'unknown'].includes(get(clusterDetail, 'basic.clusterStatus.value')), [
+          retryInit,
+        ]),
+      ],
       k8s: [
         addMachine,
         addCloudMachines,
@@ -234,7 +241,9 @@ const ClusterList = ({ dataSource, onEdit }: IProps) => {
         upgrade,
         deleteClusterCall,
         ...insertWhen(get(clusterDetail, 'basic.manageType.value') === 'agent', [showRegisterCommand]),
-        ...insertWhen(get(clusterDetail, 'basic.clusterStatus.value') === 'initialize error', [retryInit]),
+        ...insertWhen(['initialize error', 'unknown'].includes(get(clusterDetail, 'basic.clusterStatus.value')), [
+          retryInit,
+        ]),
       ],
       'alicloud-cs': [addMachine, addCloudMachines, edit, upgrade, deleteClusterCall],
       'alicloud-cs-managed': [addMachine, addCloudMachines, edit, upgrade, deleteClusterCall],

--- a/shell/app/styles/antd-extension.scss
+++ b/shell/app/styles/antd-extension.scss
@@ -118,7 +118,7 @@ $border-style: 1px solid $color-border;
 }
 
 .ant-form-inline {
-  flex-wrap: nowrap;
+  flex-wrap: nowrap !important;
 }
 
 div.ant-modal-body {


### PR DESCRIPTION
## What this PR does / why we need it:
add edas cluster operations & fix inline form wrap issue

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/5175455/128116691-5af0fec4-5e54-428c-a999-fdea0ea9a17d.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add register command & retry init operations to edas cluster          |
| 🇨🇳 中文    |  edas集群添加注册命令与初始化重试操作菜单          |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

