### PR TITLE
fix: invite url wrong in other environments

### DIFF
--- a/shell/app/common/components/log/log-roller.tsx
+++ b/shell/app/common/components/log/log-roller.tsx
@@ -131,7 +131,7 @@ export class LogRoller extends React.Component<IProps, IState> {
         {logContent}
         <div className={`log-control log-top-controls ${extraButton ? '' : 'no-switch'}`}>
           {extraButton || null}
-          <Tooltip title={hasLogs ? i18n.t('common:download log') : i18n.t('common:log download is not supported yet')}>
+          <Tooltip title={hasLogs ? i18n.t('common:download log') : i18n.t('common:No log at present')}>
             <Button disabled={!hasLogs} onClick={onShowDownloadModal} type="ghost">
               {i18n.t('common:download log')}
             </Button>

--- a/shell/app/common/components/members-table.tsx
+++ b/shell/app/common/components/members-table.tsx
@@ -629,7 +629,9 @@ export const MembersTable = ({
             />
             <UrlInviteModal
               visible={state.inviteModalVisible}
-              url={`${FULL_ROOT_DOMAIN}${goTo.resolve.inviteToOrg()}`}
+              url={`${
+                window.location.origin.endsWith('erda.cloud') ? FULL_ROOT_DOMAIN : window.location.origin
+              }${goTo.resolve.inviteToOrg()}`}
               linkPrefixTip={`${i18n.t('org:visit the link to join the organization')} [${orgDisplayName || orgName}]`}
               code={state.verifyCode}
               tip={i18n.t(

--- a/shell/app/common/constants.ts
+++ b/shell/app/common/constants.ts
@@ -13,7 +13,7 @@
 
 export const WORKSPACE_LIST = ['DEV', 'TEST', 'STAGING', 'PROD'];
 export const ROOT_DOMAIN = 'erda.cloud';
-export const FULL_ROOT_DOMAIN = `https://${ROOT_DOMAIN}`;
+export const FULL_ROOT_DOMAIN = 'https://erda.cloud';
 
 // doc domain
 export const DOC_DOMAIN = 'docs.erda.cloud';
@@ -41,7 +41,6 @@ export const DOC_MSP_MONITOR = `${DOC_PREFIX}/manual/microservice/use-apm-monito
 export const { erdaEnv } = window;
 // uc page
 export const UC_USER_SETTINGS = '/uc/settings';
-
 
 // cmp guide doc
 export const DOC_CMP_CLUSTER_MANAGE = `${DOC_PREFIX}/manual/cmp/guide/cluster/management.html`;

--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -3012,6 +3012,7 @@
     "iteration goal": "iteration goal",
     "iteration name": "iteration name",
     "joint issue type": "joint issue type",
+    "key-secret-encrypt-tip": "If the Key contains the password secret keyword, it will be encrypted to *",
     "label": "label",
     "label color": "label color",
     "label created successfully": "label created successfully",

--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -798,7 +798,7 @@
     "lack of english colon": "lack of english colon",
     "line": "line",
     "log download": "log download",
-    "log download is not supported yet": "log download is not supported yet",
+    "No log at present": "No log at present",
     "middleware": "middleware",
     "minutes": "minutes",
     "missing": "missing",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -3012,6 +3012,7 @@
     "iteration goal": "迭代目标",
     "iteration name": "迭代名称",
     "joint issue type": "协同事项类型",
+    "key-secret-encrypt-tip": "如果 Key 中包含 password、secret 关键字，则会被加密为*",
     "label": "标签",
     "label color": "标签颜色",
     "label created successfully": "创建标签成功",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -798,7 +798,7 @@
     "lack of english colon": "缺少英文冒号",
     "line": "行",
     "log download": "日志下载",
-    "log download is not supported yet": "暂不支持日志下载",
+    "No log at present": "暂无日志",
     "middleware": "中间件",
     "minutes": "分钟",
     "missing": "缺少",

--- a/shell/app/modules/project/pages/third-service/components/instance-form.tsx
+++ b/shell/app/modules/project/pages/third-service/components/instance-form.tsx
@@ -154,6 +154,7 @@ const InstanceForm = ({ form, editData, addonProto, workspace, edit, category }:
               {i18n.t('project:Modifying service parameters will restart all associated applications.')}
             </div>
             <div className="text-red">{i18n.t('project:op-affect-related-app')}</div>
+            <div className="text-red">{i18n.t('project:key-secret-encrypt-tip')}</div>
           </>
         ),
       },


### PR DESCRIPTION
## What this PR does / why we need it:
* Previous change it to constant value, to prevent confusion invitation link such as:
`orgA-org.erda.cloud/inviteToOrg/orgB`. But the invite url domain is wrong in other environments.
* fix i18n problem

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

