### PR TITLE
fix: fix history listen execute twice

### DIFF
--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -10,6 +10,23 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-import { createBrowserHistory } from 'history';
+import { createBrowserHistory, UnregisterCallback, LocationState, LocationListener } from 'history';
 
-export default createBrowserHistory();
+const history = createBrowserHistory();
+
+const { listen } = history;
+
+// because of qiankun > single-spa rewrite pushState, lead to history.listen execute twice
+history.listen = (listener: LocationListener<LocationState>): UnregisterCallback => {
+  let lastPathname = '';
+  function enhancerCb(...args: any) {
+    const [location] = args;
+    if (location.pathname === lastPathname) return;
+    lastPathname = location.pathname;
+    // @ts-ignore
+    return listener(...args);
+  }
+  return listen(enhancerCb);
+};
+
+export default history;

--- a/core/webpack.config.js
+++ b/core/webpack.config.js
@@ -138,7 +138,6 @@ module.exports = () => {
           './i18n': './src/i18n.ts',
           './agent': './src/agent.ts',
           './config': './src/config.ts',
-          './history': './src/history.ts',
           './stores/route': './src/stores/route.ts',
           './stores/loading': './src/stores/loading.ts',
           './stores/userMap': './src/stores/user-map.ts',

--- a/shell/app/App.tsx
+++ b/shell/app/App.tsx
@@ -22,8 +22,8 @@ import moment from 'moment';
 import 'moment/locale/zh-cn';
 import { startApp, registerModule } from 'core/main';
 import modules from './mf-modules'; // ambiguous modules may conflict with modules folder, then rename to mf-modules
-import { setConfig } from 'core/config';
-import history from 'core/history';
+import { setConfig, getConfig } from 'core/config';
+
 import { setGlobal } from 'app/global-space';
 import { get } from 'lodash';
 import { getCurrentLocale } from 'core/i18n';
@@ -40,6 +40,8 @@ import 'tailwindcss/tailwind.css';
 
 setConfig('onAPISuccess', nusi.message.success);
 setConfig('onAPIFail', notify);
+
+const history = getConfig('history');
 
 const { NusiConfigProvider, AntdConfigProvider } = nusi;
 const momentLangMap = {
@@ -124,6 +126,7 @@ if (pathname.startsWith('/r/')) {
     default:
       break;
   }
+
   history.replace(newPath.join('/') + search);
 }
 

--- a/shell/app/common/__tests__/components/error-boundary.test.tsx
+++ b/shell/app/common/__tests__/components/error-boundary.test.tsx
@@ -15,11 +15,19 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { ErrorBoundary } from 'common';
 import { errorCatcher } from 'common/components/error-boundary';
-import history from 'core/history';
+import { createBrowserHistory } from 'history';
+import { getConfig, setConfig } from 'core/config';
 
 const Something = () => null;
 
 describe('ErrorBoundary', () => {
+  beforeAll(() => {
+    const browserHistory = createBrowserHistory();
+    setConfig('history', browserHistory);
+  });
+  afterAll(() => {
+    setConfig('history', undefined);
+  });
   it('should render if wrapped component throws', () => {
     const wrapper = mount(
       <ErrorBoundary>
@@ -29,6 +37,8 @@ describe('ErrorBoundary', () => {
     const error = new Error('test');
     wrapper.find(Something).simulateError(error);
     wrapper.find('Button').simulate('click');
+    const history = getConfig('history');
+
     expect(history.location.pathname).toBe('/');
   });
   it('errorCatcher should work well', () => {

--- a/shell/app/common/__tests__/utils/query-string.test.tsx
+++ b/shell/app/common/__tests__/utils/query-string.test.tsx
@@ -12,9 +12,17 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import { qs, mergeSearch, updateSearch, setSearch } from 'common/utils';
-import history from 'core/history';
+import { createBrowserHistory } from 'history';
+import { setConfig, getConfig } from 'core/config';
 
 describe('query-string', () => {
+  beforeAll(() => {
+    const browserHistory = createBrowserHistory();
+    setConfig('history', browserHistory);
+  });
+  afterAll(() => {
+    setConfig('history', undefined);
+  });
   it('qs.parse', () => {
     expect(qs.parse(process.env.mock_search)).toEqual({ id: '1' });
     expect(qs.parse('ids[]=1&ids[]=2&ids[]=3', { arrayFormat: 'bracket' })).toEqual({ ids: ['1', '2', '3'] });
@@ -39,10 +47,12 @@ describe('query-string', () => {
     expect(mergeSearch({ orgName: 'erda' }, false, true)).toEqual({ orgName: 'erda' });
   });
   it('updateSearch', () => {
+    const history = getConfig('history');
     updateSearch({ orgName: 'erda' });
     expect(history.location.search).toContain('orgName=erda');
   });
   it('setSearch', () => {
+    const history = getConfig('history');
     setSearch({ orgName: 'erda' });
     expect(history.location.search).toContain('orgName=erda');
   });

--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -15,7 +15,7 @@ import path from 'path';
 import { filter, isFunction, mapValues, throttle, pickBy, isEmpty, get } from 'lodash';
 import { qs } from './query-string';
 import routeInfoStore from 'core/stores/route';
-import history from 'core/history';
+import { getConfig } from 'core/config';
 
 export function resolvePath(goPath: string) {
   return path.resolve(window.location.pathname, goPath);
@@ -23,6 +23,7 @@ export function resolvePath(goPath: string) {
 
 const changeBrowserHistory = throttle(
   (action, _path) => {
+    const history = getConfig('history');
     action === 'replace' ? history.replace(_path) : history.push(_path);
   },
   1000,
@@ -85,6 +86,7 @@ export const goTo = (pathStr: string, options?: IOptions) => {
   if (forbidRepeat) {
     changeBrowserHistory(action, _path);
   } else {
+    const history = getConfig('history');
     action === 'replace' ? history.replace(_path) : history.push(_path);
   }
 };

--- a/shell/tsconfig.json
+++ b/shell/tsconfig.json
@@ -93,7 +93,6 @@
       "agent": ["./app/agent.js"],
       "app/*": ["./app/*"],
       "core/main": ["../core/src/index"],
-      "core/history": ["../core/src/history"],
       "core/cube": ["../core/src/cube"],
       "core/i18n": ["../core/src/i18n"],
       "core/agent": ["../core/src/agent"],


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix history listen execute twice

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       fix: fix history listen execute twice       |
| 🇨🇳 中文    |      fix: 修复路由监听执行两次        |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

