### PR TITLE
fix: no permission page restriction maximum of six user names are all…

### DIFF
--- a/shell/app/common/utils/index.ts
+++ b/shell/app/common/utils/index.ts
@@ -569,3 +569,14 @@ export const colorToRgb = (color: string, opacity?: number) => {
   }
   return sColor;
 };
+
+export const pickRandomlyFromArray = (array: any[], num: number) => {
+  if (array.length > num) {
+    return new Array(num).fill(null).map(() => {
+      const index = Math.floor(Math.random() * array.length);
+      return array.splice(index, 1)[0];
+    });
+  } else {
+    return array;
+  }
+};

--- a/shell/app/user/stores/permission.ts
+++ b/shell/app/user/stores/permission.ts
@@ -126,7 +126,7 @@ const permission = createStore({
         permission.reducers.clearScopePerm(realScope);
         const userMap = getUserMap();
         userStore.reducers.setNoAuth(
-          map(contactsWhenNoPermission || [], (id) => {
+          map(contactsWhenNoPermission?.slice(0, 6) || [], (id) => {
             const match = userMap[id] || {};
             return `${match.nick || match.name} (${match.phone || match.email})`;
           }).join(', '),

--- a/shell/app/user/stores/permission.ts
+++ b/shell/app/user/stores/permission.ts
@@ -22,6 +22,7 @@ import routeInfoStore from 'core/stores/route';
 import { getUserMap } from 'core/stores/userMap';
 import userStore from './index';
 import { permPrefix, permState } from './_perm-state';
+import { pickRandomlyFromArray } from 'common/utils';
 
 const rolesMap = {
   app: appRoleMap,
@@ -126,7 +127,7 @@ const permission = createStore({
         permission.reducers.clearScopePerm(realScope);
         const userMap = getUserMap();
         userStore.reducers.setNoAuth(
-          map(contactsWhenNoPermission?.slice(0, 6) || [], (id) => {
+          map((contactsWhenNoPermission && pickRandomlyFromArray(contactsWhenNoPermission, 6)) || [], (id) => {
             const match = userMap[id] || {};
             return `${match.nick || match.name} (${match.phone || match.email})`;
           }).join(', '),


### PR DESCRIPTION
## What this PR does / why we need it:
No permission page restriction maximum of six user names are allowed.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | A maximum of six contact user names can be displayed on the no permission page. |
| 🇨🇳 中文    |  无权限页面新增限制最多显示六个联系用户名。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #  https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=222285&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMTIxNCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG

