### PR TITLE
fix(dop): issues render call api twice

### DIFF
--- a/shell/app/modules/project/pages/issue/issue-protocol.tsx
+++ b/shell/app/modules/project/pages/issue/issue-protocol.tsx
@@ -60,7 +60,7 @@ export default ({ issueType }: IProps) => {
     pageNo: 1,
     viewType: '',
     viewGroup: '',
-    urlQueryChangeByQuery: restQuery,
+    urlQueryChangeByQuery: restQuery, // Only used to listen for changes to update the page after url change
   });
   const { getFieldsByIssue: getCustomFieldsByProject } = issueFieldStore.effects;
   useMount(() => {
@@ -117,17 +117,17 @@ export default ({ issueType }: IProps) => {
   }, [urlQuery]);
 
   useUpdateEffect(() => {
-    // Change the urlQuery when url change such as page go back
     if (!compareObject(urlQuery, queryRef.current)) {
+      // Execute only after url change such as page go back
       update({
         urlQuery: queryRef.current,
-        urlQueryChangeByQuery: queryRef.current,
+        urlQueryChangeByQuery: queryRef.current, // Only used to listen for changes to update the page
       });
     }
   }, [queryRef.current]);
 
   useUpdateEffect(() => {
-    reloadRef.current.reload();
+    reloadData();
   }, [urlQueryChangeByQuery]);
 
   const onChosenIssue = (val: ISSUE.Issue) => {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of issues render call api twice.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed bug of call api twice when issues render.  |
| 🇨🇳 中文    | 修复了协同render时api调用两次的bug。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=232447&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueGantt__urlQuery=eyJ0b3RhbCI6MTYsInBhZ2VObyI6MSwicGFnZVNpemUiOjEwLCJpc3N1ZVZpZXdHcm91cFZhbHVlIjoiZ2FudHQiLCJJc3N1ZVR5cGUiOiJBTEwifQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG

