### PR TITLE
fix: in add tag form, source type change bug after submit

### DIFF
--- a/shell/app/modules/application/pages/repo/repo-tag.tsx
+++ b/shell/app/modules/application/pages/repo/repo-tag.tsx
@@ -108,6 +108,7 @@ const RepoTag = () => {
 
   const beforeSubmit = async (values: { ref: string; refType: string }) => {
     if (values.refType === 'commitId') {
+      setRefType(null);
       const ret = await checkCommitId({ commitId: values.ref });
       if (ret === 'error') {
         message.error(i18n.t('application:invalid commit SHA'));


### PR DESCRIPTION
## What this PR does / why we need it:
fix source type change bug after submit in add tag form.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a bug when changing the source type for the first time after resetting the form after a form submission error was reported while adding tags. |
| 🇨🇳 中文    | 修复了添加标签时，在表单提交报错重置表单之后，第一次切换源类型时的bug。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # in add tag form, source type change bug after submit

