### PR TITLE
fix the bug that the log cannot be downloaded using the default duration

### DIFF
--- a/shell/app/common/__tests__/components/log/download-log-modal.test.tsx
+++ b/shell/app/common/__tests__/components/log/download-log-modal.test.tsx
@@ -13,22 +13,23 @@
 
 import React from 'react';
 import { DownloadLogModal } from 'common/components/log/download-log-modal';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { describe, it, jest } from '@jest/globals';
 import moment from 'moment';
+import { sleep } from '../../../../../test/utils';
 
 describe('DownloadLogModal', () => {
+  const startTimestamp = 1624954155390947968;
+  const defaultPickerValue = moment(startTimestamp / 1000000).subtract(1, 'hours');
+  const anHourAgo = moment().subtract(1, 'hours');
+  const query = {
+    taskID: 1,
+    downloadAPI: '/api/log/download',
+  };
   it('DownloadLogModal should work well', () => {
     const spyOpen = jest.spyOn(window, 'open').mockImplementation(() => {});
-    const startTimestamp = 1624954155390947968;
-    const defaultPickerValue = moment(startTimestamp / 1000000).subtract(1, 'hours');
-    const anHourAgo = moment().subtract(1, 'hours');
     const cancelFn = jest.fn();
     const setFieldsValue = jest.fn();
-    const query = {
-      taskID: 1,
-      downloadAPI: '/api/log/download',
-    };
     const wrapper = shallow(<DownloadLogModal start={startTimestamp} visible query={query} onCancel={cancelFn} />);
     wrapper.prop('onOk')({ startTime: defaultPickerValue, endTime: 5 });
     expect(spyOpen).toHaveBeenLastCalledWith(
@@ -48,6 +49,23 @@ describe('DownloadLogModal', () => {
     expect(setFieldsValue).toHaveBeenCalledTimes(2);
     wrapper.prop('onCancel')();
     expect(cancelFn).toHaveBeenCalledTimes(2);
+    spyOpen.mockReset();
+  });
+  it('should download with default endTime', async () => {
+    const spyOpen = jest.spyOn(window, 'open').mockImplementation(() => {});
+    const cancelFn = jest.fn();
+    const wrapper = mount(<DownloadLogModal start={startTimestamp} visible query={query} onCancel={cancelFn} />);
+    wrapper.find('Picker').at(0).prop('onChange')(defaultPickerValue);
+    await wrapper.find('.ant-btn-primary').simulate('click');
+    await sleep(2000);
+    expect(cancelFn).toHaveBeenCalledTimes(1);
+    expect(spyOpen).toHaveBeenCalledTimes(1);
+    wrapper.find('Picker').at(0).prop('onChange')(defaultPickerValue);
+    wrapper.find('InputNumber').at(0).prop('onChange')(1);
+    await wrapper.find('.ant-btn-primary').simulate('click');
+    await sleep(2000);
+    expect(cancelFn).toHaveBeenCalledTimes(2);
+    expect(spyOpen).toHaveBeenCalledTimes(2);
     spyOpen.mockReset();
   });
 });

--- a/shell/app/common/__tests__/components/tree/tree.test.tsx
+++ b/shell/app/common/__tests__/components/tree/tree.test.tsx
@@ -53,8 +53,8 @@ describe('TreeCategory', () => {
         onSelectNode={selectNodeFn}
       />,
     );
-    const select = wrapper.find('Select').at(0);
-    expect(wrapper.find('Select')).toExist();
+    const select = wrapper.find('.w-full').at(0);
+    expect(wrapper.find('.w-full')).toExist();
     select.prop('onSearch')();
     expect(fuzzySearch).not.toHaveBeenCalled();
     await act(async () => {

--- a/shell/app/common/components/log/download-log-modal.tsx
+++ b/shell/app/common/components/log/download-log-modal.tsx
@@ -78,11 +78,11 @@ const DownloadLogFormModal = ({ start, visible, query, onCancel }: IProps) => {
       name: 'endTime',
       label: i18n.t('common:duration(minutes)'),
       required: true,
+      initialValue: 60,
       getComp: ({ form }: { form: FormInstance }) => (
         <InputNumber
           min={1}
           max={60}
-          defaultValue={60}
           className="w-full"
           onChange={(duration) => {
             form.setFieldsValue({ endTime: duration });


### PR DESCRIPTION
## What this PR does / why we need it:

fix the bug that the log cannot be downloaded using the default duration

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix the bug that the log cannot be downloaded using the default duration |
| 🇨🇳 中文    | 修复使用默认时长无法下载日志的bug |


## Does this PR need be patched to older version?
✅ Yes(version is required)

release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

