### PR TITLE
fix: only show download log button when have log

### DIFF
--- a/shell/app/common/components/log/log-roller.tsx
+++ b/shell/app/common/components/log/log-roller.tsx
@@ -131,11 +131,13 @@ export class LogRoller extends React.Component<IProps, IState> {
         {logContent}
         <div className={`log-control log-top-controls ${extraButton ? '' : 'no-switch'}`}>
           {extraButton || null}
-          <Tooltip title={hasLogs ? i18n.t('common:download log') : i18n.t('common:No log at present')}>
-            <Button disabled={!hasLogs} onClick={onShowDownloadModal} type="ghost">
-              {i18n.t('common:download log')}
-            </Button>
-          </Tooltip>
+          {hasLogs && (
+            <Tooltip title={i18n.t('common:download log')}>
+              <Button onClick={onShowDownloadModal} type="ghost">
+                {i18n.t('common:download log')}
+              </Button>
+            </Tooltip>
+          )}
           <Button onClick={this.changeSize} type="ghost">
             {fullScreen ? i18n.t('default:exit full screen') : i18n.t('default:full screen')}
           </Button>

--- a/shell/app/common/containers/log-roller.tsx
+++ b/shell/app/common/containers/log-roller.tsx
@@ -222,6 +222,7 @@ export class LogRoller extends React.Component<IProps, IState> {
     const { content, query, style = {}, hasLogs = true, ...otherProps } = this.props;
     const { rolling, backwardLoading, downloadLogModalVisible } = this.state;
     const lastItem = last(content);
+    const realHaveLog = hasLogs && !!lastItem;
 
     return (
       <div className="log-viewer" style={style}>
@@ -237,15 +238,17 @@ export class LogRoller extends React.Component<IProps, IState> {
           rolling={rolling}
           backwardLoading={backwardLoading}
           onShowDownloadModal={this.toggleDownloadModal}
-          hasLogs={hasLogs && !!lastItem}
+          hasLogs={realHaveLog}
           {...otherProps}
         />
-        <DownloadLogModal
-          visible={downloadLogModalVisible}
-          start={lastItem ? lastItem.timestamp : 0}
-          query={query}
-          onCancel={this.toggleDownloadModal}
-        />
+        {realHaveLog && (
+          <DownloadLogModal
+            visible={downloadLogModalVisible}
+            start={lastItem ? lastItem.timestamp : 0}
+            query={query}
+            onCancel={this.toggleDownloadModal}
+          />
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## What this PR does / why we need it:
Remove log download button when not support download or no log.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | only show download log button when have log or support download  |
| 🇨🇳 中文    | 查看日志时只有存在日志或支持下载时才显示下载按钮 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

