### PR TITLE
scheduler add max-age

### DIFF
--- a/scheduler/src/app.module.ts
+++ b/scheduler/src/app.module.ts
@@ -27,9 +27,6 @@ const { publicDir } = getEnv();
       serveRoot: '/',
       serveStaticOptions: {
         index: false,
-        setHeaders: (res) => {
-          res.setHeader('Cache-Control', 'no-cache');
-        },
       },
     }),
   ],

--- a/scheduler/src/app.module.ts
+++ b/scheduler/src/app.module.ts
@@ -26,6 +26,7 @@ const { publicDir } = getEnv();
       rootPath: publicDir,
       serveRoot: '/',
       serveStaticOptions: {
+        maxAge: 60 * 60 * 1000, // unit is milliseconds so it means 1 hour max-age
         index: false,
       },
     }),

--- a/scheduler/src/app.module.ts
+++ b/scheduler/src/app.module.ts
@@ -27,6 +27,9 @@ const { publicDir } = getEnv();
       serveRoot: '/',
       serveStaticOptions: {
         index: false,
+        setHeaders: (res) => {
+          res.setHeader('Cache-Control', 'no-cache');
+        },
       },
     }),
   ],


### PR DESCRIPTION
## What this PR does / why we need it:
max-age was removed mistakenly yesterday.
I found max-age is still required, otherwise it will always go to revalidate cache

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

