### PR TITLE
fix: display groups in notification object(msp & cmp)

### DIFF
--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -187,6 +187,7 @@
     "allocation": "allocation",
     "allocation component node": "allocation component node",
     "analysis result": "analysis result",
+    "and {length} others": "and {length} others",
     "announcement content": "content",
     "announcement management": "announcement management",
     "application used": "application used",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -187,6 +187,7 @@
     "allocation": "分配量",
     "allocation component node": "分配组件节点",
     "analysis result": "分析结果",
+    "and {length} others": "等 {length} 组在内",
     "announcement content": "公告内容",
     "announcement management": "公告管理",
     "application used": "应用已使用",

--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { isEmpty } from 'lodash';
+import { map } from 'lodash';
 import moment from 'moment';
 import { useMount, useUnmount } from 'react-use';
 import { Modal, Button, Spin, Switch, Table, Tooltip } from 'antd';
@@ -25,7 +25,6 @@ import orgMemberStore from 'common/stores/org-member';
 import projectMemberStore from 'common/stores/project-member';
 import cmpAlarmStrategyStore from 'app/modules/cmp/stores/alarm-strategy';
 import mspAlarmStrategyStore from 'app/modules/msp/alarm-manage/alarm-strategy/stores/alarm-strategy';
-import { ListTargets } from 'application/pages/settings/components/app-notify/common-notify-group';
 import orgStore from 'app/org-home/stores/org';
 import routeInfoStore from 'core/stores/route';
 import './index.scss';
@@ -53,10 +52,8 @@ interface IProps {
   scopeId: string;
   commonPayload?: Obj;
 }
-
 export default ({ scopeType, scopeId, commonPayload }: IProps) => {
   const memberStore = memberStoreMap[scopeType];
-  const roleMap = memberStore.useStore((s) => s.roleMap);
   const { getRoleMap } = memberStore.effects;
   const alarmStrategyStore = alarmStrategyStoreMap[scopeType];
   const [alertList, alarmPaging] = alarmStrategyStore.useStore((s) => [s.alertList, s.alarmPaging]);
@@ -130,21 +127,22 @@ export default ({ scopeType, scopeId, commonPayload }: IProps) => {
     // ]),
     {
       title: i18n.t('default:notification target'),
-      dataIndex: ['notifies', '0', 'notifyGroup'],
+      dataIndex: 'notifies',
       width: 400,
       className: 'notify-info',
       ellipsis: true,
-      render: (notifyGroup: COMMON_STRATEGY_NOTIFY.INotifyGroup) => {
+      render: (notifies: COMMON_STRATEGY_NOTIFY.INotifyGroupNotify[]) => {
         const tips = i18n.t('cmp:Notification group does not exist or has been remove. Please change one.');
+        if (notifies?.length > 0 && notifies[0]?.notifyGroup?.name) {
+          const groupNames = map(notifies, (item) => item?.notifyGroup?.name).join(', ');
+          const groupLength = notifies?.length;
+          return `${groupNames} ${i18n.t('cmp:and {length} others', { length: groupLength })}`;
+        }
         return (
           <div className="flex-div flex">
-            {isEmpty(notifyGroup) ? (
-              <Tooltip title={tips}>
-                <span className="text-sub">{tips}</span>
-              </Tooltip>
-            ) : (
-              <ListTargets targets={notifyGroup.targets} roleMap={roleMap} />
-            )}
+            <Tooltip title={tips}>
+              <span className="text-sub">{tips}</span>
+            </Tooltip>
           </div>
         );
       },

--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -133,9 +133,9 @@ export default ({ scopeType, scopeId, commonPayload }: IProps) => {
       ellipsis: true,
       render: (notifies: COMMON_STRATEGY_NOTIFY.INotifyGroupNotify[]) => {
         const tips = i18n.t('cmp:Notification group does not exist or has been remove. Please change one.');
-        if (notifies?.length > 0 && notifies[0]?.notifyGroup?.name) {
-          const groupNames = map(notifies, (item) => item?.notifyGroup?.name).join(', ');
-          const groupLength = notifies?.length;
+        if (notifies?.length && notifies[0].notifyGroup?.name) {
+          const groupNames = map(notifies, (item) => item.notifyGroup?.name).join(', ');
+          const groupLength = notifies.length;
           return `${groupNames} ${i18n.t('cmp:and {length} others', { length: groupLength })}`;
         }
         return (


### PR DESCRIPTION
## What this PR does / why we need it:
display groups in notification object(msp & cmp)

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)

before:
![image](https://user-images.githubusercontent.com/30014895/142139809-959cfb36-1afc-4792-88da-b0d1fd40b375.png)

current:
![image](https://user-images.githubusercontent.com/30014895/142139764-bed35c9f-a6d8-4c11-b9f1-21310eafe67d.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  In MSP and CMP,  change the display content of the notification object of the notification strategy to display all notification groups instead of person  |
| 🇨🇳 中文    | 在微服务平台和多云管理平台中，将通知策略的通知对象显示内容改为显示所有通知组别而不是个人 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.4.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【告警】告警策略列表，当添加多个通知组时，列表中通知对象字段只显示了第一个](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D)
