### PR TITLE
fix(common): add checkbox of quota in project info edit

### DIFF
--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -82,7 +82,7 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
       } = item;
 
       if (!hideWhenReadonly && !(itemProps?.type === 'hidden' && !showInfo)) {
-        let value = name === undefined && getComp ? getComp() : get(data, name || '');
+        let value = name === undefined && getComp ? getComp({ readOnly: true }) : get(data, name || '');
         if (type === 'radioGroup' && !isFunction(options)) {
           value = ((options as any[]).find((option) => option.value === value) || {}).name;
         }

--- a/shell/app/modules/project/pages/settings/components/project-info.tsx
+++ b/shell/app/modules/project/pages/settings/components/project-info.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import i18n from 'i18n';
-import { Tooltip, Button, Input } from 'core/nusi';
+import { Tooltip, Button, Input, Checkbox } from 'core/nusi';
 import { FormInstance } from 'core/common/interface';
 import { theme } from 'app/themes';
 import { ImageUpload, Icon as CustomIcon, ConfirmDelete } from 'common';
@@ -54,6 +54,8 @@ export default ({ canEdit, canDelete, canEditQuota, showQuotaTip }: IProps) => {
   const info = projectStore.useStore((s) => s.info);
   const [confirmProjectName, setConfirmProjectName] = React.useState('');
   const [canGetClusterListAndResources, setCanGetClusterListAndResources] = React.useState(false);
+  const [ifConfigCluster, setIfConfigCluster] = React.useState(false);
+  const [ifConfigClusterDisable, setIfConfigClusterDisable] = React.useState(false);
   const updatePrj = (values: Obj) => {
     const { isPublic, resourceConfig } = values;
     if (resourceConfig) {
@@ -76,6 +78,17 @@ export default ({ canEdit, canDelete, canEditQuota, showQuotaTip }: IProps) => {
       reloadHeadInfo();
     });
   };
+
+  React.useEffect(() => {
+    if (info.resourceConfig) {
+      setIfConfigCluster(true);
+      setIfConfigClusterDisable(true);
+    } else {
+      setIfConfigCluster(false);
+      setIfConfigClusterDisable(false);
+    }
+  }, [info]);
+
   const notMSP = info.type !== 'MSP';
   const fieldsList = [
     {
@@ -120,7 +133,21 @@ export default ({ canEdit, canDelete, canEditQuota, showQuotaTip }: IProps) => {
       required: false,
       itemProps: { rows: 4, maxLength: 200 },
     },
-    ...insertWhen(notMSP, useQuotaFields(canEditQuota, showQuotaTip, canGetClusterListAndResources)),
+    ...insertWhen(notMSP, [
+      {
+        getComp: ({ readOnly }: { readOnly: boolean }) =>
+          !readOnly ? (
+            <Checkbox
+              checked={ifConfigCluster}
+              disabled={ifConfigClusterDisable}
+              onChange={() => setIfConfigCluster(!ifConfigCluster)}
+            >
+              {i18n.t('org:need to configure project cluster resources')}
+            </Checkbox>
+          ) : null,
+      },
+    ]),
+    ...insertWhen(notMSP && ifConfigCluster, useQuotaFields(canEditQuota, showQuotaTip, canGetClusterListAndResources)),
     // {
     //   label: i18n.t('project:DingTalk notification address'),
     //   name: 'ddHook',


### PR DESCRIPTION
## What this PR does / why we need it:
Add checkbox of quota in project info edit

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/139181990-a96cb149-2153-47e8-a0f4-87321ad97ec1.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Add checkbox of quota in project info edit. |
| 🇨🇳 中文    |  在项目信息编辑中新增quota的复选框。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

