### PR TITLE
Hotfix: modify key of option to id in strategy

### DIFF
--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -231,8 +231,8 @@ export default ({ scopeType, scopeId }: IProps) => {
             updater.editingRules(rules);
           }}
         >
-          {map(allRules, ({ alertIndex }) => (
-            <Select.Option key={alertIndex} value={alertIndex}>
+          {map(allRules, ({ alertIndex, id }) => (
+            <Select.Option key={id} value={alertIndex}>
               {allRuleMap[alertIndex]}
             </Select.Option>
           ))}


### PR DESCRIPTION
## What this PR does / why we need it:
Use alertIndex as option's key is repeated, use id as its key.
![image](https://user-images.githubusercontent.com/30014895/128795624-82351887-46dc-40c6-9d49-b9b71bdffad7.png)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.1,  release/1.2

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

