### PR TITLE
fix: cluster list operate more btn wrong limitNum bug

### DIFF
--- a/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
@@ -349,7 +349,7 @@ const ClusterList = ({ dataSource, onEdit }: IProps) => {
   const actions: IActions<ORG_CLUSTER.ICluster> = {
     width: 120,
     render: (record: ORG_CLUSTER.ICluster) => renderMenu(record),
-    limitNum: 3,
+    limitNum: 1,
   };
 
   const [renderOp, drawer] = useInstanceOperation<ORG_CLUSTER.ICluster>({


### PR DESCRIPTION
## What this PR does / why we need it:
Fixed cluster list operate more btn wrong limitNum bug.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/133258400-aa7436b1-5247-4ee6-ac77-4983cad3222c.png)
->
![image](https://user-images.githubusercontent.com/82502479/133258703-538a1a6b-c44c-402b-b792-777c83ca8ae0.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The number of buttons in the action column of the cluster management table has changed from three to one.  |
| 🇨🇳 中文    | 集群管理表格操作列显示按钮数量从三个变成一个。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

