### PR TITLE
fix: pipeline log height is not 100%

### DIFF
--- a/shell/app/common/components/log/log-roller.scss
+++ b/shell/app/common/components/log/log-roller.scss
@@ -3,6 +3,10 @@ $log-bg-color: #3c444f;
 
 .log-viewer {
   height: 100%;
+
+  .ant-tabs-content {
+    height: 100%;
+  }
 }
 
 .log-roller {

--- a/shell/app/modules/application/pages/pipeline/run-detail/build-log.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-log.tsx
@@ -156,7 +156,7 @@ export class PureBuildLog extends React.PureComponent<IProps, IState> {
 
     const logRollerComp =
       Array.isArray(taskContainers) && taskContainers.length !== 0 ? (
-        <Tabs>
+        <Tabs className="log-viewer">
           {taskContainers.map((item) => (
             <TabPane tab={item.taskName} key={item.containerID}>
               {logRollerFn(item.containerID)}


### PR DESCRIPTION
## What this PR does / why we need it:
fix pipeline log height is not 100% bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/131791053-d096593e-2d49-4ed9-91a9-76afd4f5a33d.png)
->
![image](https://user-images.githubusercontent.com/82502479/131791087-636b6e46-0aca-449f-ac7c-6c43bbee38e2.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix a bug where pipeline log height is not 100. |
| 🇨🇳 中文    | 修复了流水线日志的高度没有100%的bug。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

