### PR TITLE
fix: the project owner view app doesn't have permission

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -824,6 +824,7 @@
     "set successfully": "set successfully",
     "set tags": "set tags",
     "setting": "setting",
+    "setting permissions": "setting permissions",
     "silence period policy": "silence period policy",
     "site message": "site message",
     "skip": "skip",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -824,6 +824,7 @@
     "set successfully": "设置成功",
     "set tags": "设置标签",
     "setting": "设置",
+    "setting permissions": "设置权限",
     "silence period policy": "沉默周期策略",
     "site message": "站内信",
     "skip": "跳过",

--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -165,6 +165,7 @@ export enum pages {
   projectTicket = '/{orgName}/dop/projects/{projectId}/ticket',
   projectTestReport = '/{orgName}/dop/projects/{projectId}/test-report',
   projectTestReportCreate = '/{orgName}/dop/projects/{projectId}/test-report/create',
+  projectMemberManagement = '/{orgName}/dop/projects/{projectId}/setting?tabKey=projectMember',
 
   // app
   app = '/{orgName}/dop/projects/{projectId}/apps/{appId}',

--- a/shell/app/layout/common/error-page.scss
+++ b/shell/app/layout/common/error-page.scss
@@ -12,8 +12,7 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      align-items: center;
-      height: 100px;
+      min-height: 100px;
       font-size: 30px;
       line-height: 30px;
     }

--- a/shell/app/layout/common/error-page.tsx
+++ b/shell/app/layout/common/error-page.tsx
@@ -25,25 +25,50 @@ import './error-page.scss';
 const NoAuth = () => {
   const authContact = userStore.useStore((s) => s.authContact);
   const permProject = permStore.useStore((s) => s.project);
+  const permApp = permStore.useStore((s) => s.app);
+  // permProject or permApp is newPermObj, the type is not inconsistent with state[scope]
   const hasCurProject = permProject.access;
+  // isProjectOwner: is the owner of the current project
+  const isProjectOwner = permProject?.roles?.includes('Owner');
+  // when the user has no auth enter the current project, back-end will return projectName
+  const { projectName: noAuthProjectName } = permProject?.scopeInfo || {};
+  // when the user has no auth enter the current app, back-end will return projectName and appName
+  const { appName, projectName } = permApp?.scopeInfo || {};
 
   return (
     <div className="no-auth-page basic-error-page">
       <div className="info">
         <CustomIcon type="no-auth" color />
         <div className="desc">
-          <span>{i18n.t('layout:sorry, you do not have access to this page')}</span>
+          <div>
+            <span>{i18n.t('layout:sorry, you do not have access to this page')} </span>
+            {noAuthProjectName && <span>({noAuthProjectName || ''})</span>}
+            {appName && (
+              <span>
+                ({projectName || ''}/{appName || ''})
+              </span>
+            )}
+          </div>
           {authContact ? (
             <>
               <span className="contact-info">
                 {i18n.t('please contact')} {authContact}
               </span>
               {hasCurProject ? (
-                <Link to={goTo.resolve.projectApps()}>
-                  <Button size="large" type="primary">
-                    {i18n.t('layout:back to application list')}
-                  </Button>
-                </Link>
+                <div>
+                  {isProjectOwner && (
+                    <Link to={goTo.resolve.projectMemberManagement()} className="mr-2">
+                      <Button size="large" type="primary">
+                        {i18n.t('setting permissions')}
+                      </Button>
+                    </Link>
+                  )}
+                  <Link to={goTo.resolve.projectApps()}>
+                    <Button size="large" type={`${isProjectOwner ? 'ghost' : 'primary'}`}>
+                      {i18n.t('layout:back to application list')}
+                    </Button>
+                  </Link>
+                </div>
               ) : (
                 <Link to={goTo.resolve.dopRoot()}>
                   <Button size="large" type="primary">
@@ -53,11 +78,20 @@ const NoAuth = () => {
               )}
             </>
           ) : (
-            <Link to={goTo.resolve.orgRoot()}>
-              <Button size="large" type="primary">
-                {i18n.t('back to home')}
-              </Button>
-            </Link>
+            <div>
+              {isProjectOwner && (
+                <Link to={goTo.resolve.projectMemberManagement()} className="mr-2">
+                  <Button size="large" type="primary">
+                    {i18n.t('setting permissions')}
+                  </Button>
+                </Link>
+              )}
+              <Link to={goTo.resolve.orgRoot()}>
+                <Button size="large" type={`${isProjectOwner ? 'ghost' : 'primary'}`}>
+                  {i18n.t('back to home')}
+                </Button>
+              </Link>
+            </div>
           )}
         </div>
       </div>

--- a/shell/app/user/types/user.d.ts
+++ b/shell/app/user/types/user.d.ts
@@ -19,7 +19,14 @@ interface IPermResponseData {
   contactsWhenNoPermission: null | string[];
   permissionList: IPerm[];
   resourceRoleList?: IPerm[];
+  scopeInfo?: IScopeInfo;
 }
+
+interface IScopeInfo {
+  projectName?: string;
+  appName?: string;
+}
+
 interface IPerm {
   resource: string;
   action: string;


### PR DESCRIPTION


## What this PR does / why we need it:
1. jump to project member management when the project owner view app doesn’t have permission to
2. According to design recommendations，align content to the left 
  before:
![image](https://user-images.githubusercontent.com/30014895/141434731-616ad619-c95d-4f52-951c-e83a9df096c1.png)

    current:
![image](https://user-images.githubusercontent.com/30014895/141434650-27e9ceef-b074-4c47-8644-556a495380b3.png)



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Project owner can jump to project member management settings when don’t have the app permission |
| 🇨🇳 中文    | 项目管理员在无应用权限时可以跳转至项目成员管理进行设置 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[项目管理员无法给自己赋应用的权限，因为页面无法获取应用名](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D)
