### PR TITLE
fix(dop): creator and assignee can change issue type

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -691,7 +691,7 @@ export const EditIssueDrawer = (props: IProps) => {
   const deleteAuth = isMonitorTicket ? true : getAuth(permObj.delete, checkRole);
   const createAuth = permObj.create.pass;
   const editAuth = isMonitorTicket ? true : !isEditMode || getAuth(permObj.edit, checkRole);
-  const switchTypeAuth = permObj.switchType?.pass;
+  const switchTypeAuth = getAuth(permObj.switchType, checkRole);
 
   const addRelatedMattersProjectId = routeInfoStore.getState((s) => s.params).projectId;
   const { addIssueRelation } = issueStore.effects;

--- a/shell/app/user/stores/_perm-project.ts
+++ b/shell/app/user/stores/_perm-project.ts
@@ -116,7 +116,7 @@ export const projectPerm = {
     },
     switchType: {
       pass: false,
-      role: ['Owner', 'Lead', 'PM', 'Creator', 'Assignee'],
+      role: ['Owner', 'Lead', 'PM', 'Creator'],
       name: i18n.t('user:switch type'),
     },
     import: {

--- a/shell/app/user/stores/_perm-project.ts
+++ b/shell/app/user/stores/_perm-project.ts
@@ -116,7 +116,7 @@ export const projectPerm = {
     },
     switchType: {
       pass: false,
-      role: ['Owner', 'Lead', 'PM'],
+      role: ['Owner', 'Lead', 'PM', 'Creator', 'Assignee'],
       name: i18n.t('user:switch type'),
     },
     import: {


### PR DESCRIPTION
## What this PR does / why we need it:
Creator and assignee can change issue type.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Projects collaborate with item creators and handlers to increase the ability to modify item types. |
| 🇨🇳 中文    | 项目协同事项创建者和处理人增加修改项目类型的权限。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=223554&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMTIxNCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG

