### PR TITLE
feat(dop): manual test plan table adjustment

### DIFF
--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -3144,6 +3144,7 @@
     "pipeline-run-tip": "The current configuration is historical, please switch to the latest configuration before operating",
     "plan": "plan",
     "plan details": "plan details",
+    "plan ID": "plan ID",
     "plan name": "plan name",
     "plan-remove-case-confirm": "are you sure to remove the currently selected use case in the current plan?",
     "please add a test leader": "please add a test leader",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -3143,6 +3143,7 @@
     "pipeline-run-tip": "当前为历史配置，请切换最新配置后再操作",
     "plan": "版本",
     "plan details": "计划详情",
+    "plan ID": "计划 ID",
     "plan name": "计划名称",
     "plan-remove-case-confirm": "是否确认在当前计划中移除掉当前选中用例?",
     "please add a test leader": "请添加测试负责人",

--- a/shell/app/modules/project/pages/test-plan/test-plan.tsx
+++ b/shell/app/modules/project/pages/test-plan/test-plan.tsx
@@ -87,15 +87,18 @@ const TestPlan = () => {
 
   const columns: Array<ColumnProps<TEST_PLAN.Plan>> = [
     {
+      title: i18n.t('project:plan ID'),
+      dataIndex: 'id',
+      width: 120,
+    },
+    {
       title: i18n.t('project:plan name'),
       dataIndex: 'name',
       render: (text, record) => {
         return (
-          <div className="title flex items-center" title={`${record.id}-${text}`}>
+          <div className="title flex items-center" title={text}>
             {iconMap[record.status]}
-            <span className="truncate">
-              {record.id}-{text}
-            </span>
+            <span className="truncate">{text}</span>
           </div>
         );
       },


### PR DESCRIPTION
## What this PR does / why we need it:
Manual test plan table adjustment

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/138097050-90b4ed7a-c3b9-4578-a95b-797953083b80.png)
->
![image](https://user-images.githubusercontent.com/82502479/138096990-10957a50-3752-4d05-b6e3-df2404bd717d.png)

## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  In manual test plan, separate the plan ID from the plan name as a separate column.   |
| 🇨🇳 中文    | 在手动测试执行计划中，将计划id从计划名称中拆出来单独一列。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

