### PR TITLE
fix: adjust test case table td line-height

### DIFF
--- a/shell/app/modules/application/pages/test/test-detail.tsx
+++ b/shell/app/modules/application/pages/test/test-detail.tsx
@@ -192,7 +192,6 @@ class TestDetail extends React.Component<IProps, IState> {
             <ChartContainer title={i18n.t('application:test environment')}>
               <Table
                 loading={false}
-                size="middle"
                 dataSource={dataSource}
                 columns={cols}
                 rowKey="env"

--- a/shell/app/modules/project/pages/test-manage/components/case-table/index.tsx
+++ b/shell/app/modules/project/pages/test-manage/components/case-table/index.tsx
@@ -283,7 +283,6 @@ const CaseTable = ({ query: queryProp, columns, onClickRow, scope, onChange, tes
       loading={loading}
       className={className}
       indentSize={0}
-      size="middle"
       expandedRowKeys={expandedRowKeys}
       dataSource={dataSource}
       columns={newColumns}


### PR DESCRIPTION
## What this PR does / why we need it:
Adjust line-height of test case table. 

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/135217638-4758a3e8-1032-491f-a678-96781ac88c1f.png)
->
![image](https://user-images.githubusercontent.com/82502479/135217556-78fc911a-8cf6-45b8-9367-a097d084ada4.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Adjust line-height of test case table.   |
| 🇨🇳 中文    |   调整测试用例表格的行高。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

