### PR TITLE
refactor: rename copy to copyButton component in config-page

### DIFF
--- a/shell/app/config-page/components/copy-button/copy-button.mock.ts
+++ b/shell/app/config-page/components/copy-button/copy-button.mock.ts
@@ -11,11 +11,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_COPY.Spec = {
-  type: 'Copy',
+export const mockData: CP_COPY_BUTTON.Spec = {
+  type: 'CopyButton',
   props: {
     copyText: '复制的内容',
     copyTip: '复制xx成功中的 xx',
+    buttonText: '复制',
     renderType: 'icon', // or button
   },
 };

--- a/shell/app/config-page/components/copy-button/copy-button.spec.d.ts
+++ b/shell/app/config-page/components/copy-button/copy-button.spec.d.ts
@@ -11,20 +11,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-declare namespace CP_COPY {
+declare namespace CP_COPY_BUTTON {
   interface Spec {
-    type: 'Copy';
+    type: 'CopyButton';
     props?: IProps;
   }
 
   interface IProps {
     copyText: string;
     copyTip?: string;
-    disabled?: boolean;
+    buttonText?: string;
     renderType?: 'button' | 'icon';
   }
 
-  type Props = MakeProps<Spec> & {
-    children: React.ReactChild | React.ReactChild[];
-  };
+  type Props = MakeProps<Spec>;
 }

--- a/shell/app/config-page/components/copy-button/copy-button.tsx
+++ b/shell/app/config-page/components/copy-button/copy-button.tsx
@@ -18,17 +18,15 @@ import React from 'react';
 import { uniqueId } from 'lodash';
 import { Copy as IconCopy } from '@icon-park/react';
 
-const Copy = (props: CP_COPY.Props) => {
-  const { props: configProps, children } = props;
-  const { copyText, disabled, copyTip, renderType = 'button' } = configProps || {};
+const CopyButton = (props: CP_COPY_BUTTON.Props) => {
+  const { props: configProps } = props;
+  const { copyText, copyTip, buttonText, renderType = 'button' } = configProps || {};
 
   const idRef = React.useRef(uniqueId('cp-copy-'));
 
-  if (disabled) return children;
-
-  const defaultChildren =
+  const children =
     renderType === 'button' ? (
-      <Button type="primary">{i18n.t('copy')}</Button>
+      <Button type="primary">{buttonText || i18n.t('copy')}</Button>
     ) : (
       <IconCopy className="hover:text-primary" size={16} />
     );
@@ -36,11 +34,11 @@ const Copy = (props: CP_COPY.Props) => {
   return (
     <>
       <span className={`${idRef.current} cursor-copy`} data-clipboard-tip={copyTip} data-clipboard-text={copyText}>
-        {children ?? defaultChildren}
+        {children}
       </span>
       <CopyComp selector={idRef.current} />
     </>
   );
 };
 
-export default Copy;
+export default CopyButton;

--- a/shell/app/config-page/components/index.tsx
+++ b/shell/app/config-page/components/index.tsx
@@ -61,7 +61,7 @@ import DatePicker from './date-picker/date-picker';
 import Dropdown from './dropdown/dropdown';
 import MarkdownEditor from './markdown-editor/markdown-editor';
 import { CardContainer, ChartContainer } from './card-container/card-container';
-import Copy from './copy/copy';
+import CopyButton from './copy-button/copy-button';
 
 export const containerMap = {
   Alert,
@@ -116,5 +116,5 @@ export const containerMap = {
   MarkdownEditor,
   CardContainer,
   ChartContainer,
-  Copy,
+  CopyButton,
 };


### PR DESCRIPTION
## What this PR does / why we need it:
Copy wrap another component and triggered by that component, this is confused for backend developer.
Change to standalone copyButton component.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

