### PR TITLE
fix(msp): only the access service button is displayed under the MSP item

### DIFF
--- a/shell/app/modules/msp/env-overview/service-list/pages/index.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/index.tsx
@@ -62,9 +62,11 @@ export default () => {
 
   return (
     <div>
-      <Button className="top-button-group mt-2" type="primary" onClick={() => goTo(goTo.pages.mspConfiguationPage)}>
-        {i18n.t('msp:access service')}
-      </Button>
+      {currentProject?.type === 'MSP' ? (
+        <Button className="top-button-group mt-2" type="primary" onClick={() => goTo(goTo.pages.mspConfiguationPage)}>
+          {i18n.t('msp:access service')}
+        </Button>
+      ) : null}
       <div className="mb-2 flex flex-wrap items-center justify-between">
         <Search
           allowClear

--- a/shell/app/modules/msp/env-overview/topology/pages/topology-dashboard/index.tsx
+++ b/shell/app/modules/msp/env-overview/topology/pages/topology-dashboard/index.tsx
@@ -155,9 +155,11 @@ const TopologyDashboard = () => {
 
   return (
     <div className="topology-dashboard">
-      <Button className="top-button-group mt-2" type="primary" onClick={() => goTo(goTo.pages.mspConfiguationPage)}>
-        {i18n.t('msp:access service')}
-      </Button>
+      {currentProject?.type === 'MSP' ? (
+        <Button className="top-button-group mt-2" type="primary" onClick={() => goTo(goTo.pages.mspConfiguationPage)}>
+          {i18n.t('msp:access service')}
+        </Button>
+      ) : null}
       {/* 全局概览 */}
       <div className="topology-global-dashboard">
         {!isEmpty(globalVariable) && <PureBoardGrid layout={overviewBoard} globalVariable={globalVariable} />}


### PR DESCRIPTION

## What this PR does / why we need it:
only the access service button is displayed under the MSP item

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

