### PR TITLE
Actively monitor related bugs

### DIFF
--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -2129,6 +2129,7 @@
     "earlier": "earlier",
     "edit a endpoint": "edit a endpoint",
     "emergency": "emergency",
+    "edit monitoring": "edit monitoring",
     "enable daily report": "enable daily report",
     "enable rule": "enable rule",
     "enable weekly report": "enable weekly report",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -2128,6 +2128,7 @@
     "earlier": "更早",
     "edit a endpoint": "编辑流量入口",
     "emergency": "紧急",
+    "edit monitoring": "编辑监控",
     "enable daily report": "开启日报",
     "enable rule": "开启规则",
     "enable weekly report": "开启周报",

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -88,7 +88,10 @@ const convertFormData = (_formData?: Obj) => {
           : _formData.config?.body?.type,
       frequency: _formData.config?.interval || TIME_LIMITS[0],
       apiMethod: _formData.config?.method || HTTP_METHOD_LIST[0],
-      body: _formData.config?.body || { content: '', type: noneType },
+      body: _formData.config?.body || {
+        content: '',
+        type: noneType,
+      },
       headers: _formData.config?.headers || {},
       url: _formData.config?.url || '',
       query: qs.parseUrl(_formData.config?.url || '')?.query,
@@ -166,17 +169,15 @@ const AddModal = (props: IProps) => {
   };
 
   const setOperator = (index: number, operate: string) => {
-    if (condition[index]) {
-      condition[index].operate = operate;
-    }
-    updater.condition([...condition]);
+    const newCondition = [...condition];
+    newCondition[index] = { ...newCondition[index], operate };
+    updater.condition(newCondition);
   };
 
   const setKey = (index: number, key: string) => {
-    if (condition[index]) {
-      condition[index].key = key;
-    }
-    updater.condition([...condition]);
+    const newCondition = [...condition];
+    newCondition[index] = { ...newCondition[index], key };
+    updater.condition(newCondition);
   };
 
   const formatBody = () => {
@@ -484,9 +485,13 @@ const AddModal = (props: IProps) => {
                           value={item?.key}
                           onChange={(v) => {
                             if (v === 'http_code') {
-                              condition[index].operate = '>=';
+                              const newCondition = [...condition];
+                              newCondition[index] = { ...newCondition[index], operate: '>=' };
+                              updater.condition(newCondition);
                             } else {
-                              condition[index].operate = 'contains';
+                              const newCondition = [...condition];
+                              newCondition[index] = { ...newCondition[index], operate: 'contains' };
+                              updater.condition(newCondition);
                             }
                             setKey(index, v);
                           }}

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -153,7 +153,6 @@ const AddModal = (props: IProps) => {
   }, [modalVisible]);
 
   const deleteItem = (index: number) => {
-    // condition.splice(index, 1);
     const newCondition = produce(condition, (draft) => {
       draft.splice(index, 1);
     });

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -23,6 +23,7 @@ import constants from './constants';
 import './add-modal.scss';
 import { Input, Select, Radio, Tabs, Form, Tooltip, Button, InputNumber } from 'antd';
 import { FormInstance } from 'core/common/interface';
+import { produce } from 'immer';
 import { Down as IconDown, Up as IconUp, Help as IconHelp } from '@icon-park/react';
 
 const { Option } = Select;
@@ -152,8 +153,11 @@ const AddModal = (props: IProps) => {
   }, [modalVisible]);
 
   const deleteItem = (index: number) => {
-    condition.splice(index, 1);
-    updater.condition([...condition]);
+    // condition.splice(index, 1);
+    const newCondition = produce(condition, (draft) => {
+      draft.splice(index, 1);
+    });
+    updater.condition(newCondition);
   };
 
   const addItem = () => {
@@ -168,19 +172,23 @@ const AddModal = (props: IProps) => {
   };
 
   const setInputValue = (index: number, value: number | string) => {
-    condition[index].value = value;
-    updater.condition([...condition]);
+    const newCondition = produce(condition, (draft) => {
+      draft[index].value = value;
+    });
+    updater.condition(newCondition);
   };
 
   const setOperator = (index: number, operate: string) => {
-    const newCondition = [...condition];
-    newCondition[index] = { ...newCondition[index], operate };
+    const newCondition = produce(condition, (draft) => {
+      draft[index].operate = operate;
+    });
     updater.condition(newCondition);
   };
 
   const setKey = (index: number, key: string) => {
-    const newCondition = [...condition];
-    newCondition[index] = { ...newCondition[index], key };
+    const newCondition = produce(condition, (draft) => {
+      draft[index].key = key;
+    });
     updater.condition(newCondition);
   };
 
@@ -494,12 +502,14 @@ const AddModal = (props: IProps) => {
                           value={item?.key}
                           onChange={(v) => {
                             if (v === 'http_code') {
-                              const newCondition = [...condition];
-                              newCondition[index] = { ...newCondition[index], operate: '>=' };
+                              const newCondition = produce(condition, (draft) => {
+                                draft[index].operate = '>=';
+                              });
                               updater.condition(newCondition);
                             } else {
-                              const newCondition = [...condition];
-                              newCondition[index] = { ...newCondition[index], operate: 'contains' };
+                              const newCondition = produce(condition, (draft) => {
+                                draft[index].operate = 'operate';
+                              });
                               updater.condition(newCondition);
                             }
                             setKey(index, v);

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -35,7 +35,6 @@ const { HTTP_METHOD_LIST, TIME_LIMITS, OPERATORS, CONTAINS } = constants;
 interface IProps {
   formData: any;
   modalVisible: boolean;
-  mode: string;
   afterSubmit: (args?: any) => Promise<any>;
   toggleModal: (args?: any) => void;
 }
@@ -130,7 +129,7 @@ const convertFormData = (_formData?: Obj) => {
 };
 
 const AddModal = (props: IProps) => {
-  const { formData, modalVisible, afterSubmit, toggleModal, mode } = props;
+  const { formData, modalVisible, afterSubmit, toggleModal } = props;
   const { env, projectId } = routeInfoStore.useStore((s) => s.params);
   const { saveService, updateMetric } = monitorStatusStore.effects;
   const [form] = Form.useForm();
@@ -355,9 +354,6 @@ const AddModal = (props: IProps) => {
                 if (key === '2' && bodyType === noneType) {
                   if (headers['Content-Type'] === ('x-www-form-urlencoded' || 'text/plain' || 'application/json')) {
                     updater.headers({});
-                  } else {
-                    // eslint-disable-next-line no-useless-return
-                    return;
                   }
                 }
               }}
@@ -573,7 +569,7 @@ const AddModal = (props: IProps) => {
               </Button>
               <h4 className="mt-4 mb-3 text-sm">{i18n.t('msp:number of retries')}</h4>
               <InputNumber
-                parser={(formatRetry: string) => (/^\d+$/.test(formatRetry) ? formatRetry : formatRetry[0])}
+                precision={0}
                 value={retry}
                 min={0}
                 max={10}
@@ -606,7 +602,7 @@ const AddModal = (props: IProps) => {
       ref={formRef}
       className="h-4/5"
       width={620}
-      title={mode === 'add' ? i18n.t('msp:add monitoring') : i18n.t('msp:edit monitoring')}
+      title={formData ? i18n.t('msp:edit monitoring') : i18n.t('msp:add monitoring')}
       fieldsList={fieldsList}
       visible={modalVisible}
       formData={formData}

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
@@ -37,10 +37,11 @@ const Status = () => {
 
   const { type = 'All' } = query || {};
 
-  const [{ modalVisible, formData, filterType }, updater, update] = useUpdate({
+  const [{ modalVisible, formData, filterType, mode }, updater, update] = useUpdate({
     modalVisible: false,
     formData: null as MONITOR_STATUS.IMetricsBody | null,
     filterType: type,
+    mode: '',
   });
 
   useEffectOnce(() => {
@@ -54,12 +55,17 @@ const Status = () => {
     update({
       modalVisible: !modalVisible,
       formData: _data,
+      mode: 'add',
     });
   };
 
   const handleEdit = (e: any, _data: MONITOR_STATUS.IMetricsBody) => {
     e.stopPropagation();
-    toggleModal(_data);
+    update({
+      modalVisible: !modalVisible,
+      formData: _data,
+      mode: 'edit',
+    });
   };
 
   const handleDelete = (e: any, id: string) => {
@@ -258,6 +264,7 @@ const Status = () => {
         </span>
       </div>
       <AddModal
+        mode={mode}
         modalVisible={modalVisible}
         toggleModal={toggleModal}
         formData={formData}

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
@@ -37,7 +37,7 @@ const Status = () => {
 
   const { type = 'All' } = query || {};
 
-  const [{ modalVisible, formData, filterType, mode }, updater, update] = useUpdate({
+  const [{ modalVisible, formData, filterType }, updater, update] = useUpdate({
     modalVisible: false,
     formData: null as MONITOR_STATUS.IMetricsBody | null,
     filterType: type,

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
@@ -55,17 +55,12 @@ const Status = () => {
     update({
       modalVisible: !modalVisible,
       formData: _data,
-      mode: 'add',
     });
   };
 
   const handleEdit = (e: any, _data: MONITOR_STATUS.IMetricsBody) => {
     e.stopPropagation();
-    update({
-      modalVisible: !modalVisible,
-      formData: _data,
-      mode: 'edit',
-    });
+    toggleModal(_data);
   };
 
   const handleDelete = (e: any, id: string) => {
@@ -264,7 +259,6 @@ const Status = () => {
         </span>
       </div>
       <AddModal
-        mode={mode}
         modalVisible={modalVisible}
         toggleModal={toggleModal}
         formData={formData}

--- a/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/status.tsx
@@ -41,7 +41,6 @@ const Status = () => {
     modalVisible: false,
     formData: null as MONITOR_STATUS.IMetricsBody | null,
     filterType: type,
-    mode: '',
   });
 
   useEffectOnce(() => {


### PR DESCRIPTION
## What this PR does / why we need it:
1. Remove the background color of the Add button for exception checking 
2. Edit active monitoring, and the last saved value is displayed in the header 
3. In advanced settings, the number of retransmissions cannot be limited to decimal    
4. Edit the Title Modification of the active monitoring page 
5. Repair the monitoring details page and click Edit. The exception check in advanced settings cannot be edited

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    1. Remove the background color of the Add button for exception checking 2. Edit active monitoring, and the last saved value is displayed in the header 3. In advanced settings, the number of retransmissions cannot be limited to decimal    4.  Edit the Title Modification of the active monitoring page 5.  Repair the monitoring details page and click Edit. The exception check in advanced settings cannot be edited   |
| 🇨🇳 中文    |      1. 去掉异常检查下方添加按钮的底色 2. 编辑主动监控，header中显示上次保存的值 3. 高级设置中，重发次数限制不能输入小数  4. 编辑主动监控页面的标题修改 5. 修复监控详情页面，点击编辑，高级设置中异常检查无法编辑 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
relase/1.4

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

