### PR TITLE
fix: fix resource rank icon style

### DIFF
--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -49,7 +49,7 @@
   }
 
   .bg-hover:hover {
-    background-color: #efeef0;
+    background-color: $color-bg-gray;
     cursor: pointer;
   }
 

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -255,7 +255,7 @@ function WrappedTable<T extends object = any>({
                     className="leading-none"
                   />
                   {Object.keys(args).includes('subTitle') && (
-                    <span className="erda-table-td-subTitle">{subTitleText || '-'}</span>
+                    <span className="erda-table-td-subTitle truncate">{subTitleText || '-'}</span>
                   )}
                 </div>
               </div>

--- a/shell/app/modules/dcos/pages/cluster-dashboard/resources-summary.scss
+++ b/shell/app/modules/dcos/pages/cluster-dashboard/resources-summary.scss
@@ -1,0 +1,9 @@
+.resource-summary-op-icon {
+  cursor: pointer;
+  color: $color-dark-4;
+
+  &:hover {
+    background-color: $color-bg-gray;
+    color: $color-dark-8;
+  }
+}

--- a/shell/app/modules/dcos/pages/cluster-dashboard/resources-summary.tsx
+++ b/shell/app/modules/dcos/pages/cluster-dashboard/resources-summary.tsx
@@ -26,6 +26,7 @@ import clusterStore from 'cmp/stores/cluster';
 import { statusColorMap } from 'app/config-page/utils';
 import i18n, { isZh } from 'i18n';
 import { ColumnsType } from 'antd/es/table';
+import './resources-summary.scss';
 
 const defaultGaugeData = {
   cpu: {
@@ -424,10 +425,10 @@ export const ResourceTable = React.memo(() => {
               }}
             />
             <ErdaIcon
-              className="cursor-pointer px-3"
+              className="ml-3 resource-summary-op-icon p-2"
               onClick={() => updater.showCalculate(true)}
               type="calculator-one"
-              color="sub"
+              color="currentColor"
             />
           </div>
         }

--- a/shell/app/styles/_color.scss
+++ b/shell/app/styles/_color.scss
@@ -113,6 +113,7 @@ $color-table-color: #837d90;
 $color-table-text-highlight: #7c53db;
 $color-table-bg-hover: #f7f7f8;
 $color-table-head-bg: #fbfbfb;
+$color-bg-gray: #efeef0;
 
 // Color Filter
 $color-input-bg: #efeef0;


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix resource rank icon style

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
❎ N
![image](https://user-images.githubusercontent.com/15364706/140917443-ba6425b7-3801-42c3-a13b-94c8e8625d75.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

