### PR TITLE
feat: use root domain in invite url

### DIFF
--- a/shell/app/common/components/members-table.tsx
+++ b/shell/app/common/components/members-table.tsx
@@ -34,6 +34,7 @@ import routeInfoStore from 'core/stores/route';
 import memberLabelStore from 'common/stores/member-label';
 import orgStore from 'app/org-home/stores/org';
 import './members-table.scss';
+import { FULL_ROOT_DOMAIN } from '../constants';
 
 const storeMap = {
   [MemberScope.ORG]: orgMemberStore,
@@ -603,7 +604,7 @@ export const MembersTable = ({
           />
           <UrlInviteModal
             visible={state.inviteModalVisible}
-            url={`${window.location.origin}${goTo.resolve.inviteToOrg()}`}
+            url={`${FULL_ROOT_DOMAIN}${goTo.resolve.inviteToOrg()}`}
             linkPrefixTip={`${i18n.t('org:visit the link to join the organization')} [${orgDisplayName || orgName}]`}
             code={state.verifyCode}
             tip={i18n.t(

--- a/shell/app/common/constants.ts
+++ b/shell/app/common/constants.ts
@@ -12,7 +12,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 export const WORKSPACE_LIST = ['DEV', 'TEST', 'STAGING', 'PROD'];
+export const ROOT_DOMAIN = 'erda.cloud';
 export const DOC_DOMAIN = 'docs.erda.cloud';
+export const FULL_ROOT_DOMAIN = `https://${ROOT_DOMAIN}`;
 export const FULL_DOC_DOMAIN = `https://${DOC_DOMAIN}`;
 export const HELP_DOCUMENT = `${FULL_DOC_DOMAIN}/${process.env.mainVersion}/manual/deploy/resource-management.html#%E7%AE%A1%E7%90%86%E9%85%8D%E9%A2%9D`;
 export const HELP_DOCUMENT_PREFIX = `${FULL_DOC_DOMAIN}/${process.env.mainVersion}/manual`;


### PR DESCRIPTION
## What this PR does / why we need it:
Some time the domain is not the current org, eg: erda-org.erda.cloud/playground, invite url will confuse users.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No

