### PR TITLE
fix(dop): issues is blank when filter change

### DIFF
--- a/shell/app/modules/project/pages/issue/issue-protocol.tsx
+++ b/shell/app/modules/project/pages/issue/issue-protocol.tsx
@@ -113,7 +113,7 @@ export default ({ issueType }: IProps) => {
       queryRef.current = restQuery;
       update({ urlQuery: restQuery });
     }
-  }, [query]);
+  }, [restQuery]);
 
   const onChosenIssue = (val: ISSUE.Issue) => {
     update({


### PR DESCRIPTION
## What this PR does / why we need it:
Issues page is blank when filter change.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed bug of Issues page is blank when filter change. |
| 🇨🇳 中文    | 解决了过滤器改变时协同页面会白屏的问题。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda.cloud/erda/dop/projects/387/issues/all?id=231301&issueFilter__urlQuery=eyJ0aXRsZSI6IueZveWxjyIsInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl19&issueGantt__urlQuery=eyJ0b3RhbCI6MywicGFnZU5vIjoxLCJwYWdlU2l6ZSI6MTAsImlzc3VlVmlld0dyb3VwVmFsdWUiOiJnYW50dCIsIklzc3VlVHlwZSI6IkFMTCJ9&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImdhbnR0IiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=BUG

