### PR TITLE
feat(msp): The access configuration page removes the request parameter subjectType and retains the subject

### DIFF
--- a/shell/app/modules/msp/env-setting/configuration/index.tsx
+++ b/shell/app/modules/msp/env-setting/configuration/index.tsx
@@ -68,7 +68,7 @@ const ItemRender = ({ title, children }: IProps) => {
 };
 
 const Configuration = () => {
-  const { projectId, tenantGroup } = routeInfoStore.useStore((s) => s.params);
+  const { tenantGroup } = routeInfoStore.useStore((s) => s.params);
   const accessPerm = usePerm((s) => s.project.microService.accessConfiguration);
   const [{ lang, currentPage, strategy, languages, mode, visible }, updater, update] = useUpdate<IState>({
     lang: '',
@@ -93,7 +93,7 @@ const Configuration = () => {
   React.useEffect(() => {
     getAcquisitionAndLang.fetch();
     getAllToken.fetch({
-      subject: projectId,
+      subjectType: 3,
       pageNo: 1,
       pageSize: PAGINATION.pageSize,
       scopeId: tenantGroup,
@@ -165,12 +165,12 @@ const Configuration = () => {
 
   const createKey = async () => {
     await createToken.fetch({
-      subject: projectId,
       scopeId: tenantGroup,
+      subjectType: 3,
     });
 
     await getAllToken.fetch({
-      subject: projectId,
+      subjectType: 3,
       pageNo: 1,
       pageSize: PAGINATION.pageSize,
       scopeId: tenantGroup,
@@ -188,7 +188,7 @@ const Configuration = () => {
       id,
     });
     await getAllToken.fetch({
-      subject: projectId,
+      subjectType: 3,
       pageNo: 1,
       pageSize: PAGINATION.pageSize,
       scopeId: tenantGroup,
@@ -214,7 +214,7 @@ const Configuration = () => {
       currentPage: page,
     });
     getAllToken.fetch({
-      subject: projectId,
+      subjectType: 3,
       pageNo: page,
       pageSize: PAGINATION.pageSize,
       scopeId: tenantGroup,

--- a/shell/app/modules/msp/types/configuration.d.ts
+++ b/shell/app/modules/msp/types/configuration.d.ts
@@ -32,7 +32,7 @@ declare namespace CONFIGURATION {
   }
 
   interface IAllToken {
-    subject: string;
+    subjectType: number;
     accessKey?: string;
     pageNo: number;
     pageSize: number;
@@ -42,7 +42,7 @@ declare namespace CONFIGURATION {
 
   interface ICreateKey {
     description?: string;
-    subject: string;
+    subjectType: number;
     scopeId: string;
   }
 
@@ -55,19 +55,18 @@ declare namespace CONFIGURATION {
   }
 
   interface IAllTokenData {
-    // accessKey: string;
     token: string;
     createdAt: string;
     description: string;
     id: string;
     status: string;
-    subject: string;
+    subjectType: number;
     scope: string;
     scopeId: string;
   }
 
   interface ITokenList {
-    list: IAllKeyData[];
+    list: IAllTokenData[];
     total: number;
   }
 }


### PR DESCRIPTION

## What this PR does / why we need it:
The access configuration page removes the request parameter subjectType and retains the subject

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

