### PR TITLE
fix: upgrade dashboard to v2.0.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.2
+      '@erda-ui/dashboard-configurator': 2.0.3
       '@erda-ui/react-markdown-editor-lite': ^1.4.7
       '@icon-park/react': ^1.3.3
       '@module-federation/automatic-vendor-federation': ^1.2.1
@@ -468,7 +468,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.2_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.3_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
       '@icon-park/react': 1.3.3_react-dom@16.14.0+react@16.14.0
       ace-builds: 1.4.12
@@ -5707,8 +5707,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.2_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-8OpPfRL4YwvKPmi0HCfokFHMRxF5KPy9MKup/nyA7wNL7ACa96lsSIfUlpGVQLmy1IweIkfoxl2KbfV3akhdbw==}
+  /@erda-ui/dashboard-configurator/2.0.3_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-0xVFOw94bTDLH9Ts9amwWbi8Tcam6NpJHGTFlyc11l9Z0gRvOJGu1goD+XNyO8w2ChMELfJncf3TjRN0OE+02w==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'

--- a/shell/package.json
+++ b/shell/package.json
@@ -47,7 +47,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.2",
+    "@erda-ui/dashboard-configurator": "2.0.3",
     "@erda-ui/react-markdown-editor-lite": "^1.4.7",
     "@icon-park/react": "^1.3.3",
     "ace-builds": "^1.4.7",


### PR DESCRIPTION
## What this PR does / why we need it:
1. v2.0.2 is fixing that i18n impact erda-ui error, remove ConfigProvider from the dashboard when is production env
2. v2.0.3 is fixing that (1)display no mask which reminds user get data failed when didn't complete required fields
   (2)line chart selected by default when adding chart


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

