### PR TITLE
feat(msp): add reset-button

### DIFF
--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-history-list.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-history-list.tsx
@@ -28,16 +28,18 @@ const TraceHistoryList = ({
   clearTraceStatusDetail,
   clearCurrentTraceRequestId,
   clearRequestTraceParams,
+  form,
 }: any) => {
   if (!dataSource.length) {
     return <EmptyHolder />;
   }
 
-  const handleClick = (requestId: string) => {
+  const handleClick = (requestId: string, url: string) => {
     const isNewId = currentTraceRequestId !== requestId;
     // 点击已选中的 item 取消选中，currentTraceRequestId 置空
     setCurrentTraceRequestId(isNewId ? requestId : '');
     if (isNewId) {
+      form.setFieldsValue({ url });
       getTraceDetail({ requestId });
       getTraceStatusDetail({ requestId });
     } else {
@@ -51,7 +53,7 @@ const TraceHistoryList = ({
     const isActive = currentTraceRequestId === requestId;
     return (
       <li
-        onClick={() => handleClick(requestId)}
+        onClick={() => handleClick(requestId, url)}
         className={classNames({
           'trace-history-list-item': true,
           active: isActive,

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { map as _map, pickBy } from 'lodash';
-import { Row, Col, Input, Select, Button, Tabs, Form, Modal } from 'app/nusi';
+import { Row, Col, Input, Select, Button, Tabs, Form, Popconfirm } from 'app/nusi';
 import { Copy, KeyValueEditor, IF } from 'common';
 import { regRules, notify, qs } from 'common/utils';
 import CommonPanel from './trace-common-panel';
@@ -36,7 +36,6 @@ const { banFullWidthPunctuation, url: urlRule } = regRules;
 
 const TraceInsightQuerier = () => {
   const [form] = Form.useForm();
-  const [modalVis, setModalVis] = React.useState(false);
   const [
     requestTraceParams,
     traceHistoryList,
@@ -109,7 +108,6 @@ const TraceInsightQuerier = () => {
   }, [getTraceDetailContent, requestId]);
 
   const resetRequestTrace = () => {
-    setModalVis(false);
     form.resetFields();
     clearRequestTraceParams();
     clearCurrentTraceRequestId();
@@ -206,17 +204,17 @@ const TraceInsightQuerier = () => {
             <Button type="primary" loading={isRequestTraceFetching} onClick={handleRequestTrace}>
               {i18n.t('msp:request')}
             </Button>
-            <Button className="ml-4" danger onClick={() => setModalVis(true)}>
-              {i18n.t('common:reset')}
-            </Button>
-            <Modal
+            <Popconfirm
               title={i18n.t('confirm to reset?')}
-              visible={modalVis}
-              onOk={resetRequestTrace}
-              onCancel={() => {
-                setModalVis(false);
+              placement="bottom"
+              onConfirm={() => {
+                resetRequestTrace();
               }}
-            />
+            >
+              <Button type="primary" className="ml-4">
+                {i18n.t('common:reset')}
+              </Button>
+            </Popconfirm>
           </Col>
         </Row>
       </div>

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { map as _map, pickBy } from 'lodash';
-import { Row, Col, Input, Select, Button, Tabs, Form } from 'app/nusi';
+import { Row, Col, Input, Select, Button, Tabs, Form, Modal } from 'app/nusi';
 import { Copy, KeyValueEditor, IF } from 'common';
 import { regRules, notify, qs } from 'common/utils';
 import CommonPanel from './trace-common-panel';
@@ -36,6 +36,7 @@ const { banFullWidthPunctuation, url: urlRule } = regRules;
 
 const TraceInsightQuerier = () => {
   const [form] = Form.useForm();
+  const [modalVis, setModalVis] = React.useState(false);
   const [
     requestTraceParams,
     traceHistoryList,
@@ -106,6 +107,14 @@ const TraceInsightQuerier = () => {
         setTraceRecords(content);
       });
   }, [getTraceDetailContent, requestId]);
+
+  const resetRequestTrace = () => {
+    setModalVis(false);
+    form.resetFields();
+    clearRequestTraceParams();
+    clearCurrentTraceRequestId();
+    clearTraceStatusDetail();
+  };
 
   const handleSetRequestTraceParams = (payload: any) => {
     return validateFields().then(() => {
@@ -178,12 +187,8 @@ const TraceInsightQuerier = () => {
     return (
       <div className="url-editor">
         <Row gutter={10}>
-          <Col span={21}>
-            <FormItem
-              name="url"
-              initialValue={`${url}${queryStr ? `?${queryStr}` : ''}`}
-              rules={[{ required: true, message: i18n.t('msp:this item is required') }, urlRule]}
-            >
+          <Col span={18}>
+            <FormItem name="url" rules={[{ required: true, message: i18n.t('msp:this item is required') }, urlRule]}>
               <Input
                 addonBefore={selectBefore}
                 placeholder={
@@ -197,10 +202,21 @@ const TraceInsightQuerier = () => {
               />
             </FormItem>
           </Col>
-          <Col span={3}>
+          <Col span={6}>
             <Button type="primary" loading={isRequestTraceFetching} onClick={handleRequestTrace}>
               {i18n.t('msp:request')}
             </Button>
+            <Button className="ml-4" danger onClick={() => setModalVis(true)}>
+              {i18n.t('common:reset')}
+            </Button>
+            <Modal
+              title={i18n.t('confirm to reset?')}
+              visible={modalVis}
+              onOk={resetRequestTrace}
+              onCancel={() => {
+                setModalVis(false);
+              }}
+            />
           </Col>
         </Row>
       </div>
@@ -309,6 +325,7 @@ const TraceInsightQuerier = () => {
               clearTraceStatusDetail={clearTraceStatusDetail}
               clearCurrentTraceRequestId={clearCurrentTraceRequestId}
               clearRequestTraceParams={clearRequestTraceParams}
+              form={form}
             />
           </CommonPanel>
         </Col>
@@ -316,7 +333,7 @@ const TraceInsightQuerier = () => {
           <CommonPanel>
             <React.Fragment>
               {renderMetaViewer()}
-              <Form>
+              <Form form={form}>
                 {renderUrlEditor()}
                 {renderRequestEditor()}
               </Form>

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
@@ -211,9 +211,7 @@ const TraceInsightQuerier = () => {
                 resetRequestTrace();
               }}
             >
-              <Button type="primary" className="ml-4">
-                {i18n.t('common:reset')}
-              </Button>
+              <Button className="ml-4">{i18n.t('common:reset')}</Button>
             </Popconfirm>
           </Col>
         </Row>


### PR DESCRIPTION
## What this PR does / why we need it:
add reset-button

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
<img width="1022" alt="截屏2021-08-09上午11 36 51" src="https://user-images.githubusercontent.com/48612739/128658094-6aaeafa1-703b-4272-88e7-8e5d4c88958d.png">
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      [monitoring] link debugging, add reset button and clear all contents of the page        |
| 🇨🇳 中文    | 【监控】链路调试，添加重置按钮，清空页面所有内容         |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

