### PR TITLE
fix: page-container Card style bug

### DIFF
--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -159,7 +159,9 @@ const PageContainer = ({ route }: IProps) => {
     MainContent = noWrapper ? (
       Inner
     ) : (
-      <Card className={layout && layout.fullHeight ? 'h-full overflow-auto' : ''}>{Inner}</Card>
+      <Card className={layout && layout.fullHeight ? 'h-full overflow-auto' : ''} bodyStyle={{ height: '100%' }}>
+        {Inner}
+      </Card>
     );
   }
 


### PR DESCRIPTION
## What this PR does / why we need it:
fix page-container Card style bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/129659028-bb642581-3d29-4a2b-a6e7-2afd016176f8.png)
->
![image](https://user-images.githubusercontent.com/82502479/129659050-f9d4ad19-37f4-45e9-b401-f17f9b4d0ca5.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed an API design bug that did not display empty page icon when the page had no branches. |
| 🇨🇳 中文    | 解决了api设计页面无分支时不显示空页面图标的bug。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # page-container Card style bug

