### PR TITLE
fix: upgrade dashboard to v2.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.0
+      '@erda-ui/dashboard-configurator': 2.0.1
       '@erda-ui/react-markdown-editor-lite': ^1.4.6
       '@icon-park/react': ^1.3.3
       '@module-federation/automatic-vendor-federation': ^1.2.1
@@ -468,7 +468,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.0_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.1_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.6_react@16.14.0
       '@icon-park/react': 1.3.3_react-dom@16.14.0+react@16.14.0
       ace-builds: 1.4.12
@@ -5707,8 +5707,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.0_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-4XJILsfLQjzDmjXizvxDusCnMJ5dc3hSWi283GAT9u+DRCSOBRq1uUckl+e7YUalKZqVsB7J4OpxBymlYe8WuQ==}
+  /@erda-ui/dashboard-configurator/2.0.1_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-xn9ztmw0MP4iAYyIC6PMID1+ROR7VqpNfddiUQv+BQ94N5oihrab4uhuHF01LsczJwn7I/hhAd4naZL32qj1aQ==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -8798,7 +8798,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.7.0_6256c4c7530243cf24a1ff746ee9d921
+      webpack-cli: 4.7.0_ba633acb38016457254722d87c7e8964
     dev: true
 
   /@webpack-cli/serve/1.4.0_webpack-cli@4.7.0:
@@ -8810,7 +8810,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.7.0_6256c4c7530243cf24a1ff746ee9d921
+      webpack-cli: 4.7.0_ba633acb38016457254722d87c7e8964
     dev: true
 
   /@xobotyi/scrollbar-width/1.9.5:

--- a/shell/app/modules/msp/env-overview/service-list/pages/service-list-dashboard.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/service-list-dashboard.tsx
@@ -39,7 +39,7 @@ const ServiceListDashboard: React.FC<IProps> = ({ timeSpan: times, dashboardId, 
   const [serviceId, serviceName] = serviceAnalyticsStore.useStore((s) => [s.serviceId, s.serviceName]);
 
   const globalVariable = useMemo(() => {
-    const { terminusKey } = params;
+    const { terminusKey, applicationId } = params;
     const { startTimeMs, endTimeMs } = timeSpan;
     return {
       terminusKey,
@@ -47,6 +47,7 @@ const ServiceListDashboard: React.FC<IProps> = ({ timeSpan: times, dashboardId, 
       serviceId: window.decodeURIComponent(serviceId),
       startTime: startTimeMs,
       endTime: endTimeMs,
+      applicationId,
       ...extraGlobalVariable,
     };
   }, [params, timeSpan, serviceName, serviceId, extraGlobalVariable]);

--- a/shell/package.json
+++ b/shell/package.json
@@ -47,7 +47,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.0",
+    "@erda-ui/dashboard-configurator": "2.0.1",
     "@erda-ui/react-markdown-editor-lite": "^1.4.6",
     "@icon-park/react": "^1.3.3",
     "ace-builds": "^1.4.7",


### PR DESCRIPTION
## What this PR does / why we need it:
1. display chart in overview of service
2. display chart in chart editor
the same as [fix: upgrade dashboard to v2.0.1 #2007](https://github.com/erda-project/erda-ui/pull/2007/files)

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【服务分析】使用ES存储trace/error和log数据后，服务概览中有图表显示有问题](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D)

[【运维大盘】使用ES存储trace/error和log数据后，旧的大盘数显示不出来](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D)
