### PR TITLE
hotfix(dop): Error analysis and statistics big market interface display problem

### DIFF
--- a/shell/app/modules/publisher/pages/artifacts/artifacts-detail.tsx
+++ b/shell/app/modules/publisher/pages/artifacts/artifacts-detail.tsx
@@ -80,7 +80,7 @@ const ArtifactsDetail = ({ data, artifactsId }: IProps) => {
         </div>
       </div>
       <div
-        className={`artifacts-content ${['statistics', 'errorReport'].includes(chosenTab) ? 'bg-gray' : ''}`}
+        className={`artifacts-content ${['statistics', 'errorReport'].includes(chosenTab) ? 'bg-layout' : ''}`}
         id="artifacts-content"
       >
         {TabCompMap[chosenTab] || null}


### PR DESCRIPTION

## What this PR does / why we need it:

Error analysis and statistics big market interface display problem
## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)

<img width="1271" alt="截屏2021-09-16上午10 45 13的副本" src="https://user-images.githubusercontent.com/48612739/133541377-8b933b2f-7ee6-4b22-8a32-2422c6e131f4.png">
<img width="1270" alt="截屏2021-09-16上午10 45 29" src="https://user-images.githubusercontent.com/48612739/133541402-2a5c7dde-e93f-47a5-bebc-8da117971953.png">


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3



## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

