### PR TITLE
fix:  restore escaped quotes in log content

### DIFF
--- a/shell/app/common/components/log/log-content.tsx
+++ b/shell/app/common/components/log/log-content.tsx
@@ -14,10 +14,8 @@
 import { map } from 'lodash';
 import React from 'react';
 import moment from 'moment';
-import AnsiUp from 'ansi_up';
+import { transformLog } from 'app/common/utils';
 import './log-content.scss';
-
-const AU = new AnsiUp();
 
 interface ILogItem {
   content: string;
@@ -30,7 +28,7 @@ interface IItemProps {
 }
 const DefaultLogItem = ({ log, transformContent }: IItemProps) => {
   const { content, timestamp } = log;
-  let reContent = AU.ansi_to_html(content).replace(/&quot;/g, '"'); // restore escaped quotes
+  let reContent = transformLog(content);
   let suffix = null;
   if (typeof transformContent === 'function') {
     const result = transformContent(reContent);

--- a/shell/app/common/components/runtime/simple-log-roller.tsx
+++ b/shell/app/common/components/runtime/simple-log-roller.tsx
@@ -14,11 +14,10 @@
 import React from 'react';
 import { PureLogRoller, useUpdate } from 'common';
 import { regLog } from 'common/components/log/log-util';
-import AnsiUp from 'ansi_up';
+import { transformLog } from 'app/common/utils';
 import commonStore from 'app/common/stores/common';
 
 const noop = () => {};
-const AU = new AnsiUp();
 
 export const LogItem = ({ log }: { log: COMMON.LogItem }) => {
   const { content } = log;
@@ -33,7 +32,7 @@ export const LogItem = ({ log }: { log: COMMON.LogItem }) => {
     showContent = `[${serviceName}] --- ${content.split(parent).join('')}`;
   }
 
-  const reContent = AU.ansi_to_html(showContent).replace(/&quot;/g, '"');
+  const reContent = transformLog(showContent);
   return (
     <div className="log-insight-item">
       <span className="log-item-logtime">{time}</span>

--- a/shell/app/common/utils/index.ts
+++ b/shell/app/common/utils/index.ts
@@ -36,6 +36,7 @@ export {
   daysRange,
   formatTime,
 } from './str-num-date';
+import AnsiUp from 'ansi_up';
 
 export { getLabel } from './component-utils';
 
@@ -536,4 +537,11 @@ export const interpolationComp = (str: string, compMap: Record<string, JSX.Eleme
   });
   parts.push(left);
   return parts;
+};
+
+const AU = new AnsiUp();
+export const transformLog = (content: string) => {
+  return AU.ansi_to_html(content)
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'"); // restore escaped quotes
 };

--- a/shell/app/modules/runtime/common/logs/components/container-log.jsx
+++ b/shell/app/modules/runtime/common/logs/components/container-log.jsx
@@ -16,13 +16,12 @@ import React from 'react';
 import { Tooltip, Switch } from 'core/nusi';
 import { LogRoller, SimpleLog } from 'common';
 import { regLog } from 'common/components/log/log-util';
-import AnsiUp from 'ansi_up';
+import { transformLog } from 'app/common/utils';
 import i18n from 'i18n';
 import { LeftOne as IconLeftOne } from '@icon-park/react';
 
 import './container-log.scss';
 
-const AU = new AnsiUp();
 const defaultLogName = 'stdout';
 
 const parseLinkInContent = (content, pushSlideComp) => {
@@ -57,7 +56,7 @@ const getLogItem =
       level = _level;
     }
 
-    const reContent = parseLinkInContent(AU.ansi_to_html(content).replaceAll('&quot;', '"'), pushSlideComp);
+    const reContent = parseLinkInContent(transformLog(content), pushSlideComp);
     return (
       <div className="container-log-item">
         {time && <span className="log-item-logtime">{time}</span>}


### PR DESCRIPTION
## What this PR does / why we need it:
Restore the " and ' in log content.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the problem of quotation marks being escaped in the log |
| 🇨🇳 中文    |  修复日志中引号被转义的问题  |


## Does this PR need be patched to older version?
❎ No


