### PR TITLE
fix: remove useless dependency of loadmore in list

### DIFF
--- a/shell/app/config-page/components/list/list.tsx
+++ b/shell/app/config-page/components/list/list.tsx
@@ -59,7 +59,7 @@ const List = (props: CP_LIST.Props) => {
         combineList: newState.pageNo === 1 ? list : (newState.combineList || []).concat(list),
       };
     });
-  }, [propsState, list, update, data]);
+  }, [list, update, data]);
 
   const pagination = React.useMemo(() => {
     return isNumber(pageNo)


### PR DESCRIPTION
## What this PR does / why we need it:
remove the useless dependency of loadmore in the list to avoid multiple renders in useEffect

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

