### PR TITLE
feat(dop): support use last execute cluster in project pipeline

### DIFF
--- a/shell/app/modules/project/common/components/pipeline-manage/common/config-env-selector.tsx
+++ b/shell/app/modules/project/common/components/pipeline-manage/common/config-env-selector.tsx
@@ -84,7 +84,7 @@ const ConfigEnvSelector = (props: IProps) => {
           component: 'select',
           required: true,
           key: 'clusterName',
-          defaultValue: 'TEST',
+          defaultValue: getLastRunParams().clusterName || 'TEST',
           type: 'select',
           dataSource: {
             type: 'static',
@@ -134,7 +134,7 @@ const ConfigEnvSelector = (props: IProps) => {
 
   const getLastRunParams = () => {
     const runParams = get(caseDetail, 'meta.runParams');
-    const val = {};
+    const val: Obj = {};
     map(runParams, (item) => {
       val[item.name] = item.value;
     });


### PR DESCRIPTION
## What this PR does / why we need it:
support use last execute cluster in project pipeline, prevent choose the wrong cluster.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The project-level pipelining execution defaults to the last cluster |
| 🇨🇳 中文    | 项目级流水线执行是默认选择上次的集群 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3
release/1.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

