### PR TITLE
fix: alarm compatible with old data

### DIFF
--- a/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
@@ -242,7 +242,13 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
               : undefined,
             silencePolicy: notifies ? `${state.editingFormRule.notifies[0].silence.policy}` : SilencePeriodType.FIXED,
           });
-          updater.editingRules(map(rules, (rule) => ({ key: uniqueId(), ...rule })));
+          updater.editingRules(
+            map(rules, (rule) => ({
+              key: uniqueId(),
+              ...rule,
+              level: rule?.level === 'WARNING' ? undefined : rule?.level,
+            })),
+          );
           updater.activeGroupId(notifies[0].groupId);
 
           updater.triggerCondition(
@@ -265,7 +271,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
             (notifies || []).map((x) => ({
               id: uniqueId(),
               groupId: x.groupId,
-              level: x.level ? x.level?.split(',') : 'Breakdown',
+              level: x.level ? x.level?.split(',') : undefined,
               groupType: x.groupType?.split(','),
               groupTypeOptions:
                 (notifyChannelMap[x.notifyGroup.targets?.[0].type] || []).map((y) => ({
@@ -297,7 +303,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
         },
       ]);
     }
-  }, []);
+  }, [alertTriggerConditionsContent]);
 
   React.useEffect(() => {
     if (alertTriggerConditions?.length) {

--- a/shell/app/modules/org/pages/setting/notice-channel.tsx
+++ b/shell/app/modules/org/pages/setting/notice-channel.tsx
@@ -408,7 +408,10 @@ const NotifyChannel = () => {
     const { editChannel, deleteChannel, enableChannel } = {
       editChannel: {
         title: i18n.t('edit'),
-        onClick: () => handleEdit(record.id),
+        onClick: () => {
+          handleEdit(record.id);
+          updater.passwordVisible(false);
+        },
       },
       deleteChannel: {
         title: i18n.t('delete'),

--- a/shell/app/modules/org/pages/setting/notice-channel.tsx
+++ b/shell/app/modules/org/pages/setting/notice-channel.tsx
@@ -290,7 +290,7 @@ const NotifyChannel = () => {
       required: true,
       itemProps: {
         placeholder: `${i18n.t('please input')} AccessKeySecret`,
-        type: passwordVisible ? 'text' : 'password',
+        type: isEditing ? (passwordVisible ? 'text' : 'password') : 'text',
         autoComplete: 'off',
         addonAfter: passwordVisible ? (
           <IconPreviewOpen onClick={() => updater.passwordVisible(false)} />

--- a/shell/app/modules/org/pages/setting/notice-channel.tsx
+++ b/shell/app/modules/org/pages/setting/notice-channel.tsx
@@ -281,6 +281,7 @@ const NotifyChannel = () => {
       itemProps: {
         maxLength: 50,
         placeholder: `${i18n.t('please input')} AccessKeyId`,
+        autoComplete: 'off',
       },
     },
     {
@@ -290,6 +291,7 @@ const NotifyChannel = () => {
       itemProps: {
         placeholder: `${i18n.t('please input')} AccessKeySecret`,
         type: passwordVisible ? 'text' : 'password',
+        autoComplete: 'off',
         addonAfter: passwordVisible ? (
           <IconPreviewOpen onClick={() => updater.passwordVisible(false)} />
         ) : (

--- a/shell/app/modules/org/pages/setting/notice-channel.tsx
+++ b/shell/app/modules/org/pages/setting/notice-channel.tsx
@@ -290,7 +290,7 @@ const NotifyChannel = () => {
       required: true,
       itemProps: {
         placeholder: `${i18n.t('please input')} AccessKeySecret`,
-        type: isEditing ? (passwordVisible ? 'text' : 'password') : 'text',
+        type: passwordVisible ? 'text' : 'password',
         autoComplete: 'off',
         addonAfter: passwordVisible ? (
           <IconPreviewOpen onClick={() => updater.passwordVisible(false)} />
@@ -451,6 +451,7 @@ const NotifyChannel = () => {
           className="absolute right-3 hover-active add-channel-button"
           onClick={() => {
             handleAdd();
+            updater.passwordVisible(true);
           }}
         >
           <Button type="primary">{i18n.t('new notification channel')}</Button>


### PR DESCRIPTION
## What this PR does / why we need it:
1. compatible with old data
2. should not auto fill the AccessKeyId and AccessKeySecret 

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【告警】旧的数据升级后，告警规则、通知对象中的告警基级别显示有错](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D)

[【告警】进入告警列表页面，第一次打开告警规则的编辑页面，过滤规则的值字段不能编辑](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D)
