### PR TITLE
feat: add confirmation when issue-drawer esc keydown

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -1112,12 +1112,12 @@ export const EditIssueDrawer = (props: IProps) => {
   }
 
   if (!isEditMode) {
-    footer = (isChanged: boolean, confirmCloseTip: string) => [
+    footer = (isChanged: boolean, confirmCloseTip: string | undefined) => [
       <div key="holder" />,
       <Spin key="submit" spinning={updateIssueLoading}>
         <div>
           {isChanged && confirmCloseTip ? (
-            <Popconfirm title={confirmCloseTip} placement="bottomRight" onConfirm={onClose}>
+            <Popconfirm title={confirmCloseTip} placement="bottomRight" onConfirm={() => onClose()}>
               <Button>{i18n.t('cancel')}</Button>
             </Popconfirm>
           ) : (

--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -1117,7 +1117,7 @@ export const EditIssueDrawer = (props: IProps) => {
       <Spin key="submit" spinning={updateIssueLoading}>
         <div>
           {isChanged && confirmCloseTip ? (
-            <Popconfirm title={confirmCloseTip} placement="bottomRight" onConfirm={() => onClose()}>
+            <Popconfirm title={confirmCloseTip} placement="topLeft" onConfirm={() => onClose()}>
               <Button>{i18n.t('cancel')}</Button>
             </Popconfirm>
           ) : (

--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Button, Select, Tabs, message, Spin, Dropdown, Menu, Divider } from 'core/nusi';
+import { Button, Select, Tabs, message, Spin, Dropdown, Menu, Divider, Popconfirm } from 'core/nusi';
 import { IssueIcon, getIssueTypeOption } from 'project/common/components/issue/issue-icon';
 import { map, has, cloneDeep, includes, isEmpty, merge, find } from 'lodash';
 import moment from 'moment';
@@ -1112,11 +1112,18 @@ export const EditIssueDrawer = (props: IProps) => {
   }
 
   if (!isEditMode) {
-    footer = [
+    footer = (isChanged: boolean, confirmCloseTip: string) => [
       <div key="holder" />,
       <Spin key="submit" spinning={updateIssueLoading}>
         <div>
-          <Button onClick={() => onClose()}>{i18n.t('cancel')}</Button>
+          {isChanged && confirmCloseTip ? (
+            <Popconfirm title={confirmCloseTip} placement="bottomRight" onConfirm={onClose}>
+              <Button>{i18n.t('cancel')}</Button>
+            </Popconfirm>
+          ) : (
+            <Button onClick={() => onClose()}>{i18n.t('cancel')}</Button>
+          )}
+
           <Button disabled={disableSubmit} onClick={() => handleSubmit()} type="primary">
             {i18n.t('ok')}
           </Button>
@@ -1125,7 +1132,7 @@ export const EditIssueDrawer = (props: IProps) => {
     ];
   }
 
-  footer = footer.length ? <>{footer}</> : undefined;
+  footer = typeof footer === 'function' ? footer : footer.length ? <>{footer}</> : undefined;
 
   return (
     <IssueDrawer
@@ -1145,6 +1152,7 @@ export const EditIssueDrawer = (props: IProps) => {
       projectId={projectId}
       issueType={issueType}
       setData={setFormData}
+      footer={footer}
       // loading={
       //   loading.createIssue || loading.getIssueDetail || loading.updateIssue
       // }
@@ -1246,7 +1254,6 @@ export const EditIssueDrawer = (props: IProps) => {
         formData={formData}
         setFieldCb={setFieldCb}
       />
-      {footer}
     </IssueDrawer>
   );
 };

--- a/shell/app/modules/project/common/components/issue/issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-drawer.tsx
@@ -14,6 +14,7 @@
 import { Copy, IF } from 'common';
 import i18n from 'i18n';
 import React from 'react';
+import useEvent from 'react-use/lib/useEvent';
 import { WithAuth } from 'user/common';
 import issueStore from 'project/stores/issues';
 import { isEqual, find } from 'lodash';
@@ -90,8 +91,8 @@ export const IssueDrawer = (props: IProps) => {
   const preDataRef = React.useRef(data);
   const preData = preDataRef.current;
 
-  React.useEffect(() => {
-    const escClose = (e) => {
+  const escClose = React.useCallback(
+    (e) => {
       if (e.keyCode === 27) {
         if (isChanged && confirmCloseTip) {
           Modal.confirm({
@@ -104,14 +105,11 @@ export const IssueDrawer = (props: IProps) => {
           onClose(e);
         }
       }
-    };
-    document.removeEventListener('keydown', escClose);
-    document.addEventListener('keydown', escClose);
+    },
+    [isChanged, confirmCloseTip, onClose],
+  );
 
-    return () => {
-      document.removeEventListener('keydown', escClose);
-    };
-  }, [isChanged, confirmCloseTip, onClose]);
+  useEvent('keydown', escClose);
 
   React.useEffect(() => {
     const isIssueDrawerChanged = (initData: CreateDrawerData, currentData: CreateDrawerData) => {

--- a/shell/app/modules/project/common/components/issue/issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-drawer.tsx
@@ -44,7 +44,7 @@ interface IProps {
   onDelete?: () => void;
   handleCopy?: (isCopy: boolean, copyTitle: string) => void;
   setData: (data: object) => void;
-  footer: ElementChild[] | (() => ElementChild[]);
+  footer: ElementChild[] | ((isChanged: boolean, confirmCloseTip: string | undefined) => ElementChild[]);
 }
 
 /**


### PR DESCRIPTION
## What this PR does / why we need it:
add confirmation when issue-drawer esc keydown.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/130425003-06cccdf1-9638-44db-aeed-ad8c590216b6.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

