### PR TITLE
fix(scheduler): fix can't get ws org header issue in cluster

### DIFF
--- a/scheduler/src/proxy.ts
+++ b/scheduler/src/proxy.ts
@@ -45,7 +45,11 @@ export const createProxyService = (app: INestApplication) => {
       secure: false,
       pathRewrite: replaceApiOrgPath,
       onProxyReqWs: (proxyReq, req: Request, socket) => {
-        proxyReq.setHeader('org', extractOrg(req.originalUrl));
+        const uri = req.headers['x-original-uri'];
+        if (uri && typeof uri === 'string') {
+          const org = uri.split('/')?.[2];
+          proxyReq.setHeader('org', org);
+        }
         socket.on('error', (error) => {
           logWarn('Websocket error.', error); // add error handler to prevent server crash https://github.com/chimurai/http-proxy-middleware/issues/463#issuecomment-676630189
         });


### PR DESCRIPTION
## What this PR does / why we need it:
when scheduler deployed to dev, req.originalUrl is always undefined which is different with local env. So we have to rollback to  fetch org by `x-original-uri`

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->

❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?

❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

