### PR TITLE
fix: modify style of waterfall flow in trace detail

### DIFF
--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-detail/components/trace-detail.scss
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-detail/components/trace-detail.scss
@@ -177,7 +177,6 @@
     .duration,
     .span-name {
       position: absolute;
-      width: 100%;
       height: 23px;
       padding-left: 4px;
       //overflow: hidden;

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-detail/components/trace-detail.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-detail/components/trace-detail.tsx
@@ -198,28 +198,32 @@ class TraceDetail extends React.Component<IProps, IState> {
                         </div>
                       );
                     })}
-                    <div className="duration" style={{ left: `${span.left}%`, width: `${span.width}%` }}>
-                      {map(annotations, (annotation, index) => {
-                        const { isCore, left, value, endpoint, timestamp, relativeTime, serviceName } = annotation;
-                        return (
-                          <div
-                            key={`annotation${index}`}
-                            className={`annotation${isCore ? 'core' : ''}`}
-                            style={{ left: `${left}%` }}
-                            title={value}
-                            data-keys="endpoint,value,timestamp,relativeTime,serviceName"
-                            data-endpoint={endpoint}
-                            data-value={value}
-                            data-timestamp={timestamp}
-                            data-relative-time={relativeTime}
-                            data-service-name={serviceName}
-                          />
-                        );
-                      })}
-                    </div>
-                    <Tooltip title={tags.spanName} overlayClassName="span-tooltip" arrowPointAtCenter>
-                      <span className="span-name" style={{ left: `${span.left}%`, width: `${100 - span.left}%` }}>
-                        {durationStr} : {operationName}
+                    <Tooltip
+                      title={`${durationStr} : ${operationName}`}
+                      overlayClassName="span-tooltip"
+                      arrowPointAtCenter
+                    >
+                      <div className="duration" style={{ left: `${span.left}%`, width: `${span.width}%` }}>
+                        {map(annotations, (annotation, index) => {
+                          const { isCore, left, value, endpoint, timestamp, relativeTime, serviceName } = annotation;
+                          return (
+                            <div
+                              key={`annotation${index}`}
+                              className={`annotation${isCore ? 'core' : ''}`}
+                              style={{ left: `${left}%` }}
+                              title={value}
+                              data-keys="endpoint,value,timestamp,relativeTime,serviceName"
+                              data-endpoint={endpoint}
+                              data-value={value}
+                              data-timestamp={timestamp}
+                              data-relative-time={relativeTime}
+                              data-service-name={serviceName}
+                            />
+                          );
+                        })}
+                      </div>
+                      <span className="span-name" style={{ left: `${span.left}%` }}>
+                        {durationStr}
                       </span>
                     </Tooltip>
                   </div>

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-detail.scss
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-detail.scss
@@ -147,7 +147,7 @@
     .duration,
     .span-name {
       position: absolute;
-      width: 100%;
+      // width: 100%;
       height: 23px;
       padding-left: 4px;
       //overflow: hidden;

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-detail.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-detail.tsx
@@ -204,7 +204,6 @@ class TraceDetail extends React.Component<IProps, IState> {
                       </Tooltip>
                     </div>
                   </div>
-
                   <div
                     className="duration-container"
                     onClick={() => this.props.getSpanDetailContent({ span, visible: true })}
@@ -216,28 +215,32 @@ class TraceDetail extends React.Component<IProps, IState> {
                         </div>
                       );
                     })}
-                    <div className="duration" style={{ left: `${span.left}%`, width: `${span.width}%` }}>
-                      {map(annotations, (annotation, index) => {
-                        const { isCore, left, value, endpoint, timestamp, relativeTime, serviceName } = annotation;
-                        return (
-                          <div
-                            key={`annotation${index}`}
-                            className={`annotation${isCore ? 'core' : ''}`}
-                            style={{ left: `${left}%` }}
-                            title={value}
-                            data-keys="endpoint,value,timestamp,relativeTime,serviceName"
-                            data-endpoint={endpoint}
-                            data-value={value}
-                            data-timestamp={timestamp}
-                            data-relative-time={relativeTime}
-                            data-service-name={serviceName}
-                          />
-                        );
-                      })}
-                    </div>
-                    <Tooltip title={tags.spanName} overlayClassName="span-tooltip" arrowPointAtCenter>
-                      <span className="span-name" style={{ left: `${span.left}%`, width: `${100 - span.left}%` }}>
-                        {durationStr} : {operationName}
+                    <Tooltip
+                      title={`${durationStr} : ${operationName}`}
+                      overlayClassName="span-tooltip"
+                      arrowPointAtCenter
+                    >
+                      <div className="duration" style={{ left: `${span.left}%`, width: `${span.width}%` }}>
+                        {map(annotations, (annotation, index) => {
+                          const { isCore, left, value, endpoint, timestamp, relativeTime, serviceName } = annotation;
+                          return (
+                            <div
+                              key={`annotation${index}`}
+                              className={`annotation${isCore ? 'core' : ''}`}
+                              style={{ left: `${left}%` }}
+                              title={value}
+                              data-keys="endpoint,value,timestamp,relativeTime,serviceName"
+                              data-endpoint={endpoint}
+                              data-value={value}
+                              data-timestamp={timestamp}
+                              data-relative-time={relativeTime}
+                              data-service-name={serviceName}
+                            />
+                          );
+                        })}
+                      </div>
+                      <span className="span-name" style={{ left: `${span.left}%` }}>
+                        {durationStr}
                       </span>
                     </Tooltip>
                   </div>


### PR DESCRIPTION
## What this PR does / why we need it:
display detail when hovering over the time span.

before:
![image](https://user-images.githubusercontent.com/30014895/132291773-251cd654-d68a-4ab4-bd7f-256b4e83d77d.png)

now:
![image](https://user-images.githubusercontent.com/30014895/132291953-665f95ef-4d98-4e89-a519-9d17df93aa7e.png)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

