### PR TITLE
fix: apply issue template when quick create

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -54,6 +54,7 @@ import { FIELD_WITH_OPTION, FIELD_TYPE_ICON_MAP } from 'org/common/config';
 import { produce } from 'immer';
 import issueFieldStore from 'org/stores/issue-field';
 import orgStore from 'app/org-home/stores/org';
+import { templateMap } from 'project/common/issue-config';
 
 import './edit-issue-drawer.scss';
 
@@ -61,63 +62,6 @@ export const ColorIcon = ({ icon }: { icon: string }) => {
   return (
     <CustomIcon type={icon} className="mr-2" color style={{ height: '20px', width: '20px', verticalAlign: 'sub' }} />
   );
-};
-
-const templateMap = {
-  [ISSUE_TYPE.REQUIREMENT]: `### 【用户故事/要解决的问题】*
-> 解决了什么问题，尝试用 As a (who), I want (what), so I can (why/value) 三段式来描述问题
-
-
-### 【意向用户】*
-> 影响了哪些人，需求来源是什么人？
-
-
-### 【用户体验目标】*
-> 可以从多方面描述，意向用户如何在需求/任务完成后解决了他的问题。比如“用户可以通过编辑 pipeline.yml 跑一条流水线”。
-
-
-### 【链接/参考】
-
-`,
-  [ISSUE_TYPE.TASK]: `### 【用户故事/要解决的问题】*
-> 解决了什么问题，尝试用 As a (who), I want (what), so I can (why/value) 三段式来描述问题
-
-
-### 【意向用户】*
-> 影响了哪些人，需求来源是什么人？
-
-
-### 【用户体验目标】*
-> 可以从多方面描述，意向用户如何在需求/任务完成后解决了他的问题。比如“用户可以通过编辑 pipeline.yml 跑一条流水线”。
-
-
-### 【链接/参考】
-
-`,
-  [ISSUE_TYPE.BUG]: `### 【环境信息】
-> 缺陷产生的环境、链接、使用特殊账号的描述账号信息
-
-
-### 【缺陷描述】*
-> 描述出缺陷的具体问题，一般为操作场景加上错误信息或截图
-
-
-### 【重现步骤】
-> 缺陷的操作步骤
-
-
-### 【实际结果】
-> 按照上述操作步骤，实际中出现的结果
-
-
-### 【期望结果】*
-> 按照上述操作步骤，希望出现的结果
-
-
-### 【修复建议】
-> 针对该缺陷应该如何修复，测试人员提出建议
-
-`,
 };
 
 const { Option } = Select;

--- a/shell/app/modules/project/common/issue-config.ts
+++ b/shell/app/modules/project/common/issue-config.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import i18n from 'i18n';
+import i18n, { isZh } from 'i18n';
 
 export enum ISSUE_TYPE {
   ALL = 'ALL',
@@ -130,3 +130,116 @@ export enum ISSUE_OPTION {
   TASK = 'TASK',
   BUG = 'BUG',
 }
+
+export const templateMap = isZh()
+  ? {
+      [ISSUE_TYPE.REQUIREMENT]: `### 【用户故事/要解决的问题】*
+> 解决了什么问题，尝试用 As a (who), I want (what), so I can (why/value) 三段式来描述问题
+
+
+### 【意向用户】*
+> 影响了哪些人，需求来源是什么人？
+
+
+### 【用户体验目标】*
+> 可以从多方面描述，意向用户如何在需求/任务完成后解决了他的问题。比如“用户可以通过编辑 pipeline.yml 跑一条流水线”。
+
+
+### 【链接/参考】
+
+`,
+      [ISSUE_TYPE.TASK]: `### 【用户故事/要解决的问题】*
+> 解决了什么问题，尝试用 As a (who), I want (what), so I can (why/value) 三段式来描述问题
+
+
+### 【意向用户】*
+> 影响了哪些人，需求来源是什么人？
+
+
+### 【用户体验目标】*
+> 可以从多方面描述，意向用户如何在需求/任务完成后解决了他的问题。比如“用户可以通过编辑 pipeline.yml 跑一条流水线”。
+
+
+### 【链接/参考】
+
+`,
+      [ISSUE_TYPE.BUG]: `### 【环境信息】
+> 缺陷产生的环境、链接、使用特殊账号的描述账号信息
+
+
+### 【缺陷描述】*
+> 描述出缺陷的具体问题，一般为操作场景加上错误信息或截图
+
+
+### 【重现步骤】
+> 缺陷的操作步骤
+
+
+### 【实际结果】
+> 按照上述操作步骤，实际中出现的结果
+
+
+### 【期望结果】*
+> 按照上述操作步骤，希望出现的结果
+
+
+### 【修复建议】
+> 针对该缺陷应该如何修复，测试人员提出建议
+
+`,
+    }
+  : {
+      [ISSUE_TYPE.REQUIREMENT]: `### [User story/problem to solve] *
+> As a (who), I want (what), so I can (why/value)
+
+
+### [Intended users] *
+> Who is affected and who is the source of demand?
+
+
+### [User experience Goals] *
+> Can describe in many ways how the intended user solved his problem once the requirement/task was completed.For example, "Users can run a pipeline by editing pipeline.yml."
+
+
+### [Link/Reference]
+
+`,
+      [ISSUE_TYPE.TASK]: `### [User story/problem to solve] *
+> As a (who), I want (what), so I can (why/value)
+
+
+### [Intended users] *
+> Who is affected and who is the source of demand?
+
+
+### [User experience Goals] *
+> Can describe in many ways how the intended user solved his problem once the requirement/task was completed.For example, "Users can run a pipeline by editing pipeline.yml."
+
+
+### [Link/Reference]
+
+`,
+      [ISSUE_TYPE.BUG]: `### [Environment Information]
+> Environment where the defect occurs, link, and description of the special account Account information
+
+
+### [Defect Description] *
+> Describe the specific problem of the defect, usually with an error message or screenshots for the operation scenario
+
+
+### [Reoccurrence Procedure]
+> Steps for defects
+
+
+### [Actual Result]
+> The actual result of following the preceding steps
+
+
+### [Expected Result] *
+> Follow the steps above to get the desired result
+
+
+### [Repair suggestion]
+> How does the tester recommend that this defect be fixed
+`,
+    };

--- a/shell/app/modules/project/pages/backlog/issue-item.tsx
+++ b/shell/app/modules/project/pages/backlog/issue-item.tsx
@@ -27,6 +27,7 @@ import './issue-item.scss';
 import routeInfoStore from 'core/stores/route';
 import userStore from 'app/user/stores';
 import { useUserMap } from 'core/stores/userMap';
+import { templateMap } from 'project/common/issue-config';
 
 export enum BACKLOG_ISSUE_TYPE {
   iterationIssue = 'iterationIssue',
@@ -159,7 +160,10 @@ export const IssueForm = (props: IIssueFormProps) => {
     if (curForm) {
       curForm.onSubmit((val: ISSUE.BacklogIssueCreateBody) => {
         if (val.title) {
-          onOk(val).then(() => curForm.reset('title'));
+          onOk({
+            ...val,
+            content: templateMap[val.type] || '',
+          }).then(() => curForm.reset('title'));
         } else {
           message.warn(i18n.t('please enter {name}', { name: i18n.t('title') }));
         }


### PR DESCRIPTION
## What this PR does / why we need it:
Add template for quick create issue.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

