### PR TITLE
fix(dop): pageNo bug when filter change in issues gantt

### DIFF
--- a/shell/app/modules/project/pages/issue/issue-protocol.tsx
+++ b/shell/app/modules/project/pages/issue/issue-protocol.tsx
@@ -101,6 +101,11 @@ export default ({ issueType }: IProps) => {
   }, [filterObj]);
 
   useUpdateEffect(() => {
+    const { id: _id, iterationID: _iterationID, type: _type, ..._restQuery } = query;
+    queryRef.current = _restQuery;
+  }, [query]);
+
+  useUpdateEffect(() => {
     if (!compareObject(urlQuery, queryRef.current)) {
       queryRef.current = urlQuery;
       updateSearch({ ...(urlQuery || {}) });
@@ -109,11 +114,10 @@ export default ({ issueType }: IProps) => {
 
   useUpdateEffect(() => {
     // Change the urlQuery when url change such as page go back
-    if (!compareObject(urlQuery, restQuery)) {
-      queryRef.current = restQuery;
-      update({ urlQuery: restQuery });
+    if (!compareObject(urlQuery, queryRef.current)) {
+      update({ urlQuery: queryRef.current });
     }
-  }, [restQuery]);
+  }, [queryRef.current]);
 
   const onChosenIssue = (val: ISSUE.Issue) => {
     update({


### PR DESCRIPTION
## What this PR does / why we need it:
When filter criteria change, the page number does not return to the first page.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | In issues gantt, when filter criteria change, the page number does not return to the first page.  |
| 🇨🇳 中文    | 协同的甘特图中，筛选条件变化时，页码不会回到第一页。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

