### PR TITLE
fix(cmp): rds info does not display caused by replace Panel

### DIFF
--- a/shell/app/common/components/panel/index.tsx
+++ b/shell/app/common/components/panel/index.tsx
@@ -109,7 +109,7 @@ const Panel = (props: PanelProps) => {
           if (item.hide) return null;
           return (
             <Row gutter={12} key={item.label as React.Key}>
-              <Col span={24}>
+              <Col span={24} className="pb-2">
                 <div className="text-black-400" title={`${getInnerText(item.label)}`}>
                   {item.label}
                   {item.tips && (
@@ -120,8 +120,8 @@ const Panel = (props: PanelProps) => {
                     </span>
                   )}
                 </div>
-                <div title={getInnerText(getRealValue(item))} className="break-words">
-                  {getRealValue(item)}
+                <div title={item.value || getInnerText(getRealValue(item))} className="break-words">
+                  {item.value || getRealValue(item)}
                 </div>
               </Col>
             </Row>


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of rds info does not display caused by replace Panel.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/139042380-e0d9219c-ad03-4704-877d-46899efe42ea.png)
->
![image](https://user-images.githubusercontent.com/82502479/139042418-b920bcfa-7728-4f2a-bb78-9a75332221c2.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=239936&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG

