### PR TITLE
fix(common): fix post put api carry extra query string issue

### DIFF
--- a/core/src/service/index.ts
+++ b/core/src/service/index.ts
@@ -100,6 +100,7 @@ export const genRequest = function <T extends FN>(apiConfig: APIConfig) {
     const { $options, $headers, $body, ...rest } = params || {};
     const { bodyOrQuery, pathParams } = extractPathParams(path, rest);
     const { isDownload, uploadFileKey } = $options || {};
+    let getParams = bodyOrQuery;
     if ('pageNo' in bodyOrQuery && !('pageSize' in bodyOrQuery)) {
       bodyOrQuery.pageSize = DEFAULT_PAGESIZE;
     }
@@ -108,6 +109,7 @@ export const genRequest = function <T extends FN>(apiConfig: APIConfig) {
       if (Object.keys(bodyOrQuery).length) {
         bodyData = uploadFileKey ? bodyOrQuery[uploadFileKey] : bodyOrQuery;
       }
+      getParams = {};
     } else if (method === 'delete') {
       bodyData = $body;
     }
@@ -115,7 +117,7 @@ export const genRequest = function <T extends FN>(apiConfig: APIConfig) {
       method: method as any,
       url: generatePath(path, pathParams),
       headers: headers ?? $headers,
-      params: bodyOrQuery,
+      params: getParams,
       paramsSerializer: (p: Obj<string>) => qs.stringify(p),
       responseType: isDownload ? 'blob' : 'json',
       data: bodyData,


### PR DESCRIPTION
## What this PR does / why we need it:
currently post & put api will carry body as query string which is incorrect.

![image](https://user-images.githubusercontent.com/5175455/141274673-1166139a-788c-46b2-ab5a-4d3ca6bb7997.png)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

