### PR TITLE
fix(dop): addonsManage settings page not displayed

### DIFF
--- a/shell/app/modules/dop/router.ts
+++ b/shell/app/modules/dop/router.ts
@@ -135,7 +135,7 @@ export default function getDopRouter(): RouteConfigItem[] {
                 {
                   path: 'settings',
                   breadcrumbName: i18n.t('dop:addon setting'),
-                  getComp: (cb) => cb(import('common/components/addon-settings'), 'AddonSettings'),
+                  getComp: (cb) => cb(import('common/components/addon-settings')),
                 },
                 // {
                 //   path: 'log-analytics',


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of addons-manage settings page not displayed.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

