### PR TITLE
feat: add holder before get data from api and hide calculator default

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -222,6 +222,7 @@
     "schedulable",
     "screenfull",
     "scrollbar",
+    "serie",
     "serr",
     "serviceaccounts",
     "Sevenday",

--- a/shell/app/common/components/card-container/index.tsx
+++ b/shell/app/common/components/card-container/index.tsx
@@ -24,7 +24,7 @@ export interface CardContainerProps {
   operation?: React.ReactNode;
   holderWhen?: boolean;
   style?: React.CSSProperties;
-  children: React.ReactChild | React.ReactChild[];
+  children: React.ReactChild | React.ReactChild[] | null;
 }
 
 const CardContainer = ({ title, tip, className, operation, holderWhen, style, children }: CardContainerProps) => {

--- a/shell/app/common/components/erda-icon/erda-icon.tsx
+++ b/shell/app/common/components/erda-icon/erda-icon.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import './erda-icon.scss';
 import themeColor from '../../../../theme-color';
 
-type IconColor = typeof themeColor;
+type IconColor = keyof typeof themeColor;
 
 export const iconMap = {
   lock: 'lock',

--- a/shell/app/common/components/title/index.tsx
+++ b/shell/app/common/components/title/index.tsx
@@ -16,8 +16,8 @@ import { Tooltip } from 'antd';
 import { Help as IconHelp } from '@icon-park/react';
 
 export interface TitleProps {
-  title: string | React.ElementType;
-  tip?: string | React.ElementType;
+  title: string | React.ElementType | JSX.Element;
+  tip?: string | React.ElementType | JSX.Element;
   operations?: Array<TitleOperate | React.ReactNode>;
   level?: 1 | 2 | 3;
   mt?: 0 | 8 | 16;

--- a/shell/app/views/index.ejs
+++ b/shell/app/views/index.ejs
@@ -39,7 +39,7 @@
   <!-- layout -->
   <script src="https://lf1-cdn-tos.bytegoofy.com/obj/iconpark/icons_1776_8.ba89731a7541ef588c93a4ace53a6b3d.es5.js" ></script>
   <!-- dice iconpark -->
-  <script src="https://lf1-cdn-tos.bytegoofy.com/obj/iconpark/icons_138_83.7d844e521b4648831c7eb7a9ad02f786.es5.js"></script>
+  <script src="https://lf1-cdn-tos.bytegoofy.com/obj/iconpark/icons_138_90.c19188c8cd1973a4cd6c15ccd777b09c.es5.js"></script>
   <!-- $ -->
 </body>
 


### PR DESCRIPTION
## What this PR does / why we need it:
* add holder instead render null before load data
* hide calculator default

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/139206724-0324a381-f97c-44ee-8e68-5508c0520f08.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

