### PR TITLE
fix: click home page with joined org from notFound and freshMan page

### DIFF
--- a/shell/app/org-home/stores/org.tsx
+++ b/shell/app/org-home/stores/org.tsx
@@ -89,8 +89,9 @@ const org = createStore({
         return;
       }
       const curPathname = location.pathname;
-      if (!resOrg) {
+      if (!Object.keys(resOrg).length) {
         goTo(goTo.pages.notFound);
+        update({ initFinish: true });
       } else {
         const currentOrg = resOrg || {};
         const orgId = currentOrg.id;
@@ -132,6 +133,7 @@ const org = createStore({
             const joinOrgTip = map(orgPermRes.userInfo, (u) => u.nick).join(', ');
             userStore.reducers.setJoinOrgTip(joinOrgTip);
             goTo(goTo.pages.freshMan);
+            update({ initFinish: true });
             return;
           }
           // redirect path by roles.


### PR DESCRIPTION
## What this PR does / why we need it:
1. if resOrg is empty, it's value is '{}'
2. back home page with joined org from notFound and freshMan page

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

