### PR TITLE
fix: encode some character error with encodeURI

### DIFF
--- a/shell/app/common/__tests__/components/img-holder.test.tsx
+++ b/shell/app/common/__tests__/components/img-holder.test.tsx
@@ -35,4 +35,10 @@ describe('ImgHolder', () => {
       `holder.js/40x40?${encodeURI('size=12&text=D&theme=avatar&font=PingFang SC&fontweight=normal')}`,
     );
   });
+  it('render with part of emoji character', () => {
+    const wrapper = mount(<ImgHolder rect="40x40" type="avatar" text={'🍅'.substring(0, 1)} />);
+    expect(wrapper.find('img').prop('data-src')).toBe(
+      `holder.js/40x40?${encodeURI('size=12&text=n&theme=avatar&font=PingFang20%SC&fontweight=normal')}`,
+    );
+  });
 });

--- a/shell/app/common/components/img-holder.tsx
+++ b/shell/app/common/components/img-holder.tsx
@@ -90,11 +90,22 @@ export const ImgHolder = (props: IProps) => {
         theme = 'avatar';
       }
     }
-    const holderParams = encodeURI(
-      compact(
-        map({ random, size, text, theme, fg, bg, font, fontweight }, (v, k) => (v === undefined ? v : `${k}=${v}`)),
-      ).join('&'),
-    );
+    let holderParams = '';
+    try {
+      holderParams = encodeURI(
+        compact(
+          map({ random, size, text, theme, fg, bg, font, fontweight }, (v, k) => (v === undefined ? v : `${k}=${v}`)),
+        ).join('&'),
+      );
+    } catch (error) {
+      holderParams = encodeURI(
+        compact(
+          map({ random, size, text: 'n', theme, fg, bg, font, fontweight }, (v, k) =>
+            v === undefined ? v : `${k}=${v}`,
+          ),
+        ).join('&'),
+      );
+    }
     return (
       <img
         alt="holder"


### PR DESCRIPTION
## What this PR does / why we need it:
when encode some character such as emoji, will throw error and cause page crash.
![image](https://user-images.githubusercontent.com/3955437/128342529-c290b00e-a7e5-4a0e-bdc5-150ea1fa7144.png)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the crash problem that may occur when adding members with nicknames of special characters |
| 🇨🇳 中文    | 修复添加成员时昵称为特殊字符可能出现的崩溃问题 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

