### PR TITLE
fix: repo-branch commit comment too long style bug

### DIFF
--- a/shell/app/modules/application/pages/repo/repo-branch.scss
+++ b/shell/app/modules/application/pages/repo/repo-branch.scss
@@ -13,5 +13,13 @@
       overflow: hidden;
       line-height: 24px;
     }
+
+    &-commit {
+      max-width: calc(100% - 260px);
+    }
+
+    .dice-avatar-wrap .nowrap {
+      max-width: 100px;
+    }
   }
 }

--- a/shell/app/modules/application/pages/repo/repo-branch.tsx
+++ b/shell/app/modules/application/pages/repo/repo-branch.tsx
@@ -105,11 +105,11 @@ const RepoBranch = () => {
                       &nbsp;{i18n.t('committed at')}
                     </span>
                     <span className="ml-1">{fromNow(when)}</span>
-                    <span className="ml-6 text-desc nowrap flex">
+                    <span className="ml-6 text-desc nowrap flex branch-item-commit">
                       <GotoCommit length={6} commitId={id} />
                       &nbsp;·&nbsp;
                       <Tooltip title={commitMessage.length > 50 ? commitMessage : null}>
-                        <Link className="text-desc hover-active" to={getCommitPath(id)}>
+                        <Link className="text-desc nowrap hover-active" to={getCommitPath(id)}>
                           {replaceEmoji(commitMessage)}
                         </Link>
                       </Tooltip>


### PR DESCRIPTION
## What this PR does / why we need it:
fix repo-branch commit comment too long style bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/130934863-fae55a28-ec66-4c67-86e2-4ec0e279dd3c.png)
->
![image](https://user-images.githubusercontent.com/82502479/130934911-9705c766-17b7-4ff6-ab20-1e4267742552.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

