### PR TITLE
fix: choose chart type before saving in dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
       '@babel/preset-typescript': ^7.13.0
       '@babel/runtime': ^7.12.5
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 1.0.24
+      '@erda-ui/dashboard-configurator': 1.0.25
       '@erda-ui/react-markdown-editor-lite': ^1.4.4
       '@icon-park/react': ^1.3.3
       '@module-federation/automatic-vendor-federation': ^1.2.1
@@ -440,7 +440,7 @@ importers:
       xterm: 3.12.0
     dependencies:
       '@babel/runtime': 7.14.0
-      '@erda-ui/dashboard-configurator': 1.0.24_89f7d333518b25ce6638797795704a0d
+      '@erda-ui/dashboard-configurator': 1.0.25_89f7d333518b25ce6638797795704a0d
       '@erda-ui/react-markdown-editor-lite': 1.4.4_react@16.14.0
       '@icon-park/react': 1.3.3_react-dom@16.14.0+react@16.14.0
       ace-builds: 1.4.12
@@ -3622,8 +3622,8 @@ packages:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
     dev: false
 
-  /@erda-ui/dashboard-configurator/1.0.24_89f7d333518b25ce6638797795704a0d:
-    resolution: {integrity: sha512-KlaPTZOSjG6LvEn6V3+A9QmhW0eucrtUKd+r9fi82NPlJiqPBeKgxEfqBjagBGeBZWZis+4c0/TgSkwrN3i+SA==}
+  /@erda-ui/dashboard-configurator/1.0.25_89f7d333518b25ce6638797795704a0d:
+    resolution: {integrity: sha512-BZITcM91vo/HBjVX+qMZFPoAqaQAjGpiAllqrPZQrrjukhm6raCzj3MNieT/R+NiAWHDLZTdvKNXOL4qeCXbBw==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -13355,7 +13355,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.1_supports-color@6.1.0
+      debug: 4.3.1
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}

--- a/shell/package.json
+++ b/shell/package.json
@@ -46,7 +46,7 @@
   "license": "AGPL",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@erda-ui/dashboard-configurator": "1.0.24",
+    "@erda-ui/dashboard-configurator": "1.0.25",
     "@erda-ui/react-markdown-editor-lite": "^1.4.4",
     "@icon-park/react": "^1.3.3",
     "ace-builds": "^1.4.7",


### PR DESCRIPTION
## What this PR does / why we need it:
choose chart type before saving in dashboard

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

