### PR TITLE
fix: markdown editor can not input Chinese in Safari

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,7 +283,7 @@ importers:
       '@babel/preset-typescript': ^7.13.0
       '@babel/traverse': ^7.14.7
       '@erda-ui/dashboard-configurator': 1.0.29
-      '@erda-ui/react-markdown-editor-lite': ^1.4.4
+      '@erda-ui/react-markdown-editor-lite': ^1.4.5
       '@icon-park/react': ^1.3.3
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -417,7 +417,7 @@ importers:
       xterm: 3.12.0
     dependencies:
       '@erda-ui/dashboard-configurator': 1.0.29_89f7d333518b25ce6638797795704a0d
-      '@erda-ui/react-markdown-editor-lite': 1.4.4_react@16.14.0
+      '@erda-ui/react-markdown-editor-lite': 1.4.5_react@16.14.0
       '@icon-park/react': 1.3.3_react-dom@16.14.0+react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -4087,8 +4087,8 @@ packages:
       - supports-color
     dev: false
 
-  /@erda-ui/react-markdown-editor-lite/1.4.4_react@16.14.0:
-    resolution: {integrity: sha512-IIjtYL3bFcWp/bXG8MI7SyKrObZjaIQpTc6IlFpcywtAiXnBuynrDl2wZTc45Ms0Hfq0z4bDBcpCHslVywAo3g==}
+  /@erda-ui/react-markdown-editor-lite/1.4.5_react@16.14.0:
+    resolution: {integrity: sha512-TLa3YJZw4ZEMz3YuVVMDnvKinRI151KTpKE0JvwQQv+wpR7x1ZLqWRCohWa+MRZ5HWQPqxZha2dwJ6BCDqUhGw==}
     peerDependencies:
       react: ^16.9.0
     dependencies:

--- a/shell/package.json
+++ b/shell/package.json
@@ -46,7 +46,7 @@
   "license": "AGPL",
   "dependencies": {
     "@erda-ui/dashboard-configurator": "1.0.29",
-    "@erda-ui/react-markdown-editor-lite": "^1.4.4",
+    "@erda-ui/react-markdown-editor-lite": "^1.4.5",
     "@icon-park/react": "^1.3.3",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:
Safari can not input Chinese with IME in textarea. See https://github.com/ianstormtaylor/slate/issues/2457#issuecomment-490319129

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix markdown editor can not input Chinese in Safari |
| 🇨🇳 中文    | 修复 Safari 下 markdown 编辑器无法输入中文的问题 |


## Does this PR need be patched to older version?
❎ No



