### PR TITLE
fix(common): remove thread-loader to fix build crash issue

### DIFF
--- a/shell/webpack.config.js
+++ b/shell/webpack.config.js
@@ -134,7 +134,6 @@ module.exports = () => {
           include: [resolve('app')],
           use: [
             ...(isProd ? [MiniCssExtractPlugin.loader] : []), // extract not support hmr, https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/222
-            'thread-loader',
             ...(isProd ? [] : ['style-loader']),
             {
               loader: 'css-loader',
@@ -183,7 +182,6 @@ module.exports = () => {
           test: /\.(tsx?|jsx?)$/,
           include: [resolve('app')],
           use: [
-            'thread-loader',
             {
               loader: 'babel-loader', // TODO tree sharking is not available in MF, will handle it later
               options: {


### PR DESCRIPTION
## What this PR does / why we need it:
we got build error while building shell, maybe caused by recent package update. according to github issue https://github.com/webpack-contrib/thread-loader/issues/124 . I remove thread-loader for now

![image](https://user-images.githubusercontent.com/5175455/132942097-d9461612-a057-4679-8320-311015c98e06.png)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

