### PR TITLE
feat(dop): move the dashboard under the project collaboration

### DIFF
--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -2880,7 +2880,7 @@
     "custom config of issue type": "事项类型自定义配置",
     "custom fields": "自定义字段",
     "cut": "剪切",
-    "dashboard": "项目大盘",
+    "dashboard": "仪表盘",
     "data bank": "数据银行",
     "data sources": "数据源",
     "date cannot be empty": "日期不能为空",

--- a/shell/app/menus/project.tsx
+++ b/shell/app/menus/project.tsx
@@ -83,12 +83,6 @@ export const getProjectMenu = (projectId: string, pathname: string) => {
       ],
     },
     {
-      href: goTo.resolve.projectDashboard(), // `/dop/projects/${projectId}/dashboard`,
-      icon: <IconDashboardCar />,
-      text: i18n.t('project:dashboard'),
-      show: projectPerm.dashboard.viewDashboard.pass,
-    },
-    {
       href: goTo.resolve.projectService(),
       icon: <CustomIcon type="kuozhanfuwu" />,
       text: i18n.t('project:addon'),

--- a/shell/app/modules/project/router.js
+++ b/shell/app/modules/project/router.js
@@ -34,18 +34,6 @@ function getProjectRouter() {
           getComp: (cb) => cb(import('project/pages/apps/app-form')),
         },
         {
-          path: 'dashboard',
-          routes: [
-            {
-              breadcrumbName: i18n.t('project:dashboard'),
-              getComp: (cb) => cb(import('project/pages/dashboard'), 'ProjectDashboard'),
-              layout: {
-                fullHeight: true,
-              },
-            },
-          ],
-        },
-        {
           path: 'issues',
           mark: 'issues',
           breadcrumbName: i18n.t('project:issues'),
@@ -121,6 +109,20 @@ function getProjectRouter() {
               ignoreTabQuery: true,
               getComp: (cb) => cb(import('project/pages/milestone'), 'Milestone'),
               layout: { noWrapper: true, fullHeight: true },
+            },
+            {
+              path: 'dashboard',
+              tabs: PROJECT_TABS,
+              ignoreTabQuery: true,
+              routes: [
+                {
+                  breadcrumbName: i18n.t('project:dashboard'),
+                  getComp: (cb) => cb(import('project/pages/dashboard'), 'ProjectDashboard'),
+                  layout: {
+                    fullHeight: true,
+                  },
+                },
+              ],
             },
           ],
         },

--- a/shell/app/modules/project/tabs.tsx
+++ b/shell/app/modules/project/tabs.tsx
@@ -134,6 +134,11 @@ export const PROJECT_TABS = () => {
       name: i18n.t('bug'),
       show: projectPerm.bug.read.pass,
     },
+    {
+      key: 'dashboard',
+      name: i18n.t('project:dashboard'),
+      show: projectPerm.dashboard.viewDashboard.pass,
+    },
   ];
   return tabs;
 };


### PR DESCRIPTION
## What this PR does / why we need it:
Adjust the dashboard position.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/131939230-ae7f507e-af05-4833-aae0-393aaa00d34b.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | move the dashboard under the project collaboration  |
| 🇨🇳 中文    | 把项目大盘移到了项目协同下 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

