### PR TITLE
feat: support render newline in audit template

### DIFF
--- a/shell/app/modules/org/pages/safety/index.tsx
+++ b/shell/app/modules/org/pages/safety/index.tsx
@@ -16,7 +16,7 @@ import { CustomFilter, useFilter, MemberSelector, FileEditor } from 'common';
 import { useLoading } from 'core/stores/loading';
 import i18n from 'i18n';
 import moment from 'moment';
-import { DatePicker, Table, Button, Tooltip, Drawer } from 'core/nusi';
+import { DatePicker, Table, Button, Popover, Drawer } from 'core/nusi';
 import auditStore from 'org/stores/audit';
 import auditTpl from 'org/common/audit-render';
 import React from 'react';
@@ -89,12 +89,26 @@ const AuditList = ({ sys }: { sys: boolean }) => {
       title: i18n.t('org:operation'),
       key: 'op',
       render: (val: string, r: AUDIT.Item) => {
-        const _content = auditTpl(r, extraTpls);
+        const content = auditTpl(r, extraTpls);
+        const contentWithBr: Array<string | JSX.Element> = [];
+        if (Array.isArray(content)) {
+          content.forEach((c) => {
+            if (typeof c === 'string' && c.includes('\n')) {
+              c.split('\n').forEach((a) => {
+                contentWithBr.push(a);
+                contentWithBr.push(<br />);
+              });
+              contentWithBr.pop();
+            } else {
+              contentWithBr.push(c);
+            }
+          });
+        }
         return (
-          <>
-            <Tooltip title={_content}>{_content}</Tooltip>
+          <Popover overlayStyle={{ maxWidth: '80%' }} content={contentWithBr.length ? contentWithBr : content}>
+            {content}
             {r.result !== 'success' ? ` (${r.errorMsg})` : null}
-          </>
+          </Popover>
         );
       },
     },


### PR DESCRIPTION
## What this PR does / why we need it:
Support render br for long audit content.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/129715541-c06ccac6-f6f3-4c2f-a6d3-7248488b2d62.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Audit log supports newline rendering  |
| 🇨🇳 中文    |  审计日志支持换行渲染  |


## Does this PR need be patched to older version?
❎ No


