### PR TITLE
fix(msp): compatible with old data, si redirects to transaction

### DIFF
--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -260,6 +260,8 @@ export enum pages {
   // 微服务-事务分析页
   mspServiceTransaction = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/service-list/{applicationId}/{serviceId}/{serviceName}/transaction',
 
+  mspServiceProcess = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/service-list/{applicationId}/{serviceId}/{serviceName}/process',
+
   // 服务分析页-追踪详情
   mspServiceTraceDetail = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/service-list/{applicationId}/{serviceId}/{serviceName}/transaction/trace-detail/{traceId}',
 

--- a/shell/app/modules/msp/pages/transfer/si.tsx
+++ b/shell/app/modules/msp/pages/transfer/si.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import React from 'react';
+import routeInfoStore from 'core/stores/route';
+import { goTo } from 'common/utils';
+
+enum TRANSACTION_TYPE {
+  web = 'http',
+  overview = 'http',
+  rpc = 'rpc',
+  cache = 'cache',
+  db = 'database',
+}
+
+const Transfer = () => {
+  React.useEffect(() => {
+    const [params] = routeInfoStore.getState((s) => [s.params]);
+    const { applicationId, runtimeName, serviceName, type, ...rest } = params;
+    const serviceId = window.encodeURIComponent(`${applicationId}_${runtimeName}_${serviceName}`);
+    let url = goTo.pages.mspServiceTransaction;
+    let query;
+    if (['nodejs', 'jvm'].includes(type)) {
+      url = goTo.pages.mspServiceProcess;
+      query = undefined;
+    } else {
+      query = { type: TRANSACTION_TYPE[type] };
+    }
+    goTo(url, {
+      ...rest,
+      applicationId,
+      serviceName,
+      serviceId,
+      query,
+      replace: true,
+    });
+  }, []);
+  return null;
+};
+export default Transfer;

--- a/shell/app/modules/msp/router.ts
+++ b/shell/app/modules/msp/router.ts
@@ -49,6 +49,11 @@ function getMspRouter(): RouteConfigItem[] {
           mark: 'mspDetail',
           routes: [
             {
+              // compatible with old data, si redirects to transaction
+              path: 'topology/:terminusKey/:applicationId/:runtimeName/:serviceName/si/:type',
+              getComp: (cb) => cb(import('msp/pages/transfer/si')),
+            },
+            {
               path: 'synopsis',
               routes: [getEnvOverViewRouter()],
             },


### PR DESCRIPTION
## What this PR does / why we need it:

compatible with old data, si redirects to transaction 

**[fix(msp): replace monitor alarm page](https://github.com/erda-project/erda-ui-enterprise/pull/151)**

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)

release/1.4
release/1.3-hotfix

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

