### PR TITLE
feat: action show multiple instances log

### DIFF
--- a/shell/app/common/types/pipeline.d.ts
+++ b/shell/app/common/types/pipeline.d.ts
@@ -60,11 +60,17 @@ declare namespace PIPELINE {
     extra: {
       uuid: string;
       allowFailure: boolean;
+      taskContainers: ITaskContainers[];
     };
     result: {
       metadata?: MetaData[];
     };
     [k: string]: any;
+  }
+
+  interface ITaskContainers {
+    taskName: string;
+    containerID: string;
   }
 
   interface IPipelineDetail {

--- a/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
@@ -263,6 +263,7 @@ const BuildDetail = (props: IProps) => {
           taskID,
           pipelineID,
           logId: node.extra.uuid,
+          taskContainers: node.extra.taskContainers,
         });
         updater.logVisible(true);
         break;

--- a/shell/app/modules/application/pages/pipeline/run-detail/build-log.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-log.tsx
@@ -136,45 +136,35 @@ export class PureBuildLog extends React.PureComponent<IProps, IState> {
       />
     );
 
+    const logRollerFn = (id?: string) => (
+      <LogRoller
+        key={String(isStdErr)}
+        query={{
+          // 此处如果使用了customFetchAPIPrefix，在drawer关闭瞬间又触发了请求会使用后面的api，此时pipelineID为undefined(见自动化测试)
+          fetchApi:
+            customFetchAPIPrefix || (pipelineID && taskID ? `/api/cicd/${pipelineID}/tasks/${taskID}/logs` : false),
+          downloadAPI,
+          taskID,
+          id,
+          stream: isStdErr ? 'stderr' : 'stdout',
+        }}
+        logKey={logId}
+        extraButton={switchLog}
+        transformContent={this.transformContentToLink}
+      />
+    );
+
     const logRollerComp =
-      taskContainers.length !== 0 ? (
-        <Tabs defaultActiveKey="1">
+      Array.isArray(taskContainers) && taskContainers.length !== 0 ? (
+        <Tabs>
           {taskContainers.map((item) => (
             <TabPane tab={item.taskName} key={item.containerID}>
-              <LogRoller
-                key={String(isStdErr)}
-                query={{
-                  // 此处如果使用了customFetchAPIPrefix，在drawer关闭瞬间又触发了请求会使用后面的api，此时pipelineID为undefined(见自动化测试)
-                  fetchApi:
-                    customFetchAPIPrefix ||
-                    (pipelineID && taskID ? `/api/cicd/${pipelineID}/tasks/${taskID}/logs` : false),
-                  downloadAPI,
-                  taskID,
-                  id: item.containerID,
-                  stream: isStdErr ? 'stderr' : 'stdout',
-                }}
-                logKey={logId}
-                extraButton={switchLog}
-                transformContent={this.transformContentToLink}
-              />
+              {logRollerFn(item.containerID)}
             </TabPane>
           ))}
         </Tabs>
       ) : (
-        <LogRoller
-          key={String(isStdErr)}
-          query={{
-            // 此处如果使用了customFetchAPIPrefix，在drawer关闭瞬间又触发了请求会使用后面的api，此时pipelineID为undefined(见自动化测试)
-            fetchApi:
-              customFetchAPIPrefix || (pipelineID && taskID ? `/api/cicd/${pipelineID}/tasks/${taskID}/logs` : false),
-            downloadAPI,
-            taskID,
-            stream: isStdErr ? 'stderr' : 'stdout',
-          }}
-          logKey={logId}
-          extraButton={switchLog}
-          transformContent={this.transformContentToLink}
-        />
+        logRollerFn()
       );
 
     if (withoutDrawer) {

--- a/shell/app/modules/application/pages/pipeline/run-detail/build-log.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-log.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { LogRoller, CompSwitcher } from 'common';
-import { Switch, Drawer } from 'core/nusi';
+import { Switch, Drawer, Tabs } from 'core/nusi';
 import { map } from 'lodash';
 import DeployLog from 'runtime/common/logs/components/deploy-log';
 import i18n from 'i18n';
@@ -21,6 +21,8 @@ import commonStore from 'common/stores/common';
 import { LeftOne as IconLeftOne } from '@icon-park/react';
 
 const linkMark = '##to_link:';
+
+const { TabPane } = Tabs;
 
 interface IProps {
   withoutDrawer?: boolean;
@@ -36,6 +38,7 @@ interface IProps {
   clearLog: (logKey?: string) => void;
   pushSlideComp: (payload: any) => void;
   popSlideComp: () => void;
+  taskContainers: PIPELINE.ITaskContainers[];
 }
 
 interface IState {
@@ -114,6 +117,7 @@ export class PureBuildLog extends React.PureComponent<IProps, IState> {
       slidePanelComps,
       title,
       logId,
+      taskContainers = [],
       downloadAPI,
       customFetchAPIPrefix,
       pipelineID,
@@ -131,23 +135,50 @@ export class PureBuildLog extends React.PureComponent<IProps, IState> {
         onChange={this.toggleLogName}
       />
     );
-    if (withoutDrawer) {
-      return (
-        <CompSwitcher comps={slidePanelComps}>
-          <LogRoller
-            key={String(isStdErr)}
-            query={{
-              fetchApi: customFetchAPIPrefix || `/api/cicd/${pipelineID}/tasks/${taskID}/logs`,
-              downloadAPI,
-              taskID,
-              stream: isStdErr ? 'stderr' : 'stdout',
-            }}
-            logKey={logId}
-            extraButton={switchLog}
-            transformContent={this.transformContentToLink}
-          />
-        </CompSwitcher>
+
+    const logRollerComp =
+      taskContainers.length !== 0 ? (
+        <Tabs defaultActiveKey="1">
+          {taskContainers.map((item) => (
+            <TabPane tab={item.taskName} key={item.containerID}>
+              <LogRoller
+                key={String(isStdErr)}
+                query={{
+                  // 此处如果使用了customFetchAPIPrefix，在drawer关闭瞬间又触发了请求会使用后面的api，此时pipelineID为undefined(见自动化测试)
+                  fetchApi:
+                    customFetchAPIPrefix ||
+                    (pipelineID && taskID ? `/api/cicd/${pipelineID}/tasks/${taskID}/logs` : false),
+                  downloadAPI,
+                  taskID,
+                  id: item.containerID,
+                  stream: isStdErr ? 'stderr' : 'stdout',
+                }}
+                logKey={logId}
+                extraButton={switchLog}
+                transformContent={this.transformContentToLink}
+              />
+            </TabPane>
+          ))}
+        </Tabs>
+      ) : (
+        <LogRoller
+          key={String(isStdErr)}
+          query={{
+            // 此处如果使用了customFetchAPIPrefix，在drawer关闭瞬间又触发了请求会使用后面的api，此时pipelineID为undefined(见自动化测试)
+            fetchApi:
+              customFetchAPIPrefix || (pipelineID && taskID ? `/api/cicd/${pipelineID}/tasks/${taskID}/logs` : false),
+            downloadAPI,
+            taskID,
+            stream: isStdErr ? 'stderr' : 'stdout',
+          }}
+          logKey={logId}
+          extraButton={switchLog}
+          transformContent={this.transformContentToLink}
+        />
       );
+
+    if (withoutDrawer) {
+      return <CompSwitcher comps={slidePanelComps}>{logRollerComp}</CompSwitcher>;
     }
     return (
       <Drawer
@@ -161,22 +192,7 @@ export class PureBuildLog extends React.PureComponent<IProps, IState> {
         visible={visible}
         onClose={hideLog}
       >
-        <CompSwitcher comps={slidePanelComps}>
-          <LogRoller
-            key={String(isStdErr)}
-            query={{
-              // 此处如果使用了customFetchAPIPrefix，在drawer关闭瞬间又触发了请求会使用后面的api，此时pipelineID为undefined(见自动化测试)
-              fetchApi:
-                customFetchAPIPrefix || (pipelineID && taskID ? `/api/cicd/${pipelineID}/tasks/${taskID}/logs` : false),
-              downloadAPI,
-              taskID,
-              stream: isStdErr ? 'stderr' : 'stdout',
-            }}
-            logKey={logId}
-            extraButton={switchLog}
-            transformContent={this.transformContentToLink}
-          />
-        </CompSwitcher>
+        <CompSwitcher comps={slidePanelComps}>{logRollerComp}</CompSwitcher>
       </Drawer>
     );
   }


### PR DESCRIPTION
## What this PR does / why we need it:
action show multiple instances log.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/131318297-9c936e25-1dce-4d5f-b0e3-665f83480983.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Multiple container instance logs can be displayed. |
| 🇨🇳 中文    | Aciton 支持展示多容器实例日志。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

