### PR TITLE
fix(dop): add default value for custom fields when quick create issue

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -627,12 +627,12 @@ export const EditIssueDrawer = (props: IProps) => {
   const defaultCustomFormData = React.useMemo(() => {
     const customFieldDefaultValues = {};
     map(fieldList, (item) => {
-      if (item?.required) {
-        if (item?.propertyType === 'Select') {
-          customFieldDefaultValues[item?.propertyName] = item?.enumeratedValues[0]?.id;
+      if (item && item.required) {
+        if (item.propertyType === 'Select') {
+          customFieldDefaultValues[item.propertyName] = item.enumeratedValues?.[0].id;
         }
-        if (item?.propertyType === 'MultiSelect') {
-          customFieldDefaultValues[item?.propertyName] = [item?.enumeratedValues[0]?.id];
+        if (item.propertyType === 'MultiSelect') {
+          customFieldDefaultValues[item.propertyName] = [item.enumeratedValues?.[0].id];
         }
       }
     });
@@ -712,23 +712,23 @@ export const EditIssueDrawer = (props: IProps) => {
   }, [propsIssueType]);
 
   React.useEffect(() => {
-    if (id && visible) {
-      getIssueDetail({ type: issueType, id });
-      getIssueStreams({ type: issueType, id, pageNo: 1, pageSize: 50 });
-      getCustomFields();
-    } else {
-      visible &&
-        getCustomFieldsByProject({
-          propertyIssueType: issueType,
+    if (visible) {
+      if (id) {
+        getIssueDetail({ type: issueType, id });
+        getIssueStreams({ type: issueType, id, pageNo: 1, pageSize: 50 });
+        getCustomFields();
+      }
+      getCustomFieldsByProject({
+        propertyIssueType: issueType,
+        orgID,
+      }).then((res) => {
+        updateCustomFieldDetail({
+          property: res,
           orgID,
-        }).then((res) => {
-          updateCustomFieldDetail({
-            property: res,
-            orgID,
-            projectID: +addRelatedMattersProjectId,
-            issueID: undefined,
-          });
+          projectID: +addRelatedMattersProjectId,
+          issueID: undefined,
         });
+      });
     }
   }, [
     addRelatedMattersProjectId,

--- a/shell/app/modules/project/common/components/issue/issue-relation.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-relation.tsx
@@ -438,6 +438,7 @@ const AddNewIssue = ({ onSaveRelation, iterationID, onCancel, defaultIssueType }
           ...val,
         }).then((res: number) => {
           onSaveRelation(res); // 添加关联
+          return res;
         });
       }}
     />


### PR DESCRIPTION
## What this PR does / why we need it:
Create issue in normal mode, will fill default values in custom fields, but not in quick add mode.
This pr will fill enumerated custom fields default value when quick add issue.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | add default value for enumerated custom fields when quick create issue  |
| 🇨🇳 中文    |  快速创建事项时枚举类型的自定义字段填充默认值 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

