### PR TITLE
fix: text has no flex style by default

### DIFF
--- a/shell/app/config-page/components/text/text.spec.d.ts
+++ b/shell/app/config-page/components/text/text.spec.d.ts
@@ -54,7 +54,7 @@ declare namespace CP_TEXT {
 
   interface ILinkTextData {
     text: Array<ILinkTarget | string> | ILinkTarget | string;
-    isPureText: boolean;
+    direction?: 'row' | 'column';
   }
 
   interface ILinkTarget {

--- a/shell/app/config-page/components/text/text.tsx
+++ b/shell/app/config-page/components/text/text.tsx
@@ -82,7 +82,7 @@ const Text = (props: CP_TEXT.Props) => {
       break;
     case 'linkText':
       {
-        const { text, direction = 'row' } = (value || {}) as CP_TEXT.ILinkTextData;
+        const { text, direction = '' } = (value || {}) as CP_TEXT.ILinkTextData;
         if (isString(text)) {
           TextComp = (
             <span style={styleObj} className={textClassNames}>
@@ -91,7 +91,7 @@ const Text = (props: CP_TEXT.Props) => {
           );
         } else if (isArray(text)) {
           TextComp = (
-            <span className={`flex items-center flex-${direction}`}>
+            <span className={`${direction ? `flex items-center flex-${direction}` : ''}`}>
               {text.map((t, idx) => {
                 if (isString(t)) {
                   return (


### PR DESCRIPTION
## What this PR does / why we need it:
Text which is config-page component has no flex style by default,  unless it accepts ’direction‘.
the style fix was caused by [https://github.com/erda-project/erda-ui/pull/1498/files](url)

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

