### PR TITLE
fix(msp): When actively monitoring and modifying the format of the body, the window will pop up only when there is data

### DIFF
--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -414,15 +414,19 @@ const AddModal = (props: IProps) => {
                 <Radio.Group
                   onChange={(e) => {
                     if (e.target.value === noneType) {
-                      Modal.confirm({
-                        title: i18n.t('confirm to switch Body type?'),
-                        onOk() {
-                          updater.bodyType(e.target.value);
-                        },
-                      });
+                      if (body.content.length > 0) {
+                        Modal.confirm({
+                          title: i18n.t('confirm to switch Body type?'),
+                          onOk() {
+                            updater.bodyType(e.target.value);
+                          },
+                        });
+                      } else {
+                        updater.bodyType(e.target.value);
+                      }
                     }
                     if (e.target.value === formType) {
-                      if (bodyType !== noneType) {
+                      if (bodyType !== noneType && body.content !== '') {
                         Modal.confirm({
                           title: i18n.t('confirm to switch Body type?'),
                           onOk() {
@@ -436,7 +440,7 @@ const AddModal = (props: IProps) => {
                       }
                     }
                     if (e.target.value === raw) {
-                      if (bodyType !== noneType) {
+                      if (bodyType !== noneType && body.content.length > 0) {
                         Modal.confirm({
                           title: i18n.t('confirm to switch Body type?'),
                           onOk() {


### PR DESCRIPTION
## What this PR does / why we need it:
When actively monitoring and modifying the format of the body, the window will pop up only when there is data

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

