### PR TITLE
fix: test-plan-drawer-folder-name-too-long

### DIFF
--- a/shell/app/modules/project/pages/test-manage/case/case-drawer/index.scss
+++ b/shell/app/modules/project/pages/test-manage/case/case-drawer/index.scss
@@ -15,6 +15,14 @@
         font-size: 16px;
       }
     }
+
+    &-desc {
+      max-width: calc(100% - 210px);
+
+      .truncate {
+        max-width: calc(100 - 20px);
+      }
+    }
   }
 
   &-body {

--- a/shell/app/modules/project/pages/test-manage/case/case-drawer/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/case/case-drawer/index.tsx
@@ -350,9 +350,9 @@ const CaseDrawer = ({ visible, scope, onClose, afterClose, afterSave, caseList }
           </div>
           <div className="flex justify-between items-center mt-4">
             <Tooltip title={dirName && dirName.length < 40 ? null : dirName}>
-              <div className="flex text-base nowrap mr-5 color-text-desc">
+              <div className="flex text-base nowrap mr-5 color-text-desc case-drawer-header-desc">
                 <ErdaCustomIcon type="wjj1" size="16" className="mr-1" fill="yellow" />
-                {dirName}
+                <span className="truncate">{dirName}</span>
               </div>
             </Tooltip>
             {editMode && (


### PR DESCRIPTION
## What this PR does / why we need it:
fix test-plan-drawer-folder-name-too-long.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/132441942-8b8268b4-cded-45ac-9348-d85ab0f962fd.png)
->
![image](https://user-images.githubusercontent.com/82502479/132441961-827e861f-470b-4760-8d3e-189cc2ecbb02.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed style bug caused by folder name too long in test-plan detail drawer.  |
| 🇨🇳 中文    | 修复了测试管理-执行计划中详情划窗里文件夹名字过长导致的样式问题。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

