### PR TITLE
fix(common): project quota are displayed in different order

### DIFF
--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -41,6 +41,8 @@ const reloadHeadInfo = () => {
   selectorKey += 1;
 };
 
+const workSpaceList = ['DEV', 'TEST', 'STAGING', 'PROD'];
+
 const resourceMap = {
   DEV: i18n.t('dev environment'),
   TEST: i18n.t('test environment'),
@@ -243,7 +245,7 @@ const Info = () => {
             }
           >
             {info.resourceConfig
-              ? Object.keys(info.resourceConfig).map((key: string) => {
+              ? workSpaceList.map((key: string) => {
                   const resource = info.resourceConfig[key];
                   return (
                     <div className="erda-panel-list">


### PR DESCRIPTION
## What this PR does / why we need it:
In different page, project quota are displayed in different order.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/141397540-55afc566-c38b-43a2-a6de-9e89ca7c2019.png)
->
![image](https://user-images.githubusercontent.com/82502479/141397572-3a799d02-71ee-442c-8268-024abe8d8a5d.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=247656&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG

