### PR TITLE
remove cmp related code in cli

### DIFF
--- a/cli/lib/build.ts
+++ b/cli/lib/build.ts
@@ -193,7 +193,7 @@ export default async (options: {
     // get required build list
     const rebuildList = await getBuildList();
 
-    // reminder to copy cmp/msp code from external
+    // reminder to copy msp code from external
     await copyExternalCode(rebuildList);
 
     await buildModules(enableSourceMap, rebuildList);

--- a/cli/lib/check-build-status.ts
+++ b/cli/lib/check-build-status.ts
@@ -72,7 +72,7 @@ const checkBuildStatus = async () => {
           logWarn('In case shell has part of code maintained under enterprise, need to check enterprise code base');
           nextSha = `${headSha}/${externalHeadSha}`;
           const externalDiff = await getGitDiffFiles(prevExternalSha, externalHeadSha, enterprisePath);
-          if (new RegExp('^cmp/', 'gm').test(externalDiff) || new RegExp('^msp/', 'gm').test(externalDiff)) {
+          if (new RegExp('^msp/', 'gm').test(externalDiff)) {
             logWarn(
               `Diff detected in enterprise for shell between ${prevExternalSha} and ${externalHeadSha}`,
               externalDiff,

--- a/cli/lib/util/i18n-config.ts
+++ b/cli/lib/util/i18n-config.ts
@@ -38,7 +38,7 @@ export const externalLocalePathMap: Obj = {
 
 // all source code locations
 export const internalSrcDirMap: Obj<string[]> = {
-  shell: [resolveUI('shell', 'app'), resolveEnterprise('cmp'), resolveEnterprise('msp')],
+  shell: [resolveUI('shell', 'app'), resolveEnterprise('msp')],
 };
 
 export const externalSrcDirMap: Obj<string[]> = {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erda-ui/cli",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Command line interface for rapid Erda UI development",
   "bin": {
     "erda-ui": "dist/bin/erda.js"


### PR DESCRIPTION
## What this PR does / why we need it:
remove cmp related code in cli since enterprise has removed `cmp` folder

