### PR TITLE
feat: version-list of publisher add aab file download button

### DIFF
--- a/shell/app/modules/publisher/pages/artifacts/version-list.tsx
+++ b/shell/app/modules/publisher/pages/artifacts/version-list.tsx
@@ -368,30 +368,44 @@ const VersionList = (props: IProps) => {
                               </Button>
                             </WithAuth>
                           </IF>
-                          <Popconfirm
-                            title={i18n.t('is it confirmed {action}?', {
-                              action: isPublic ? i18n.t('publisher:withdraw') : i18n.t('publisher:publish'),
-                            })}
-                            onConfirm={() => {
-                              openGrayModal(record);
-                            }}
-                          >
-                            <WithAuth pass={publishOperationAuth}>
-                              <Tooltip
-                                title={
-                                  disableVersionConf(record)
-                                    ? i18n.t(
-                                        'publisher:The official and preview version published should be withdrawn first, then other versions can be published.',
-                                      )
-                                    : undefined
-                                }
-                              >
-                                <Button disabled={disableVersionConf(record)}>
-                                  {isPublic ? i18n.t('publisher:withdraw') : i18n.t('publisher:publish')}
-                                </Button>
-                              </Tooltip>
-                            </WithAuth>
-                          </Popconfirm>
+                          {record.resources.map((item) => {
+                            if (item.type === 'aab') {
+                              return (
+                                <WithAuth pass={publishOperationAuth}>
+                                  <Button disabled={disableVersionConf(record)} onClick={() => window.open(item.url)}>
+                                    {i18n.t('download')}
+                                  </Button>
+                                </WithAuth>
+                              );
+                            } else {
+                              return (
+                                <Popconfirm
+                                  title={i18n.t('is it confirmed {action}?', {
+                                    action: isPublic ? i18n.t('publisher:withdraw') : i18n.t('publisher:publish'),
+                                  })}
+                                  onConfirm={() => {
+                                    openGrayModal(record);
+                                  }}
+                                >
+                                  <WithAuth pass={publishOperationAuth}>
+                                    <Tooltip
+                                      title={
+                                        disableVersionConf(record)
+                                          ? i18n.t(
+                                              'publisher:The official and preview version published should be withdrawn first, then other versions can be published.',
+                                            )
+                                          : undefined
+                                      }
+                                    >
+                                      <Button disabled={disableVersionConf(record)}>
+                                        {isPublic ? i18n.t('publisher:withdraw') : i18n.t('publisher:publish')}
+                                      </Button>
+                                    </Tooltip>
+                                  </WithAuth>
+                                </Popconfirm>
+                              );
+                            }
+                          })}
                         </div>
                       </div>
                     );

--- a/shell/app/modules/publisher/types/publisher.d.ts
+++ b/shell/app/modules/publisher/types/publisher.d.ts
@@ -139,7 +139,7 @@ declare namespace PUBLISHER {
     resources: IResource[];
   }
 
-  type MobileType = 'ios' | 'android' | 'h5';
+  type MobileType = 'ios' | 'android' | 'h5' | 'aab';
 
   interface VersionListQuery {
     artifactsId: string;


### PR DESCRIPTION
## What this PR does / why we need it:
version-list of publisher add aab file download button.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/131639134-c8fe5c92-52e8-42ca-8155-13e18ca81bdc.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | In my publisher version-list, added aab file download button.   |
| 🇨🇳 中文    |  在我的发布的版本内容中，增加aab文件的下载按钮。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

