### PR TITLE
fix(common): sorting style change back except for orgCenter

### DIFF
--- a/shell/app/antd-overwrite/table/index.scss
+++ b/shell/app/antd-overwrite/table/index.scss
@@ -7,37 +7,4 @@
       background-color: #e8e8e8;
     }
   }
-
-  .sorter-icon {
-    position: absolute;
-    right: 0;
-    top: 0;
-    display: flex;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    padding: 8px;
-    font-size: 14px;
-    color: $color-dark-4;
-    cursor: pointer;
-
-    &.ascend .reverse-icon {
-      color: $black;
-    }
-
-    &.descend i:not(.reverse-icon) {
-      color: $black;
-    }
-
-    .reverse-icon {
-      transform: rotate(180deg) translateY(-5px);
-    }
-
-    i {
-      transform: translateY(-4px);
-    }
-  }
-
-  &.show-ops .ant-table-cell-fix-right:after {
-    box-shadow: inset -10px 0 8px -8px rgb(0 0 0 / 15%);
-  }
 }

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -1,0 +1,40 @@
+.wrapped-table {
+  .table-more-ops {
+    padding: 3px;
+    border-radius: 3px;
+
+    &.ant-dropdown-open {
+      background-color: #e8e8e8;
+    }
+  }
+
+  .sorter-icon {
+    display: inline-flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    margin-left: 0.5rem;
+    font-size: 14px;
+    color: $color-dark-4;
+    cursor: pointer;
+
+    &.ascend .reverse-icon {
+      color: $black;
+    }
+
+    &.descend i:not(.reverse-icon) {
+      color: $black;
+    }
+
+    .reverse-icon {
+      transform: rotate(180deg) translateY(-5px);
+    }
+
+    i {
+      transform: translateY(-4px);
+    }
+  }
+
+  &.show-ops .ant-table-cell-fix-right:after {
+    box-shadow: inset -10px 0 8px -8px rgb(0 0 0 / 15%);
+  }
+}

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -1,4 +1,4 @@
-.wrapped-table {
+.erda-table {
   .table-more-ops {
     padding: 3px;
     border-radius: 3px;

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -135,7 +135,7 @@ function WrappedTable<T extends object = any>({ columns, rowClassName, actions, 
 
   return (
     <Table
-      className="wrapped-table"
+      className="erda-table"
       scroll={{ x: '100%' }}
       columns={[...newColumns, ...renderActions(actions)]}
       rowClassName={props.onRow ? `cursor-pointer ${rowClassName || ''}` : rowClassName}

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -14,6 +14,8 @@
 import React from 'react';
 import { Dropdown, Menu, Divider } from 'antd';
 import Table, { ColumnProps as AntdColumnProps, TableProps } from 'antd/es/table';
+import { SorterResult } from 'antd/es/table/interface';
+import { Icon as CustomIcon } from 'common';
 import i18n from 'i18n';
 
 import './index.scss';
@@ -67,15 +69,73 @@ interface IAction {
   onClick: () => void;
 }
 
-function WrappedTable<T extends object = any>({ columns, rowClassName, actions, className, ...props }: IProps<T>) {
-  const newColumns = columns?.map(({ ...args }: ColumnProps<T>) => ({
-    ellipsis: true,
-    ...args,
-  }));
+declare type TableAction = 'paginate' | 'sort' | 'filter';
+
+function WrappedTable<T extends object = any>({ columns, rowClassName, actions, ...props }: IProps<T>) {
+  const [sort, setSort] = React.useState<SorterResult<T>>({});
+  const menu = React.useCallback(
+    (column: ColumnProps<T>) => {
+      const { onChange = () => {}, pagination = {}, dataSource = [] } = props;
+      const sorter = {
+        column,
+        columnKey: column.dataIndex,
+        field: column.dataIndex,
+      } as SorterResult<T>;
+
+      const extra = {
+        currentDataSource: dataSource as T[],
+        action: 'sort' as TableAction,
+      };
+
+      const onSort = (order?: 'ascend' | 'descend') => {
+        setSort({ ...sorter, order });
+        onChange(pagination || {}, {}, { ...sorter, order }, extra);
+      };
+
+      return (
+        <Menu>
+          <Menu.Item key={'0'} onClick={() => onSort()}>
+            <span className="fake-link mr-1">取消排序</span>
+          </Menu.Item>
+          <Menu.Item key={'1'} onClick={() => onSort('ascend')}>
+            <span className="fake-link mr-1">升序</span>
+          </Menu.Item>
+          <Menu.Item key={'2'} onClick={() => onSort('descend')}>
+            <span className="fake-link mr-1">降序</span>
+          </Menu.Item>
+        </Menu>
+      );
+    },
+    [props],
+  );
+
+  const newColumns = columns?.map(({ width, sorter, title, ...args }: ColumnProps<T>) => {
+    let sortTitle;
+    if (sorter) {
+      sortTitle = (
+        <span className="flex items-center">
+          {title}
+          <Dropdown overlay={menu({ ...args, title })} align={{ offset: [0, 5] }}>
+            <span className={`sorter-icon ${(sort.columnKey === args.dataIndex && sort.order) || ''}`}>
+              <CustomIcon type="caret-down" className="reverse-icon" />
+              <CustomIcon type="caret-down" />
+            </span>
+          </Dropdown>
+        </span>
+      );
+    }
+
+    return {
+      title: sortTitle || title,
+      ellipsis: true,
+      onCell: () => ({ style: { maxWidth: width } }),
+      ...args,
+    };
+  });
 
   return (
     <Table
-      className={`wrapped-table ${className || ''}`}
+      className="wrapped-table"
       scroll={{ x: '100%' }}
       columns={[...newColumns, ...renderActions(actions)]}
       rowClassName={props.onRow ? `cursor-pointer ${rowClassName || ''}` : rowClassName}

--- a/shell/app/modules/org/pages/projects/project-list.tsx
+++ b/shell/app/modules/org/pages/projects/project-list.tsx
@@ -13,12 +13,13 @@
 
 import React from 'react';
 import i18n from 'i18n';
-import { Table, Spin, Button, Tooltip } from 'antd';
+import { Spin, Button } from 'antd';
+import Table from 'common/components/table';
 import { ColumnProps } from 'core/common/interface';
 import { goTo, fromNow } from 'common/utils';
 import { useUnmount } from 'react-use';
 import { ChartHistogramTwo as IconChartHistogramTwo } from '@icon-park/react';
-import { SearchTable, Ellipsis, Icon as CustomIcon } from 'common';
+import { SearchTable, Ellipsis } from 'common';
 import { PAGINATION } from 'app/constants';
 import projectStore from 'project/stores/project';
 import { useLoading } from 'core/stores/loading';

--- a/shell/app/styles/antd-extension.scss
+++ b/shell/app/styles/antd-extension.scss
@@ -172,11 +172,27 @@ body {
         }
       }
     }
+
+    .ant-table-column-sorters {
+      justify-content: flex-start;
+
+      .ant-table-column-title {
+        flex: 0 1 auto;
+      }
+
+      .ant-table-column-sorter {
+        margin-left: 0.5rem;
+      }
+    }
   }
 
   .ant-table-thead > tr > th {
     font-weight: 500;
     white-space: nowrap;
+
+    &::before {
+      background-color: transparent !important;
+    }
   }
 
   .dice-layout .pk-table-tbody > tr > td,


### PR DESCRIPTION
## What this PR does / why we need it:
Table sorting style change back except for orgCenter.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/139800403-8960158e-a8ae-41fe-8705-bc7b6f588f96.png)
->
![image](https://user-images.githubusercontent.com/82502479/139800158-3cc38a3b-4527-490e-85d3-4cde5b83c032.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

