### PR TITLE
Fix: revert import overwrite antd component style

### DIFF
--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -187,7 +187,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          {/* <MessageCenter show={showMessage} /> */}
+          <MessageCenter show={showMessage} />
         </Shell>
         <DiceLicense />
       </div>

--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -187,7 +187,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          <MessageCenter show={showMessage} />
+          {/* <MessageCenter show={showMessage} /> */}
         </Shell>
         <DiceLicense />
       </div>

--- a/shell/babel.config.js
+++ b/shell/babel.config.js
@@ -19,6 +19,8 @@ const overwriteMap = {
 };
 
 const overwriteCssMap = {
+  table: false,
+  select: false,
   tag: false,
   'range-picker': false,
 };


### PR DESCRIPTION
## What this PR does / why we need it:
Revert overwrite style config, overwrite antd component do not need import style.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

