### PR TITLE
fix: did not display correspond service name from service list page

### DIFF
--- a/shell/app/modules/msp/env-overview/service-list/pages/service-name-select.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/service-name-select.tsx
@@ -50,7 +50,7 @@ export function ServiceNameSelect() {
     if (serviceId) {
       configServiceData(serviceId);
     } else if (params?.serviceId) {
-      configServiceData(params?.serviceId);
+      configServiceData(window.decodeURIComponent(params?.serviceId));
     } else if (!serviceId && serviceList?.length > 0) {
       configServiceData(serviceId);
     }


### PR DESCRIPTION
## What this PR does / why we need it:
fix that did not display corresponding service name from the service list page

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【服务列表】点击列表中的服务，跳转到服务概览页面，服务定位有错](https://erda.cloud/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D)
