### PR TITLE
The old data editing page crashed and repaired, And the formatted data is still displayed after the body is formatted

### DIFF
--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -67,7 +67,7 @@ const convertFormData = (_formData?: Obj) => {
       retry: _formData?.config?.retry || RETRY_TIMES[0],
       frequency: _formData?.config?.interval || TIME_LIMITS[0],
       apiMethod: _formData?.config?.method || HTTP_METHOD_LIST[0],
-      body: JSON.stringify(_formData?.config?.body, null, 2 || {}),
+      body: JSON.stringify(_formData?.config?.body, null, 2) || JSON.stringify({}),
       headers: _formData?.config?.headers || {},
       url: _formData?.config?.url || '',
       query: qs.parseUrl(_formData?.config?.url || '')?.query,


### PR DESCRIPTION
## What this PR does / why we need it:
The old data editing page crashed and repaired, And the formatted data is still displayed after the body is formatted

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
Yes
release/1.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

