### PR TITLE
fix(dop): add timer to loop get pipeline status until websocket is stable

### DIFF
--- a/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
@@ -29,7 +29,6 @@ import buildStore from 'application/stores/build';
 import { useUpdateEffect, useEffectOnce } from 'react-use';
 import routeInfoStore from 'core/stores/route';
 import { useLoading } from 'core/stores/loading';
-import { getPipelineDetail } from 'application/services/build';
 import PipelineLog from './pipeline-log';
 import './build-detail.scss';
 import deployStore from 'application/stores/deploy';
@@ -99,6 +98,18 @@ const BuildDetail = (props: IProps) => {
     'getPipelineDetail',
     'addPipeline',
   ]);
+
+  // set a timer to loop get status, until websocket push is available
+  const timer = React.useRef<NodeJS.Timeout>();
+  React.useEffect(() => {
+    if (pipelineDetail && ciBuildStatusSet.executeStatus.includes(pipelineDetail.status)) {
+      timer.current = setTimeout(() => {
+        state.chosenPipelineId && getPipelineDetail({ pipelineID: +state.chosenPipelineId });
+      }, 10000);
+    } else {
+      timer.current && clearTimeout(timer.current);
+    }
+  }, [getPipelineDetail, pipelineDetail, state.chosenPipelineId]);
 
   React.useEffect(() => {
     state.chosenPipelineId && getPipelineDetail({ pipelineID: +state.chosenPipelineId });


### PR DESCRIPTION
## What this PR does / why we need it:
Websocket is not stable, pipeline status is often not udpate until manual refresh page. Add a timer to get status.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | auto fresh pipeline status every 10 seconds  |
| 🇨🇳 中文    | 每隔 10s 自动刷新流水线状态  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

