### PR TITLE
feat(msp): Change the right margin of text

### DIFF
--- a/shell/app/modules/msp/env-setting/configuration/type-select.tsx
+++ b/shell/app/modules/msp/env-setting/configuration/type-select.tsx
@@ -78,7 +78,7 @@ const TypeSelect = <T extends Item>({ list, onChange, value, className }: IProps
             }}
           >
             <ErdaCustomIcon size="60px" type={iconMap[key] ?? defaultIcon} {...iconProps} />
-            <div className={`ml-3 name font-medium group-hover:text-primary ${isSelect ? 'text-primary' : ''}`}>
+            <div className={`ml-0.5 mr-3 name font-medium group-hover:text-primary ${isSelect ? 'text-primary' : ''}`}>
               {displayName}
             </div>
           </div>


### PR DESCRIPTION
## What this PR does / why we need it:
Change the right margin of text

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)

<img width="1037" alt="截屏2021-09-24上午11 22 27" src="https://user-images.githubusercontent.com/48612739/134613701-e8883966-6282-43e2-a3b1-8513e5e997d4.png">


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Change the right margin of text        |
| 🇨🇳 中文    |       修改文字的右边距       |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

