### PR TITLE
feat: update markdown editor interaction and style

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,7 +298,7 @@ importers:
       '@babel/runtime': ^7.12.5
       '@babel/traverse': ^7.14.7
       '@erda-ui/dashboard-configurator': 1.0.24
-      '@erda-ui/react-markdown-editor-lite': ^1.4.3
+      '@erda-ui/react-markdown-editor-lite': ^1.4.4
       '@icon-park/react': ^1.3.3
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -440,7 +440,7 @@ importers:
     dependencies:
       '@babel/runtime': 7.14.0
       '@erda-ui/dashboard-configurator': 1.0.24_89f7d333518b25ce6638797795704a0d
-      '@erda-ui/react-markdown-editor-lite': 1.4.3_react@16.14.0
+      '@erda-ui/react-markdown-editor-lite': 1.4.4_react@16.14.0
       '@icon-park/react': 1.3.3_react-dom@16.14.0+react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -3661,8 +3661,8 @@ packages:
       - supports-color
     dev: false
 
-  /@erda-ui/react-markdown-editor-lite/1.4.3_react@16.14.0:
-    resolution: {integrity: sha512-jJLmqrkKqLqOEv1gxtHjPxhkGdS8eYiBBxWJoG7c3aAFqWPHKLmeLBpgdZC7tcHUk7wjkPEwXsoBg/YqVYxWUQ==}
+  /@erda-ui/react-markdown-editor-lite/1.4.4_react@16.14.0:
+    resolution: {integrity: sha512-IIjtYL3bFcWp/bXG8MI7SyKrObZjaIQpTc6IlFpcywtAiXnBuynrDl2wZTc45Ms0Hfq0z4bDBcpCHslVywAo3g==}
     peerDependencies:
       react: ^16.9.0
     dependencies:
@@ -13354,7 +13354,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.1_supports-color@6.1.0
-    dev: false
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -14519,7 +14518,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.14.1
+      follow-redirects: 1.14.1_debug@4.3.1
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/shell/app/common/components/markdown-editor/index.scss
+++ b/shell/app/common/components/markdown-editor/index.scss
@@ -5,6 +5,10 @@
       border-radius: $radius;
       padding-bottom: 42px;
 
+      .navigation-nav.left {
+        min-width: 120px;
+      }
+
       .editor-container {
         padding: $p8;
         > .section > .section-container {

--- a/shell/app/common/components/markdown-editor/index.scss
+++ b/shell/app/common/components/markdown-editor/index.scss
@@ -1,29 +1,49 @@
 .markdown-editor {
   .markdown-editor-content {
     display: block;
-
     .rc-md-editor {
       border-radius: $radius;
+      padding-bottom: 42px;
 
-      .sec-md .input:focus {
-        outline: 1px solid $color-active-border;
+      .editor-container {
+        padding: $p8;
+        > .section > .section-container {
+          padding: $p4;
+          padding-top: 0;
+        }
+        .sec-md {
+          .input {
+            padding: $p8;
+            border: 1px solid $color-border;
+            border-radius: $radius-lg;
+            background-color: $whitesmoke;
+
+            &:focus {
+              border-color: $color-active-border;
+              box-shadow: rgb(106 84 158 / 30%) 0 0 0 3px;
+              background-color: $white;
+            }
+          }
+        }
+
+        .sec-html {
+          border-bottom: 1px solid $color-border;
+        }
+      }
+
+      .tool-bar {
+        display: none;
       }
     }
 
-    &.show-btn {
-      .rc-md-editor {
-        padding-bottom: 50px;
-      }
+    .md-content {
+      padding: 0;
     }
   }
 
   .disable-edit {
     .rc-md-navigation .right {
-      pointer-events: none;
-
-      .button {
-        color: $color-disabled;
-      }
+      visibility: hidden;
     }
   }
 

--- a/shell/app/common/components/markdown-editor/index.tsx
+++ b/shell/app/common/components/markdown-editor/index.tsx
@@ -32,7 +32,7 @@ interface IProps {
   maxLength?: number;
   isShowRate: boolean;
   score: number;
-  defaultMode?: 'md' | 'html' | 'both';
+  defaultMode?: 'md' | 'html';
   extraRight?: ReactElement | ReactElement[];
   btnText?: string;
   readOnly?: boolean;
@@ -71,8 +71,8 @@ export default class MarkdownEditor extends PureComponent<IProps, IState> {
       tempContent: props.value || '',
       score: props.score || 0,
       view: {
-        md: defaultMode === 'md' || defaultMode === 'both',
-        html: defaultMode === 'html' || defaultMode === 'both',
+        md: defaultMode === 'md',
+        html: defaultMode === 'html',
         menu: true,
       },
     };
@@ -223,11 +223,9 @@ export default class MarkdownEditor extends PureComponent<IProps, IState> {
             <Rate allowHalf onChange={this.onRateChange} value={this.state.score} />
           </div>
         </IF>
-        {view.md ? (
-          <div className="absolute left-2 " style={{ top: height - 42 }}>
-            {this.renderButton()}
-          </div>
-        ) : null}
+        <div className="absolute left-2 " style={{ top: height - 42 }}>
+          {this.renderButton()}
+        </div>
       </div>
     );
   }

--- a/shell/app/common/components/markdown-editor/index.tsx
+++ b/shell/app/common/components/markdown-editor/index.tsx
@@ -30,8 +30,8 @@ interface IProps {
   value?: string | null;
   placeholder?: string;
   maxLength?: number;
-  isShowRate: boolean;
-  score: number;
+  isShowRate?: boolean;
+  score?: number;
   defaultMode?: 'md' | 'html';
   extraRight?: ReactElement | ReactElement[];
   btnText?: string;
@@ -145,23 +145,20 @@ export default class MarkdownEditor extends PureComponent<IProps, IState> {
       <Button key="md-editor-submit-btn" className="my8 mr8" type="primary" onClick={this.onSubmit}>
         {btnText || i18n.t('common:submit')}
       </Button>,
-      <Button
-        key="md-editor-cancel-btn"
-        className="mx-2 mr-2"
-        onClick={() => {
-          onCancel?.();
-        }}
-      >
-        {i18n.t('restore')}
-      </Button>,
     ];
 
     if (onSetLS) {
-      btns.splice(
-        1,
-        0,
+      btns.push(
         <Button key="md-editor-keep-btn" className="mx-2 mr-2" onClick={this.onSetLS}>
           {i18n.t('application:temporary storage')}
+        </Button>,
+      );
+    }
+
+    if (onCancel) {
+      btns.push(
+        <Button key="md-editor-cancel-btn" className="mx-2 mr-2" onClick={() => onCancel()}>
+          {i18n.t('restore')}
         </Button>,
       );
     }

--- a/shell/app/common/components/markdown-editor/index.tsx
+++ b/shell/app/common/components/markdown-editor/index.tsx
@@ -140,29 +140,28 @@ export default class MarkdownEditor extends PureComponent<IProps, IState> {
   };
 
   renderButton() {
-    const { onSubmit, onCancel, btnText, onSetLS } = this.props;
-    const btns: JSX.Element[] = [];
-
-    if (onSubmit) {
-      btns.push(
-        <Button key="md-editor-submit-btn" className="my8 mr8" type="primary" onClick={this.onSubmit}>
-          {btnText || i18n.t('common:submit')}
-        </Button>,
-      );
-    }
+    const { onCancel, btnText, onSetLS } = this.props;
+    const btns: JSX.Element[] = [
+      <Button key="md-editor-submit-btn" className="my8 mr8" type="primary" onClick={this.onSubmit}>
+        {btnText || i18n.t('common:submit')}
+      </Button>,
+      <Button
+        key="md-editor-cancel-btn"
+        className="mx-2 mr-2"
+        onClick={() => {
+          onCancel?.();
+        }}
+      >
+        {i18n.t('restore')}
+      </Button>,
+    ];
 
     if (onSetLS) {
-      btns.push(
+      btns.splice(
+        1,
+        0,
         <Button key="md-editor-keep-btn" className="mx-2 mr-2" onClick={this.onSetLS}>
           {i18n.t('application:temporary storage')}
-        </Button>,
-      );
-    }
-
-    if (onCancel) {
-      btns.push(
-        <Button key="md-editor-cancel-btn" className="mx-2 mr-2" onClick={onCancel}>
-          {i18n.t('common:cancel')}
         </Button>,
       );
     }

--- a/shell/app/modules/project/common/components/issue/comment-box.tsx
+++ b/shell/app/modules/project/common/components/issue/comment-box.tsx
@@ -38,7 +38,7 @@ export const IssueCommentBox = (props: IProps) => {
           onChange={(val: any) => {
             updater.content(val);
           }}
-          style={{ height: '140px' }}
+          style={{ height: '200px' }}
           maxLength={3000}
         />
       </div>

--- a/shell/package.json
+++ b/shell/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@erda-ui/dashboard-configurator": "1.0.24",
-    "@erda-ui/react-markdown-editor-lite": "^1.4.3",
+    "@erda-ui/react-markdown-editor-lite": "^1.4.4",
     "@icon-park/react": "^1.3.3",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:
* disable show editor and preview at the same time
* hide toolbar buttons when preview content
* hide toggle toolbar arrow
* always show bottom button group

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![2021-08-05 15 29 39](https://user-images.githubusercontent.com/3955437/128310021-2b1fc52e-f391-4b8d-a026-631563f752a0.gif)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | update markdown editor interaction and style |
| 🇨🇳 中文    |  更新 markdown 编辑器交互和样式 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

