### PR TITLE
feat(cmp): hide register command when cluster registered

### DIFF
--- a/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
@@ -229,7 +229,10 @@ const ClusterList = ({ dataSource, onEdit }: IProps) => {
       edas: [
         edit,
         deleteClusterCall,
-        ...insertWhen(get(clusterDetail, 'basic.manageType.value') === 'agent', [showRegisterCommand]),
+        ...insertWhen(
+          get(clusterDetail, 'basic.manageType.value') === 'agent' && !get(clusterDetail, 'basic.registered.value'),
+          [showRegisterCommand],
+        ),
         ...insertWhen(['initialize error', 'unknown'].includes(get(clusterDetail, 'basic.clusterStatus.value')), [
           retryInit,
         ]),


### PR DESCRIPTION
## What this PR does / why we need it:
hide register command when cluster registered

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

