### PR TITLE
fix: upgrade dashboard to fix get chart data failed

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 1.0.42
+      '@erda-ui/dashboard-configurator': 1.0.43
       '@erda-ui/react-markdown-editor-lite': ^1.4.6
       '@icon-park/react': ^1.3.3
       '@module-federation/automatic-vendor-federation': ^1.2.1
@@ -467,7 +467,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 1.0.42_89f7d333518b25ce6638797795704a0d
+      '@erda-ui/dashboard-configurator': 1.0.43_89f7d333518b25ce6638797795704a0d
       '@erda-ui/react-markdown-editor-lite': 1.4.6_react@16.14.0
       '@icon-park/react': 1.3.3_react-dom@16.14.0+react@16.14.0
       ace-builds: 1.4.12
@@ -4469,8 +4469,8 @@ packages:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
     dev: false
 
-  /@erda-ui/dashboard-configurator/1.0.42_89f7d333518b25ce6638797795704a0d:
-    resolution: {integrity: sha512-I0X7R/MQVBGL5sJCdMbFzgPXmjFTIMAORUJrRgzEXETF5M+pW83DinY1ZMHFaT1qOea1fgQDR9Yzdvv7jAK6uA==}
+  /@erda-ui/dashboard-configurator/1.0.43_89f7d333518b25ce6638797795704a0d:
+    resolution: {integrity: sha512-dviT28rN40LNFDUpN5W4hhUH/izxhsV4FmkVBekY06l6BvZRchq0qlnImk2lni6G8arN/7tQ/zPgiiYQnMmc/g==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'

--- a/shell/package.json
+++ b/shell/package.json
@@ -47,7 +47,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "1.0.42",
+    "@erda-ui/dashboard-configurator": "1.0.43",
     "@erda-ui/react-markdown-editor-lite": "^1.4.6",
     "@icon-park/react": "^1.3.3",
     "ace-builds": "^1.4.7",


### PR DESCRIPTION
## What this PR does / why we need it:
fix: upgrade dashboard to fix get chart data failed

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【微服务总览】热点服务TOP5图表获取数据失败](https://erda.cloud/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D)
