### PR TITLE
fix(common): list prefixImg does not display

### DIFF
--- a/shell/app/common/components/list/index.scss
+++ b/shell/app/common/components/list/index.scss
@@ -78,6 +78,13 @@
 
     .erda-list-item-prefix-img {
       margin-right: 12px;
+      line-height: 1;
+
+      img {
+        margin: 10px;
+        width: calc(100% - 20px);
+        height: calc(100% - 20px);
+      }
 
       > * {
         width: 76px;
@@ -101,6 +108,7 @@
 
     .body-description {
       font-size: 12px;
+      height: 20px;
       line-height: 20px;
       color: $color-text-desc;
     }

--- a/shell/app/common/components/list/list-item.tsx
+++ b/shell/app/common/components/list/list-item.tsx
@@ -21,11 +21,19 @@ import { iconMap } from 'common/components/erda-icon';
 
 const getPrefixImg = (prefixImg: string, prefixImgCircle?: boolean) => {
   if (Object.keys(ImgMap).includes(prefixImg)) {
-    return <img src={getImg(prefixImg)} className={`item-prefix-img ${prefixImgCircle ? 'prefix-img-circle' : ''}`} />;
+    return (
+      <div>
+        <img src={getImg(prefixImg)} className={`item-prefix-img ${prefixImgCircle ? 'prefix-img-circle' : ''}`} />
+      </div>
+    );
   } else if (Object.keys(iconMap).includes(prefixImg)) {
     return <ErdaIcon type={prefixImg} size="76" className={`${prefixImgCircle ? 'prefix-img-circle' : ''}`} />;
   } else {
-    return '';
+    return (
+      <div>
+        <img src={prefixImg} className={`item-prefix-img rounded-sm ${prefixImgCircle ? 'prefix-img-circle' : ''}`} />
+      </div>
+    );
   }
 };
 
@@ -113,7 +121,11 @@ const ListItem = (props: ERDA_LIST.IListItemProps) => {
               ) : null}
               {status ? <Badge className="ml-2" {...status} /> : null}
             </div>
-            {description ? <Ellipsis className="body-description" title={description} /> : null}
+            {description ? (
+              <Ellipsis className="body-description" title={description} />
+            ) : (
+              <div className="body-description" />
+            )}
             {extraInfos ? (
               <div className="body-extra-info">
                 {extraInfos.map((info) => {


### PR DESCRIPTION
## What this PR does / why we need it:
List prefixImg does not display, and style will be different without description.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/143195889-3c8a3474-9812-4a34-99f6-97aa456c36b3.png)
->
![image](https://user-images.githubusercontent.com/82502479/143196768-e4cab4ae-1b7d-448d-929d-6b729be568d6.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

