### PR TITLE
Hotfix/issues filter spacing adjustment

### DIFF
--- a/shell/app/common/components/contractive-filter.scss
+++ b/shell/app/common/components/contractive-filter.scss
@@ -7,10 +7,10 @@
   position: relative;
   display: inline-flex;
   height: 28px;
-  margin: 2px 8px 2px 0;
+  margin: 2px 6px 2px 0;
 
   .contractive-filter-split {
-    width: 2px;
+    width: 1px;
     height: 20px;
     margin-top: 4px;
     background-color: $color-dark-2;
@@ -25,7 +25,7 @@
   .contractive-filter-item {
     display: flex;
     align-items: center;
-    padding: 4px 8px;
+    padding: 4px 0 4px 8px;
     border-radius: 4px;
     cursor: pointer;
     transition: background-color 0.1s ease-out;

--- a/shell/app/common/components/contractive-filter.scss
+++ b/shell/app/common/components/contractive-filter.scss
@@ -7,7 +7,7 @@
   position: relative;
   display: inline-flex;
   height: 28px;
-  margin: 2px 6px 2px 0;
+  margin: 2px 4px 2px 0;
 
   .contractive-filter-split {
     width: 1px;

--- a/shell/app/common/components/contractive-filter.tsx
+++ b/shell/app/common/components/contractive-filter.tsx
@@ -743,7 +743,7 @@ export const ContractiveFilter = ({
             onChange={handelItemChange}
             onQuickOperation={onQuickOperation}
           />
-          {item.split ? <div className="ml-2 contractive-filter-split" /> : null}
+          {item.split ? <div className="ml-1 contractive-filter-split" /> : null}
         </span>
       ))}
 

--- a/shell/app/common/components/contractive-filter.tsx
+++ b/shell/app/common/components/contractive-filter.tsx
@@ -179,6 +179,7 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
         // autoFocus // 默认全部展示，不需要自动获取焦点
         value={inputVal}
         size="small"
+        style={{ width: 180 }}
         allowClear
         // ref={inputRef}
         prefix={<IconSearch size="16" />}


### PR DESCRIPTION
## What this PR does / why we need it:
Adjust spacing of issues filter.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/135397883-1033a397-3f01-4056-81fb-df115706ca16.png)
->
![image](https://user-images.githubusercontent.com/82502479/135397908-81f75af6-7c22-44aa-93ec-5fe85142317f.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Adjusted the spacing of the issues filter so that the default line is displayed under the filter small screen.  |
| 🇨🇳 中文    | 调整了项目协同筛选器的间距，使筛选器小屏幕下默认一行显示。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

