### PR TITLE
fix: show view config button in addon card only in project scope

### DIFF
--- a/shell/app/modules/addonPlatform/pages/common/components/addon-cards.tsx
+++ b/shell/app/modules/addonPlatform/pages/common/components/addon-cards.tsx
@@ -25,6 +25,7 @@ import addon_png from 'app/images/resources/addon.png';
 import './addon-cards.scss';
 import addonStore from 'common/stores/addon';
 import CustomAddonConfigModal from 'project/pages/addon/custom-config';
+import routeInfoStore from 'core/stores/route';
 
 interface IProps {
   dataSource?: any[];
@@ -49,6 +50,7 @@ export const AddonCards = (props: IProps) => {
       customConfigVisible: false,
     });
   const [addonDetail, addonReferences] = addonStore.useStore((s) => [s.addonDetail, s.addonReferences]);
+  const routeParams = routeInfoStore.useStore((s) => s.params);
 
   React.useEffect(() => {
     if (dataSource) {
@@ -295,7 +297,7 @@ export const AddonCards = (props: IProps) => {
                 const [title, contents] = category;
                 const liRef = categoryRefs && categoryRefs.find((x) => x[title]);
                 let extra = null;
-                if (get(contents, '[0].category') === 'custom') {
+                if (get(contents, '[0].category') === 'custom' && routeParams.projectId) {
                   extra = (
                     <Button size="small" className="ml-2" onClick={() => updater.customConfigVisible(true)}>
                       {i18n.t('project:view config')}

--- a/shell/app/modules/application/pages/deploy/runtime-box.tsx
+++ b/shell/app/modules/application/pages/deploy/runtime-box.tsx
@@ -86,7 +86,7 @@ const RuntimeBox = (props: IProps) => {
             secondTitle={
               <span>
                 {i18n.t('application:confirm to delete Runtime')}:{' '}
-                <b>{isZh() ? `${envMap[env.toUpperCase()]} 环境的 【${branch}】` : `【${branch}】 in ${env}`}</b>
+                <b>{isZh() ? `${envMap[env.toUpperCase()]}环境的 【${branch}】` : `【${branch}】 in ${env}`}</b>
               </span>
             }
           >

--- a/shell/app/modules/msp/monitor/status-insight/index.js
+++ b/shell/app/modules/msp/monitor/status-insight/index.js
@@ -20,6 +20,9 @@ function monitorStatusRouter() {
     routes: [
       {
         getComp: (cb) => cb(import('status-insight/pages/status/status')),
+        layout: {
+          noWrapper: true,
+        },
       },
       {
         path: ':metricId',


### PR DESCRIPTION
## What this PR does / why we need it:
* show view config button in addon card only in project scope
* remove space between Chinese words
* remove wrapper in status page 

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

