### PR TITLE
fix: fix file editor data exceed

### DIFF
--- a/shell/app/common/components/file-editor.tsx
+++ b/shell/app/common/components/file-editor.tsx
@@ -135,6 +135,12 @@ interface IProps extends IAceEditorProps {
   [prop: string]: any;
 }
 
+const valueExceed = (val: string) => {
+  const bt = new Blob([val]);
+  // more than 500kb
+  return bt.size > 500 * 1024;
+};
+
 export const FileEditor = ({
   fileExtension,
   editorProps,
@@ -172,6 +178,31 @@ export const FileEditor = ({
       });
     }
   }, [mode, value]);
+
+  if (value && valueExceed(value)) {
+    const downloadValue = () => {
+      const blob = new Blob([value], { type: 'application/vnd.ms-excel;charset=utf-8' });
+      const fileName = `result.txt`;
+      const objectUrl = URL.createObjectURL(blob);
+      const downloadLink = document.createElement('a');
+      downloadLink.href = objectUrl;
+      downloadLink.setAttribute('download', fileName);
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      window.URL.revokeObjectURL(downloadLink.href);
+    };
+
+    return (
+      <div>
+        {i18n.t('common:the current data volume exceeds 500kb, please click')}&nbsp;
+        <span className="fake-link" onClick={downloadValue}>
+          {i18n.t('download')}
+        </span>
+        &nbsp;
+        {i18n.t('check detail')}
+      </div>
+    );
+  }
 
   const curActions = compact([
     actions.copy ? (

--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -852,6 +852,7 @@
     "submit": "submit",
     "test case": "test case",
     "text edit": "text edit",
+    "the current data volume exceeds 500kb, please click": "the current data volume exceeds 500kb, please click",
     "the uploaded file must not exceed {size}M": "the uploaded file must not exceed {size}M",
     "this configuration already exists": "this configuration already exists",
     "this item is required": "this item is required",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -852,6 +852,7 @@
     "submit": "提交",
     "test case": "用例",
     "text edit": "文本编辑",
+    "the current data volume exceeds 500kb, please click": "当前数据量超过500kb，请点击",
     "the uploaded file must not exceed {size}M": "上传的文件不得超过{size}M",
     "this configuration already exists": "该配置已存在",
     "this item is required": "该项为必填项",


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix file editor data exceed

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![80346CD9-A89F-4B2C-9E04-64C08EF53B68](https://user-images.githubusercontent.com/15364706/131320216-a8ed7b08-e16f-4a0a-8ce3-024e9761a045.gif)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix: download check detail when the content of the file editor exceed the limit          |
| 🇨🇳 中文    |     feat: 文件编辑器内容超过限制时转为下载查看      |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=208387&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAzOTAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG
