### PR TITLE
Adjust and add the style of body in monitoring

### DIFF
--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -63,17 +63,18 @@ const formType = 'x-www-form-urlencoded';
 const noneType = 'none';
 const jsonType = 'application/json';
 const textType = 'text/plain';
+const raw = 'raw';
+const json = 'json';
+const text = 'text';
 
 const convertType = (type: string) => {
-  let newType = '';
+  const newType = '';
   if (type === formType || type === noneType) {
     return newType;
   } else if (type === jsonType) {
-    newType = 'json';
-    return newType;
+    return json;
   } else {
-    newType = 'text';
-    return newType;
+    return text;
   }
 };
 
@@ -83,7 +84,7 @@ const convertFormData = (_formData?: Obj) => {
       retry: _formData.config?.retry || 2,
       bodyType:
         _formData.config?.body?.type === jsonType || _formData.config?.body?.type === textType
-          ? 'raw'
+          ? raw
           : _formData.config?.body?.type,
       frequency: _formData.config?.interval || TIME_LIMITS[0],
       apiMethod: _formData.config?.method || HTTP_METHOD_LIST[0],
@@ -237,13 +238,13 @@ const AddModal = (props: IProps) => {
 
   React.useEffect(() => {
     switch (textOrJson) {
-      case 'text':
+      case text:
         updater.body({ ...body, type: textType });
         updater.headers({
           'Content-Type': textType,
         });
         break;
-      case 'json':
+      case json:
         updater.body({ ...body, type: jsonType });
         updater.headers({
           'Content-Type': jsonType,
@@ -336,7 +337,7 @@ const AddModal = (props: IProps) => {
           <div className="h-full">
             <Tabs
               onChange={(key: string) => {
-                if (key === '2' && bodyType === 'raw' && textOrJson === 'text') {
+                if (key === '2' && bodyType === raw && textOrJson === text) {
                   updater.headers({ ...headers, 'Content-Type': textType });
                 }
                 if (key === '2' && bodyType === noneType) {
@@ -375,7 +376,7 @@ const AddModal = (props: IProps) => {
                       body.content = '';
                       updater.body({ ...body });
                     }
-                    if (e.target.value === 'raw') {
+                    if (e.target.value === raw) {
                       body.content = '';
                       updater.body({ ...body });
                       updater.textOrJson('text');
@@ -408,7 +409,7 @@ const AddModal = (props: IProps) => {
                     />
                   </div>
                 ) : null}
-                {bodyType === 'raw' ? (
+                {bodyType === raw ? (
                   <Select
                     value={textOrJson}
                     onChange={(v) => {
@@ -421,7 +422,7 @@ const AddModal = (props: IProps) => {
                     <Option value="json">application/json</Option>
                   </Select>
                 ) : null}
-                {bodyType === 'raw' && textOrJson === 'text' ? (
+                {bodyType === raw && textOrJson === text ? (
                   <TextArea
                     value={body?.content}
                     onChange={(e) => {
@@ -432,12 +433,12 @@ const AddModal = (props: IProps) => {
                     rows={10}
                   />
                 ) : null}
-                {textOrJson === 'json' ? (
+                {textOrJson === json ? (
                   <Button onClick={formatBody} className="ml-2" size="small" type="primary">
                     {i18n.t('format')}
                   </Button>
                 ) : null}
-                {bodyType === 'raw' && textOrJson === 'json' ? (
+                {bodyType === raw && textOrJson === json ? (
                   <FileEditor
                     className="mt-4"
                     fileExtension="json"


### PR DESCRIPTION
## What this PR does / why we need it:
Adjust and add the style of body in monitoring

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
<img width="795" alt="截屏2021-10-25上午9 34 21" src="https://user-images.githubusercontent.com/48612739/138621998-af63d7b7-b6af-4d38-a470-9e97306cf252.png">



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Adjust the style of the body added in the monitoring to be consistent with the body style of the automation test interface          |
| 🇨🇳 中文    |      将添加监控中body的样式，调整为跟自动化测试接口的body样式一致        |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

