### PR TITLE
fix(msp): The active monitoring page assigns the URL attribute in the config returned by the interface to the URL

### DIFF
--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -664,6 +664,7 @@ const AddModal = (props: IProps) => {
       },
     },
   ];
+  const data = formData && { ...formData, url: formData?.config?.url || '' };
   return (
     <FormModal
       ref={formRef}
@@ -672,7 +673,7 @@ const AddModal = (props: IProps) => {
       title={formData ? i18n.t('msp:edit monitoring') : i18n.t('msp:add monitoring')}
       fieldsList={fieldsList}
       visible={modalVisible}
-      formData={formData}
+      formData={data}
       onOk={handleSubmit}
       onCancel={toggleModal}
       modalProps={{


### PR DESCRIPTION
## What this PR does / why we need it:
The active monitoring page assigns the URL attribute in the config returned by the interface to the URL

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

