### PR TITLE
Fix the value problem of the URL of the event of losing focus in the editing and monitoring params of the active monitoring page

### DIFF
--- a/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
+++ b/shell/app/modules/msp/monitor/status-insight/pages/status/add-modal.tsx
@@ -212,9 +212,11 @@ const AddModal = (props: IProps) => {
   };
 
   const setUrlParams = (queryConfig: Obj) => {
-    if (url) {
-      formRef.current?.setFieldsValue({ config: { url: `${url.split('?')[0]}?${qs.stringify(queryConfig)}` } });
-    }
+    formRef.current?.setFieldsValue({
+      config: {
+        url: `${formRef.current?.getFieldValue(['config', 'url']).split('?')[0]}?${qs.stringify(queryConfig)}`,
+      },
+    });
   };
 
   const handleSubmit = (_data: MONITOR_STATUS.IMetricsBody) => {


### PR DESCRIPTION

## What this PR does / why we need it:
Fix the value problem of the URL of the event of losing focus in the editing and monitoring params of the active monitoring page


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4
release/1.4.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

