### PR TITLE
fix(dop): duplicate Chinese words in Safari when edit issue

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,7 +283,7 @@ importers:
       '@babel/preset-typescript': ^7.13.0
       '@babel/traverse': ^7.14.7
       '@erda-ui/dashboard-configurator': 1.0.29
-      '@erda-ui/react-markdown-editor-lite': ^1.4.5
+      '@erda-ui/react-markdown-editor-lite': ^1.4.6
       '@icon-park/react': ^1.3.3
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -417,7 +417,7 @@ importers:
       xterm: 3.12.0
     dependencies:
       '@erda-ui/dashboard-configurator': 1.0.29_89f7d333518b25ce6638797795704a0d
-      '@erda-ui/react-markdown-editor-lite': 1.4.5_react@16.14.0
+      '@erda-ui/react-markdown-editor-lite': 1.4.6_react@16.14.0
       '@icon-park/react': 1.3.3_react-dom@16.14.0+react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -4087,8 +4087,8 @@ packages:
       - supports-color
     dev: false
 
-  /@erda-ui/react-markdown-editor-lite/1.4.5_react@16.14.0:
-    resolution: {integrity: sha512-TLa3YJZw4ZEMz3YuVVMDnvKinRI151KTpKE0JvwQQv+wpR7x1ZLqWRCohWa+MRZ5HWQPqxZha2dwJ6BCDqUhGw==}
+  /@erda-ui/react-markdown-editor-lite/1.4.6_react@16.14.0:
+    resolution: {integrity: sha512-kpBk9HQfvgHLoYUUqnghyUfBdmIoVCWBQfihdGhQweWAcXP6+bhXifd0h8S/Haj7gKkzZ6UwAvZjXwBDgdshaQ==}
     peerDependencies:
       react: ^16.9.0
     dependencies:

--- a/shell/app/common/components/edit-field.tsx
+++ b/shell/app/common/components/edit-field.tsx
@@ -102,7 +102,6 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
   const {
     name,
     type,
-    value,
     placeHolder,
     className = '',
     label,
@@ -134,8 +133,8 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
   const { editValue } = state;
 
   React.useEffect(() => {
-    updater.editValue(value || get(data, name));
-  }, [value, data, name, updater]);
+    updater.editValue(originalValue);
+  }, [originalValue, updater]);
 
   let Comp = <div />;
 
@@ -154,13 +153,11 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
     }
   };
 
-  const onBlur = (v?: string, fieldType?: string) => {
+  const onBlur = () => {
     if (onChangeCb) {
       if ((type && ['input', 'textArea'].includes(type)) || !type) {
         const currentRef = typeof compRef === 'function' ? refMap?.[name] : compRef?.current;
         data[name] !== currentRef?.state.value && onChangeCb(set({}, name, currentRef?.state.value));
-      } else if (type === 'markdown') {
-        onChangeCb(set({}, name, v), fieldType);
       }
     }
   };
@@ -193,13 +190,13 @@ export const EditField = React.forwardRef((props: IProps, _compRef) => {
     case 'markdown':
       // 创建时不需要提交、取消按钮
       Comp = !itemProps.isEditMode ? (
-        <MarkdownEditor {...itemProps} value={editValue} onChange={onBlur} />
+        <MarkdownEditor {...itemProps} value={editValue} onChange={(v) => onChangeCb?.({ [name]: v })} />
       ) : (
         <EditMd
           {...itemProps}
           value={editValue}
           onChange={updater.editValue}
-          onSave={onBlur}
+          onSave={(v) => onChangeCb?.({ [name]: v })}
           originalValue={originalValue}
           disabled={disabled}
         />

--- a/shell/package.json
+++ b/shell/package.json
@@ -46,7 +46,7 @@
   "license": "AGPL",
   "dependencies": {
     "@erda-ui/dashboard-configurator": "1.0.29",
-    "@erda-ui/react-markdown-editor-lite": "^1.4.5",
+    "@erda-ui/react-markdown-editor-lite": "^1.4.6",
     "@icon-park/react": "^1.3.3",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:
Fix markdown editor update state logic, which cause duplicate Chinese words in Safari.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

