### PR TITLE
fix(dop): issue workflow not update after edit, update style

### DIFF
--- a/scheduler/src/filters/error-catch.filter.ts
+++ b/scheduler/src/filters/error-catch.filter.ts
@@ -23,7 +23,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
     const status = exception instanceof HttpException ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
 
-    logger.error('unexpected exception:', exception.stack);
+    logger.error('unexpected exception:', exception);
 
     response.status(status).json({
       statusCode: status,

--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -3215,7 +3215,7 @@
     "serious": "serious",
     "service deployment": "service deployment",
     "service instance name is repeated": "service instance name is repeated",
-    "set state": "set state",
+    "state setting": "state setting",
     "settings updated successfully": "settings updated successfully",
     "severity": "severity",
     "severity-fatal": "fatal",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -3215,7 +3215,7 @@
     "serious": "严重",
     "service deployment": "服务部署",
     "service instance name is repeated": "服务实例名称重复",
-    "set state": "设置状态",
+    "state setting": "状态设置",
     "settings updated successfully": "更新设置成功",
     "severity": "严重程度",
     "severity-fatal": "致命",

--- a/shell/app/modules/org/common/audit-render.tsx
+++ b/shell/app/modules/org/common/audit-render.tsx
@@ -27,7 +27,7 @@ export default (record: AUDIT.Item, extraTemplates = {}) => {
   const templates = { ...auditTemplates, ...extraTemplates };
   const { templateName, scopeType, appId, projectId, context, result } = record;
   // 后端把pipelineID改为了pipelineId，兼容下
-  const fullContext = { ...context, projectId, appId, env: 'test', pipelineID: context.pipelineId, scopeType } as Obj;
+  const fullContext = { ...context, projectId, appId, env: 'test', pipelineID: context?.pipelineId, scopeType } as Obj;
   // excel中使用如下格式，链接参数需要在context同级或子级存在，前端定一个map，用urlKey对应到url链接，链接参数单独放一列
   // [@动态文字](urlKey) 或 [静态文字](urlKey) 或 [@动态文字]，示例：
   // 执行[流水线](pipeline) -> 执行[流水线](./project/{projectId}/app/{appId}/pipeline/{pipelineID})

--- a/shell/app/modules/org/pages/projects/issue-field-setting-modal.scss
+++ b/shell/app/modules/org/pages/projects/issue-field-setting-modal.scss
@@ -15,16 +15,6 @@
     background-color: $color-bg;
   }
 
-  .disabled {
-    color: $color-dark-3 !important;
-    cursor: not-allowed !important;
-
-    &:hover {
-      color: $color-dark-3 !important;
-      text-decoration: unset !important;
-    }
-  }
-
   .field-label {
     min-width: 100px;
     margin-right: $p8;

--- a/shell/app/modules/org/pages/projects/issue-field-setting-modal.tsx
+++ b/shell/app/modules/org/pages/projects/issue-field-setting-modal.tsx
@@ -70,18 +70,20 @@ export const IssueFieldSettingModal = ({ visible, issueType = 'EPIC', closeModal
 
   const changePos = React.useCallback(
     async (index: number, direction: number) => {
-      const tempList = produce(fieldList, (draft) => {
-        if (direction < 0) {
-          draft[index - 1].index = index;
-          draft[index].index = index - 1;
-        } else {
-          draft[index].index = index + 1;
-          draft[index + 1].index = index;
-        }
-      });
+      if (fieldList.length > 1) {
+        const tempList = produce(fieldList, (draft) => {
+          if (direction < 0 && index > 0) {
+            draft[index - 1].index = index;
+            draft[index].index = index - 1;
+          } else {
+            draft[index].index = index + 1;
+            draft[index + 1].index = index;
+          }
+        });
 
-      await batchUpdateFieldsOrder(tempList);
-      getFieldsByIssue({ propertyIssueType: issueType, orgID });
+        await batchUpdateFieldsOrder(tempList);
+        getFieldsByIssue({ propertyIssueType: issueType, orgID });
+      }
     },
     [batchUpdateFieldsOrder, fieldList, getFieldsByIssue, issueType, orgID],
   );
@@ -114,6 +116,8 @@ export const IssueFieldSettingModal = ({ visible, issueType = 'EPIC', closeModal
   const renderCustomFields = React.useCallback(
     () =>
       map(fieldList, ({ propertyName, propertyID, propertyType, displayName }, index) => {
+        const isFirst = index === 0;
+        const isLast = index === fieldList.length - 1;
         return (
           <div className="panel" key={propertyName}>
             <div className="common-list-item">
@@ -132,16 +136,14 @@ export const IssueFieldSettingModal = ({ visible, issueType = 'EPIC', closeModal
                       <span className="table-operations-btn">{i18n.t('common:remove')}</span>
                     </Popconfirm>
                     <span
-                      className={index === 0 ? 'disabled table-operations-btn' : 'table-operations-btn'}
-                      onClick={() => changePos(index, -1)}
+                      className={`table-operations-btn ${isFirst ? 'disabled' : ''}`}
+                      onClick={() => !isFirst && changePos(index, -1)}
                     >
                       {i18n.t('move up')}
                     </span>
                     <span
-                      className={
-                        index === fieldList.length - 1 ? 'disabled table-operations-btn' : 'table-operations-btn'
-                      }
-                      onClick={() => changePos(index, 1)}
+                      className={`table-operations-btn ${isLast ? 'disabled' : ''}`}
+                      onClick={() => !isLast && changePos(index, 1)}
                     >
                       {i18n.t('move down')}
                     </span>
@@ -198,11 +200,7 @@ export const IssueFieldSettingModal = ({ visible, issueType = 'EPIC', closeModal
                 })}
               </Select>
               <div>
-                <Button
-                  type="primary"
-                  className={`${isEmpty(selectedField) ? 'disabled' : ''} mr-2`}
-                  onClick={onAddField}
-                >
+                <Button type="primary" disabled={isEmpty(selectedField)} className="mr-2" onClick={onAddField}>
                   {i18n.t('project:reference')}
                 </Button>
               </div>

--- a/shell/app/modules/project/common/components/issue-workflow-setting-modal.scss
+++ b/shell/app/modules/project/common/components/issue-workflow-setting-modal.scss
@@ -2,10 +2,6 @@
   width: 100%;
   overflow: auto;
 
-  .w-120 {
-    width: 120px;
-  }
-
   .form-content {
     &-left {
       flex-basis: 120px;
@@ -21,47 +17,51 @@
 
   .state-option-btn {
     position: relative;
-    width: 92px;
-    margin: 0 $p4;
+    width: 110px;
+    padding: 0 4px;
     color: $primary;
-    line-height: 48px;
+    height: 42px;
+    line-height: 42px;
     text-align: center;
     background-color: $color-active-bg;
     border-radius: $radius;
 
     .state-delete-btn {
       position: absolute;
-      top: 0;
-      right: 0;
+      top: -6px;
+      right: -6px;
+      margin: 0;
       padding: $p4;
       color: $primary;
-      font-size: $p8;
       text-decoration: none;
       opacity: 0;
       transition: opacity 0.15s;
-
       &:hover {
-        opacity: 1;
+        font-weight: bold;
       }
     }
 
     .state-move-btn {
-      padding: $p4;
       color: $primary;
       opacity: 0;
+      margin: 0;
       transition: opacity 0.15s;
-
       &:hover {
+        font-weight: bold;
+      }
+    }
+
+    &:hover {
+      .state-delete-btn,
+      .state-move-btn {
         opacity: 1;
       }
     }
   }
 
   .add-option-btn {
-    @extend .w-120;
-    height: 48px;
-    line-height: 48px;
-
+    height: 42px;
+    line-height: 42px;
     .ant-btn {
       width: 100%;
       height: 100%;

--- a/shell/app/modules/project/common/components/issue-workflow-setting-modal.tsx
+++ b/shell/app/modules/project/common/components/issue-workflow-setting-modal.tsx
@@ -133,7 +133,7 @@ const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps)
     <Modal
       title={i18n.t('edit {name}', { name: `${fName}${i18n.t('project:workflow')}` })}
       visible={visible}
-      width="800px"
+      width="1010px"
       onCancel={onCancel}
       destroyOnClose
       maskClosable={false}
@@ -220,7 +220,7 @@ const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps)
               </div>
             </div>
             <Divider className="my-2" orientation="left">
-              {i18n.t('project:set state')}
+              {i18n.t('project:state setting')}
             </Divider>
             <div className="flex justify-between items-center">
               <div className="form-content-left">

--- a/shell/app/modules/project/common/components/issue-workflow-setting-modal.tsx
+++ b/shell/app/modules/project/common/components/issue-workflow-setting-modal.tsx
@@ -33,11 +33,11 @@ interface IProps {
 }
 
 const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps) => {
-  const totalWorkflowStateList = issueWorkflowStore.useStore((s) => s.totalWorkflowStateList);
+  const workflowStateList = issueWorkflowStore.useStore((s) => s.workflowStateList);
   const { deleteIssueState, getStatesByIssue, batchUpdateIssueState } = issueWorkflowStore;
   const { projectId: projectID } = routeInfoStore.useStore((s) => s.params);
   const [{ dataList, formVisible, isChanged }, updater, update] = useUpdate({
-    dataList: totalWorkflowStateList,
+    dataList: workflowStateList,
     formVisible: false,
     isChanged: false,
   });
@@ -49,11 +49,11 @@ const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps)
   }, [getStatesByIssue, projectID]);
 
   React.useEffect(() => {
-    const workflowStateList = totalWorkflowStateList.filter((item) => item.issueType === issueType);
-    const tempList = map(workflowStateList, (item) => {
+    const partWorkflowStateList = workflowStateList.filter((item) => item.issueType === issueType);
+    const tempList = map(partWorkflowStateList, (item) => {
       return {
         ...item,
-        relations: map(workflowStateList, ({ stateID, stateName }) => {
+        relations: map(partWorkflowStateList, ({ stateID, stateName }) => {
           return {
             stateID,
             isRelated: item?.stateRelation?.includes(stateID),
@@ -63,7 +63,7 @@ const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps)
       };
     });
     update({ dataList: tempList });
-  }, [issueType, update, totalWorkflowStateList]);
+  }, [issueType, update, workflowStateList]);
 
   const onCancel = React.useCallback(() => {
     update({ dataList: [], isChanged: false, formVisible: false });

--- a/shell/app/modules/project/common/components/issue-workflow-setting-modal.tsx
+++ b/shell/app/modules/project/common/components/issue-workflow-setting-modal.tsx
@@ -33,11 +33,11 @@ interface IProps {
 }
 
 const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps) => {
-  const workflowStateList = issueWorkflowStore.useStore((s) => s.workflowStateList);
+  const totalWorkflowStateList = issueWorkflowStore.useStore((s) => s.totalWorkflowStateList);
   const { deleteIssueState, getStatesByIssue, batchUpdateIssueState } = issueWorkflowStore;
   const { projectId: projectID } = routeInfoStore.useStore((s) => s.params);
   const [{ dataList, formVisible, isChanged }, updater, update] = useUpdate({
-    dataList: workflowStateList,
+    dataList: totalWorkflowStateList,
     formVisible: false,
     isChanged: false,
   });
@@ -45,10 +45,11 @@ const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps)
   const hasAuth = usePerm((s) => s.project.setting.customWorkflow.operation.pass);
 
   const getDataList = React.useCallback(() => {
-    getStatesByIssue({ projectID: +projectID, issueType });
-  }, [getStatesByIssue, issueType, projectID]);
+    getStatesByIssue({ projectID: +projectID });
+  }, [getStatesByIssue, projectID]);
 
   React.useEffect(() => {
+    const workflowStateList = totalWorkflowStateList.filter((item) => item.issueType === issueType);
     const tempList = map(workflowStateList, (item) => {
       return {
         ...item,
@@ -61,8 +62,8 @@ const IssueWorkflowSettingModal = ({ visible, onCloseModal, issueType }: IProps)
         }),
       };
     });
-    update({ dataList: tempList, issueType });
-  }, [issueType, update, workflowStateList]);
+    update({ dataList: tempList });
+  }, [issueType, update, totalWorkflowStateList]);
 
   const onCancel = React.useCallback(() => {
     update({ dataList: [], isChanged: false, formVisible: false });

--- a/shell/app/modules/project/common/components/issue-workflow.tsx
+++ b/shell/app/modules/project/common/components/issue-workflow.tsx
@@ -50,7 +50,7 @@ const IssueWorkflow = () => {
 
   const onEditHandle = React.useCallback(
     (type: ISSUE_TYPE) => {
-      getStatesByIssue({ projectID: +projectID, issueType: type }).then(() => {
+      getStatesByIssue({ projectID: +projectID }).then(() => {
         updater.modalVisible(true);
         updater.issueType(type);
       });

--- a/shell/app/modules/project/common/components/issue-workflow.tsx
+++ b/shell/app/modules/project/common/components/issue-workflow.tsx
@@ -27,10 +27,7 @@ import './issue-workflow.scss';
 const IssueWorkflow = () => {
   const { projectId: projectID } = routeInfoStore.getState((s) => s.params);
 
-  const [issueList, totalWorkflowStateList] = issueWorkflowStore.useStore((s) => [
-    s.issueList,
-    s.totalWorkflowStateList,
-  ]);
+  const [issueList, workflowStateList] = issueWorkflowStore.useStore((s) => [s.issueList, s.workflowStateList]);
   const { getStatesByIssue, getIssueList, clearIssueList } = issueWorkflowStore;
 
   useEffectOnce(() => {
@@ -92,7 +89,7 @@ const IssueWorkflow = () => {
                   <div className="default-workflow-title">{i18n.t('project:default workflow')}：</div>
                   <div className="default-workflow-content">
                     {map(item.state, (name: string) => {
-                      const curStateBelong = get(find(totalWorkflowStateList, { stateName: name }), 'stateBelong');
+                      const curStateBelong = get(find(workflowStateList, { stateName: name }), 'stateBelong');
                       return (
                         <div className="flex items-center mr-3 mb-2">
                           {ISSUE_STATE_MAP[curStateBelong]?.icon}

--- a/shell/app/modules/project/pages/backlog/backlog.tsx
+++ b/shell/app/modules/project/pages/backlog/backlog.tsx
@@ -46,11 +46,11 @@ const Backlog = () => {
     s.params,
     s.query,
   ]);
-  const totalWorkflowStateList = issueWorkflowStore.useStore((s) => s.totalWorkflowStateList);
+  const workflowStateList = issueWorkflowStore.useStore((s) => s.workflowStateList);
 
   const stateCollection: Array<{ label: string | React.ReactNode; children: Array<{ label: string; value: string }> }> =
     React.useMemo(() => {
-      const collection = totalWorkflowStateList.reduce((acc, current) => {
+      const collection = workflowStateList.reduce((acc, current) => {
         const { issueType, stateName, stateID } = current;
         if (!['BUG', 'REQUIREMENT', 'TASK'].includes(issueType)) {
           return acc;
@@ -75,7 +75,7 @@ const Backlog = () => {
         };
       });
       return options;
-    }, [totalWorkflowStateList]);
+    }, [workflowStateList]);
 
   const [{ isAdding, curIssueDetail, drawerVisible, filterState }, updater, update] = useUpdate({
     isAdding: false,

--- a/shell/app/modules/project/pages/issue/component/table-view.tsx
+++ b/shell/app/modules/project/pages/issue/component/table-view.tsx
@@ -126,7 +126,7 @@ export const FieldSelector = (props: IFieldProps) => {
 };
 
 const TableView = React.forwardRef((props: IProps, ref: any) => {
-  const totalWorkflowStateList = issueWorkflowStore.useStore((s) => s.totalWorkflowStateList);
+  const workflowStateList = issueWorkflowStore.useStore((s) => s.workflowStateList);
   const { filterObj: propsFilter, issueType, viewType, onChosenIssue } = props;
   const [params] = routeInfoStore.useStore((s) => [s.params]);
   const { getAllIssues, updateIssue } = issueStore.effects;
@@ -357,7 +357,7 @@ const TableView = React.forwardRef((props: IProps, ref: any) => {
       dataIndex: 'planFinishedAt',
       key: 'planFinishedAt',
       render: (val: string, record: ISSUE.Issue) => {
-        const curStateBelong = get(find(totalWorkflowStateList, { stateID: record.state }), 'stateBelong');
+        const curStateBelong = get(find(workflowStateList, { stateID: record.state }), 'stateBelong');
         // 当前未完成且时间临近或逾期，则提示
         const timeTip = endTimeTip(val, !unFinishState.includes(curStateBelong));
         return val ? timeTip : '-';

--- a/shell/app/modules/project/pages/ticket/index.tsx
+++ b/shell/app/modules/project/pages/ticket/index.tsx
@@ -40,11 +40,11 @@ const { Option } = Select;
 const Ticket = () => {
   const [{ projectId }, { id: queryId }] = routeInfoStore.getState((s) => [s.params, s.query]);
   const [loading] = useLoading(issueStore, ['getIssues']);
-  const totalWorkflowStateList = issueWorkflowStore.useStore((s) => s.totalWorkflowStateList);
+  const workflowStateList = issueWorkflowStore.useStore((s) => s.workflowStateList);
   const ticketStateList = React.useMemo(() => {
     const temp: any[] = [];
 
-    map(totalWorkflowStateList, ({ issueType, stateName, stateID, stateBelong }) => {
+    map(workflowStateList, ({ issueType, stateName, stateID, stateBelong }) => {
       if (issueType === ISSUE_TYPE.TICKET) {
         temp.push({
           stateName,
@@ -54,7 +54,7 @@ const Ticket = () => {
       }
     });
     return temp;
-  }, [totalWorkflowStateList]);
+  }, [workflowStateList]);
 
   const [list, paging] = issueStore.useStore((s) => [s.ticketList, s.ticketPaging]);
   const { getIssues, updateIssue } = issueStore.effects;

--- a/shell/app/modules/project/stores/issue-workflow.ts
+++ b/shell/app/modules/project/stores/issue-workflow.ts
@@ -24,13 +24,11 @@ import {
 
 interface IState {
   issueList: ISSUE_WORKFLOW.IIssueItem[];
-  workflowStateList: ISSUE_WORKFLOW.IIssueStateItem[];
   totalWorkflowStateList: ISSUE_WORKFLOW.IIssueStateItem[];
 }
 
 const initState: IState = {
   issueList: [],
-  workflowStateList: [],
   totalWorkflowStateList: [],
 };
 
@@ -44,12 +42,7 @@ const issueWorkflowStore = createFlatStore({
     },
     async getStatesByIssue({ call, update }, payload: ISSUE_WORKFLOW.IStateQuery) {
       const workflowStateList = await call(getStatesByIssue, payload);
-      if (!payload.issueType) {
-        update({ totalWorkflowStateList: workflowStateList });
-      } else {
-        update({ workflowStateList });
-      }
-
+      update({ totalWorkflowStateList: workflowStateList });
       return workflowStateList;
     },
     async batchUpdateIssueState({ call }, payload: ISSUE_WORKFLOW.IUpdateQuery) {

--- a/shell/app/modules/project/stores/issue-workflow.ts
+++ b/shell/app/modules/project/stores/issue-workflow.ts
@@ -24,12 +24,12 @@ import {
 
 interface IState {
   issueList: ISSUE_WORKFLOW.IIssueItem[];
-  totalWorkflowStateList: ISSUE_WORKFLOW.IIssueStateItem[];
+  workflowStateList: ISSUE_WORKFLOW.IIssueStateItem[];
 }
 
 const initState: IState = {
   issueList: [],
-  totalWorkflowStateList: [],
+  workflowStateList: [],
 };
 
 const issueWorkflowStore = createFlatStore({
@@ -42,7 +42,7 @@ const issueWorkflowStore = createFlatStore({
     },
     async getStatesByIssue({ call, update }, payload: ISSUE_WORKFLOW.IStateQuery) {
       const workflowStateList = await call(getStatesByIssue, payload);
-      update({ totalWorkflowStateList: workflowStateList });
+      update({ workflowStateList });
       return workflowStateList;
     },
     async batchUpdateIssueState({ call }, payload: ISSUE_WORKFLOW.IUpdateQuery) {

--- a/shell/app/modules/project/stores/project.tsx
+++ b/shell/app/modules/project/stores/project.tsx
@@ -86,7 +86,7 @@ const project = createStore({
       if (isIn('project')) {
         if (`${curProjectId}` !== projectId) {
           loadingInProject = true;
-          issueWorkflowStore.getStatesByIssue({ issueType: '', projectID: +projectId });
+          issueWorkflowStore.getStatesByIssue({ projectID: +projectId });
           // 项目切换后才重新checkRouteAuth
           project.reducers.updateCurProjectId(projectId);
           breadcrumbStore.reducers.setInfo('projectName', '');


### PR DESCRIPTION
## What this PR does / why we need it:
* fix issue workflow state not update after edit, caused by split state.
* fix workflow modal style, show move and delete at the same time when hover on button, expand the modal width.
* edit issue field logic and style.
* show scheduler full exception in case of empty stack.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/133190108-42a49890-87ce-4b66-bab6-1f1426822311.png)
->
![image](https://user-images.githubusercontent.com/3955437/133190026-f4d9a840-36ac-4deb-9a21-5a99e2d4fd55.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix issue workflow not show icon after edit, update style |
| 🇨🇳 中文    | 修复工作流编辑后不展示图标的问题，更新了样式  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

