### PR TITLE
fix: Select in nusi Form width style bug

### DIFF
--- a/shell/app/styles/antd-extension.scss
+++ b/shell/app/styles/antd-extension.scss
@@ -436,3 +436,8 @@ div.ant-table {
 div.ant-progress-inner {
   background-color: rgba(0, 0, 0, 0.06);
 }
+
+.pk-form-item .ant-select,
+.pk-form-item .ant-cascader-picker {
+  width: 100%;
+}


### PR DESCRIPTION
## What this PR does / why we need it:
fix Select in nusi Form width style bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/129661155-3222f51a-827b-4ad2-99c0-28fd58dd7d82.png)
->
![image](https://user-images.githubusercontent.com/82502479/129661171-a69118cf-6065-4b3f-87c1-9f1d4732d488.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed a bug where the width of the drop-down box in some forms was not covered.  |
| 🇨🇳 中文    | 修复了一些表单中下拉框宽度不铺满的bug。   |



## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # Select in nusi Form width style bug

