### PR TITLE
Hotfix/add iteration filter in manual test plan

### DIFF
--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -187,7 +187,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          {/* <MessageCenter show={showMessage} /> */}
+          <MessageCenter show={showMessage} />
         </Shell>
         <DiceLicense />
       </div>

--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -187,7 +187,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          <MessageCenter show={showMessage} />
+          {/* <MessageCenter show={showMessage} /> */}
         </Shell>
         <DiceLicense />
       </div>

--- a/shell/app/modules/project/pages/test-plan/plan-modal.tsx
+++ b/shell/app/modules/project/pages/test-plan/plan-modal.tsx
@@ -20,6 +20,7 @@ import testPlanStore from 'project/stores/test-plan';
 import iterationStore from 'project/stores/iteration';
 import { FormModalList } from 'app/interface/common';
 import { useLoading } from 'core/stores/loading';
+import { useMount } from 'react-use';
 
 interface IProps {
   visible: boolean;
@@ -58,7 +59,7 @@ const TestPlanModal = (props: IProps) => {
     }
   };
 
-  React.useEffect(() => {
+  useMount(() => {
     if (!iterationList.length && !loadingIterationList) {
       iterationStore.effects.getIterations({
         pageNo: 1,
@@ -67,7 +68,7 @@ const TestPlanModal = (props: IProps) => {
         withoutIssueSummary: true,
       });
     }
-  }, [iterationList.length, params.projectId, loadingIterationList]);
+  });
 
   React.useEffect(() => {
     visible && testPlanId && getTestPlanItem(testPlanId);

--- a/shell/app/modules/project/pages/test-plan/plan-modal.tsx
+++ b/shell/app/modules/project/pages/test-plan/plan-modal.tsx
@@ -19,6 +19,7 @@ import routeInfoStore from 'core/stores/route';
 import testPlanStore from 'project/stores/test-plan';
 import iterationStore from 'project/stores/iteration';
 import { FormModalList } from 'app/interface/common';
+import { useLoading } from 'core/stores/loading';
 
 interface IProps {
   visible: boolean;
@@ -37,6 +38,7 @@ const TestPlanModal = (props: IProps) => {
   const iterationList = iterationStore.useStore((s) => s.iterationList);
   const { getTestPlanItem, addTestPlan, updateTestPlan } = testPlanStore.effects;
   const { cleanTestPlan } = testPlanStore.reducers;
+  const [loadingIterationList] = useLoading(iterationStore, ['getIterations']);
 
   const handleOk = (values: any) => {
     const copy = { ...values };
@@ -57,7 +59,7 @@ const TestPlanModal = (props: IProps) => {
   };
 
   React.useEffect(() => {
-    if (!iterationList.length) {
+    if (!iterationList.length && !loadingIterationList) {
       iterationStore.effects.getIterations({
         pageNo: 1,
         pageSize: 100,
@@ -65,7 +67,7 @@ const TestPlanModal = (props: IProps) => {
         withoutIssueSummary: true,
       });
     }
-  }, [iterationList.length, params.projectId]);
+  }, [iterationList.length, params.projectId, loadingIterationList]);
 
   React.useEffect(() => {
     visible && testPlanId && getTestPlanItem(testPlanId);

--- a/shell/app/modules/project/pages/test-plan/test-plan.tsx
+++ b/shell/app/modules/project/pages/test-plan/test-plan.tsx
@@ -249,7 +249,7 @@ const TestPlan = () => {
       },
       {
         type: Select,
-        name: 'iterationName',
+        name: 'iterationID',
         customProps: {
           options: iterationList.map(({ id, title }) => (
             <Option key={id} value={id}>
@@ -289,7 +289,7 @@ const TestPlan = () => {
         },
       },
     ],
-    [],
+    [iterationList],
   );
 
   return (

--- a/shell/app/modules/project/pages/test-plan/test-plan.tsx
+++ b/shell/app/modules/project/pages/test-plan/test-plan.tsx
@@ -20,6 +20,7 @@ import { isEmpty } from 'lodash';
 import { useEffectOnce } from 'react-use';
 import { useLoading } from 'core/stores/loading';
 import testPlanStore from 'project/stores/test-plan';
+import iterationStore from 'project/stores/iteration';
 import i18n from 'i18n';
 import { ColumnProps } from 'core/common/interface';
 import './test-plan.scss';
@@ -48,6 +49,7 @@ const TestPlan = () => {
   const [filterObj, setFilterObj] = React.useState<Obj>({ isArchived: 'false' });
   const [page, planList] = testPlanStore.useStore((s) => [s.planPaging, s.planList]);
   const [isFetching] = useLoading(testPlanStore, ['getPlanList']);
+  const iterationList = iterationStore.useStore((s) => s.iterationList);
 
   const updateModalProp = (a: object) => {
     setModalProp({
@@ -242,6 +244,20 @@ const TestPlan = () => {
           )),
           allowClear: true,
           placeholder: i18n.t('dop:select status'),
+          mode: 'multiple',
+        },
+      },
+      {
+        type: Select,
+        name: 'iterationName',
+        customProps: {
+          options: iterationList.map(({ id, title }) => (
+            <Option key={id} value={id}>
+              {title}
+            </Option>
+          )),
+          allowClear: true,
+          placeholder: i18n.t('dop:owned iteration'),
           mode: 'multiple',
         },
       },


### PR DESCRIPTION
## What this PR does / why we need it:
Support filter manual test plan by iteration

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/141231175-0498a06f-fb57-47af-9aad-4884e0abcd07.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | add owned iteration filter in manual test plan |
| 🇨🇳 中文    | 手动测试计划添加按所属迭代搜索 |


## Does this PR need be patched to older version?
No



## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

