### PR TITLE
fix: tree width too wide bug

### DIFF
--- a/shell/app/common/__tests__/components/tree/tree.test.tsx
+++ b/shell/app/common/__tests__/components/tree/tree.test.tsx
@@ -71,7 +71,7 @@ describe('TreeCategory', () => {
     act(() => {
       select.prop('onChange')('menu1');
     });
-    expect(wrapper.find('.file-tree-container').prop('expandedKeys')).toStrictEqual(['menu1', 'menu1-1']);
+    expect(wrapper.find('.tree-category-container').prop('expandedKeys')).toStrictEqual(['menu1', 'menu1-1']);
     act(() => {
       select.prop('onChange')();
     });
@@ -105,20 +105,20 @@ describe('TreeCategory', () => {
     wrapper.update();
     expect(getAncestors).toHaveBeenCalledTimes(1);
     expect(getAncestors).toHaveBeenLastCalledWith({ inode: 'root' });
-    expect(wrapper.find('ForwardRef.file-tree-container').prop('expandedKeys')).toStrictEqual(['menu1', 'menu1-1']);
+    expect(wrapper.find('ForwardRef.tree-category-container').prop('expandedKeys')).toStrictEqual(['menu1', 'menu1-1']);
     act(() => {
-      wrapper.find('ForwardRef.file-tree-container').prop('onExpand')(['leaf-root']);
+      wrapper.find('ForwardRef.tree-category-container').prop('onExpand')(['leaf-root']);
     });
     wrapper.update();
-    expect(wrapper.find('ForwardRef.file-tree-container').prop('expandedKeys')).toStrictEqual(['leaf-root']);
+    expect(wrapper.find('ForwardRef.tree-category-container').prop('expandedKeys')).toStrictEqual(['leaf-root']);
     act(() => {
-      wrapper.find('ForwardRef.file-tree-container').prop('onSelect')(['leaf-root'], {
+      wrapper.find('ForwardRef.tree-category-container').prop('onSelect')(['leaf-root'], {
         node: { props: { isLeaf: false } },
       });
     });
     expect(selectNodeFn).toHaveBeenLastCalledWith({ inode: 'leaf-root', isLeaf: false });
     await act(async () => {
-      await wrapper.find('ForwardRef.file-tree-container').prop('onDrop')({
+      await wrapper.find('ForwardRef.tree-category-container').prop('onDrop')({
         dragNode: simpleTreeData[0],
         node: simpleTreeData[1],
       });
@@ -152,6 +152,8 @@ describe('TreeCategory', () => {
     wrapper.update();
     expect(loadData).toHaveBeenCalledTimes(1);
     expect(loadData).toHaveBeenLastCalledWith({ pinode: initTreeData[0].key });
-    expect(wrapper.find('ForwardRef.file-tree-container').prop('expandedKeys')).toStrictEqual([initTreeData[0].key]);
+    expect(wrapper.find('ForwardRef.tree-category-container').prop('expandedKeys')).toStrictEqual([
+      initTreeData[0].key,
+    ]);
   });
 });

--- a/shell/app/common/components/tree/tree.scss
+++ b/shell/app/common/components/tree/tree.scss
@@ -32,6 +32,10 @@
       width: 0;
     }
 
+    .ant-tree-title {
+      width: calc(100% - 48px);
+    }
+
     .ant-tree-iconEle {
       display: inline-flex;
       margin: 0 8px 0 0;

--- a/shell/app/common/components/tree/tree.scss
+++ b/shell/app/common/components/tree/tree.scss
@@ -32,8 +32,8 @@
       width: 0;
     }
 
-    .ant-tree-title {
-      width: calc(100% - 48px);
+    .has-operates {
+      width: calc(100% - 24px);
     }
 
     .ant-tree-iconEle {

--- a/shell/app/common/components/tree/tree.tsx
+++ b/shell/app/common/components/tree/tree.tsx
@@ -795,21 +795,26 @@ export const TreeCategory = ({
           showIcon
           onExpand={onExpand}
           onSelect={onClickNode}
-          titleRender={(nodeData: TreeNodeNormal) => (
-            <span className="w-full inline-block truncate">
-              {nodeData.title}
-              <Popover
-                content={getActions(nodeData).map((item) => (
-                  <div className="action-btn" onClick={() => item.func?.(nodeData.key, nodeData)}>
-                    {item.node}
-                  </div>
-                ))}
-                footer={false}
-              >
-                <CustomIcon type="gd" className="tree-node-action" />
-              </Popover>
-            </span>
-          )}
+          titleRender={(nodeData: TreeNodeNormal) => {
+            const execNode = nodeData as TreeNode;
+            return (
+              <span className={`inline-block truncate ${execNode.disableAction ? 'w-full' : 'has-operates'}`}>
+                {nodeData.title}
+                {!execNode.disableAction && (
+                  <Popover
+                    content={getActions(nodeData).map((item) => (
+                      <div className="action-btn" onClick={() => item.func?.(nodeData.key, nodeData)}>
+                        {item.node}
+                      </div>
+                    ))}
+                    footer={false}
+                  >
+                    <CustomIcon type="gd" className="tree-node-action" />
+                  </Popover>
+                )}
+              </span>
+            );
+          }}
           draggable={!!moveNode && !cuttingNodeKey && !copyingNodeKey} // 当有剪切复制正在进行中时，不能拖动
           onDrop={onDrop}
           {...treeProps}


### PR DESCRIPTION
## What this PR does / why we need it:
Fixed tree width too wide bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)

![image](https://user-images.githubusercontent.com/82502479/133252932-4e66b2e3-aea9-46a7-9a96-20929576794f.png)
->
![image](https://user-images.githubusercontent.com/82502479/133252892-f1ddbfa5-2f5e-4849-a550-2096cc2cdd88.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed the bug of overlapping operations when the tree structure text with operations is too long. |
| 🇨🇳 中文    |  解决了带操作的树形结构文字过长时跟操作重叠的问题。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

