### PR TITLE
fix(common): project quota edit optimization

### DIFF
--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -59,8 +59,9 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
   };
 
   handleSubmit = (values: object) => {
-    this.props.updateInfo(values);
-    this.toggleModal();
+    return Promise.resolve(this.props.updateInfo(values)).then(() => {
+      this.toggleModal();
+    });
   };
 
   getReadonlyInfo = () => {

--- a/shell/app/modules/project/pages/settings/components/project-info.tsx
+++ b/shell/app/modules/project/pages/settings/components/project-info.tsx
@@ -67,7 +67,7 @@ export default ({ canEdit, canDelete, canEditQuota, showQuotaTip }: IProps) => {
         });
     }
 
-    updateProject({ ...values, isPublic: isPublic === 'true' }).then(() => {
+    return updateProject({ ...values, isPublic: isPublic === 'true' }).then(() => {
       updateTenantProject({
         id: `${info.id}`,
         name: values.name,


### PR DESCRIPTION
## What this PR does / why we need it:
Project quota edit optimization.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Do not close popover when editing fails when edit project quota. |
| 🇨🇳 中文    | 当编辑项目quota时，编辑失败不关闭弹窗。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/bug?id=242421&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMTQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=541&type=BUG

