### PR TITLE
refactor: use new table in msp

### DIFF
--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -15,7 +15,8 @@ import React from 'react';
 import { map } from 'lodash';
 import moment from 'moment';
 import { useMount, useUnmount } from 'react-use';
-import { Modal, Button, Spin, Badge, Tooltip } from 'antd';
+import { Modal, Button, Spin, Tooltip } from 'antd';
+import { Badge } from 'common';
 import { goTo } from 'common/utils';
 import { ColumnProps } from 'app/interface/common';
 import i18n from 'i18n';
@@ -114,10 +115,7 @@ const AlarmStrategyList = ({ scopeType, scopeId, commonPayload }: IProps) => {
       dataIndex: 'enable',
       width: 120,
       render: (enable) => (
-        <span>
-          <Badge status={enable ? 'success' : 'default'} />
-          <span>{enable ? i18n.t('enable') : i18n.t('unable')}</span>
-        </span>
+        <Badge text={enable ? i18n.t('enable') : i18n.t('unable')} status={enable ? 'success' : 'default'} />
       ),
     },
     // ...insertWhen(scopeType === ScopeType.ORG, [

--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -188,21 +188,12 @@ const AlarmStrategyList = ({ scopeType, scopeId, commonPayload }: IProps) => {
       enableStrategy: {
         title: record?.enable ? i18n.t('unable') : i18n.t('enable'),
         onClick: () => {
-          if (!record?.enable) {
-            toggleAlert({
-              id: record.id,
-              enable: !record.enable,
-            }).then(() => {
-              getAlerts({ pageNo });
-            });
-          } else {
-            toggleAlert({
-              id: record.id,
-              enable: !record.enable,
-            }).then(() => {
-              getAlerts({ pageNo });
-            });
-          }
+          toggleAlert({
+            id: record.id,
+            enable: !record.enable,
+          }).then(() => {
+            getAlerts({ pageNo });
+          });
         },
       },
     };

--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -100,8 +100,8 @@ const AlarmStrategyList = ({ scopeType, scopeId, commonPayload }: IProps) => {
     });
   };
 
-  const handlePageChange = (no: number) => {
-    getAlerts({ pageNo: no });
+  const handlePageChange = (no: number, size?: number) => {
+    getAlerts({ pageNo: no, pageSize: size });
   };
 
   const alertListColumns: Array<ColumnProps<COMMON_STRATEGY_NOTIFY.IAlert>> = [

--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import { map } from 'lodash';
 import moment from 'moment';
 import { useMount, useUnmount } from 'react-use';
-import { Modal, Button, Spin, Switch, Table, Tooltip } from 'antd';
+import { Modal, Button, Spin, Badge, Tooltip } from 'antd';
 import { goTo } from 'common/utils';
 import { ColumnProps } from 'app/interface/common';
 import i18n from 'i18n';
@@ -25,8 +25,8 @@ import orgMemberStore from 'common/stores/org-member';
 import projectMemberStore from 'common/stores/project-member';
 import cmpAlarmStrategyStore from 'app/modules/cmp/stores/alarm-strategy';
 import mspAlarmStrategyStore from 'app/modules/msp/alarm-manage/alarm-strategy/stores/alarm-strategy';
-import orgStore from 'app/org-home/stores/org';
-import routeInfoStore from 'core/stores/route';
+import Table from 'common/components/table';
+import { IActions } from 'common/components/table/interface';
 import './index.scss';
 
 const { confirm } = Modal;
@@ -52,13 +52,13 @@ interface IProps {
   scopeId: string;
   commonPayload?: Obj;
 }
-export default ({ scopeType, scopeId, commonPayload }: IProps) => {
+
+const AlarmStrategyList = ({ scopeType, scopeId, commonPayload }: IProps) => {
   const memberStore = memberStoreMap[scopeType];
   const { getRoleMap } = memberStore.effects;
   const alarmStrategyStore = alarmStrategyStoreMap[scopeType];
   const [alertList, alarmPaging] = alarmStrategyStore.useStore((s) => [s.alertList, s.alarmPaging]);
   const { total, pageNo, pageSize } = alarmPaging;
-  const orgId = orgStore.getState((s) => s.currentOrg.id);
   const [getAlertDetailLoading, getAlertsLoading, toggleAlertLoading] = useLoading(alarmStrategyStore, [
     'getAlertDetail',
     'getAlerts',
@@ -109,6 +109,17 @@ export default ({ scopeType, scopeId, commonPayload }: IProps) => {
       dataIndex: 'name',
       width: 150,
     },
+    {
+      title: i18n.t('status'),
+      dataIndex: 'enable',
+      width: 120,
+      render: (enable) => (
+        <span>
+          <Badge status={enable ? 'success' : 'default'} />
+          <span>{enable ? i18n.t('enable') : i18n.t('unable')}</span>
+        </span>
+      ),
+    },
     // ...insertWhen(scopeType === ScopeType.ORG, [
     //   {
     //     title: i18n.t('cmp:cluster'),
@@ -153,42 +164,51 @@ export default ({ scopeType, scopeId, commonPayload }: IProps) => {
       width: 180,
       render: (text) => moment(text).format('YYYY-MM-DD HH:mm:ss'),
     },
-    {
-      title: i18n.t('default:operation'),
-      dataIndex: 'id',
-      width: 150,
-      render: (_text, record) => {
-        return (
-          <div className="table-operations">
-            <span className="table-operations-btn" onClick={() => goTo(`./edit-strategy/${record.id}`)}>
-              {i18n.t('edit')}
-            </span>
-            <span
-              className="table-operations-btn"
-              onClick={() => {
-                handleDeleteAlarm(record.id);
-              }}
-            >
-              {i18n.t('delete')}
-            </span>
-            <Switch
-              size="small"
-              defaultChecked={record.enable}
-              onChange={() => {
-                toggleAlert({
-                  id: record.id,
-                  enable: !record.enable,
-                }).then(() => {
-                  getAlerts({ pageNo });
-                });
-              }}
-            />
-          </div>
-        );
-      },
-    },
   ];
 
+  const actions: IActions<COMMON_STRATEGY_NOTIFY.IAlert> = {
+    width: 120,
+    render: (record: COMMON_STRATEGY_NOTIFY.IAlert) => renderMenu(record),
+  };
+
+  const renderMenu = (record: COMMON_STRATEGY_NOTIFY.IAlert) => {
+    const { editStrategy, deleteStrategy, enableStrategy } = {
+      editStrategy: {
+        title: i18n.t('edit'),
+        onClick: () => {
+          goTo(`./edit-strategy/${record.id}`);
+        },
+      },
+      deleteStrategy: {
+        title: i18n.t('delete'),
+        onClick: () => {
+          handleDeleteAlarm(record.id);
+        },
+      },
+      enableStrategy: {
+        title: record?.enable ? i18n.t('unable') : i18n.t('enable'),
+        onClick: () => {
+          if (!record?.enable) {
+            toggleAlert({
+              id: record.id,
+              enable: !record.enable,
+            }).then(() => {
+              getAlerts({ pageNo });
+            });
+          } else {
+            toggleAlert({
+              id: record.id,
+              enable: !record.enable,
+            }).then(() => {
+              getAlerts({ pageNo });
+            });
+          }
+        },
+      },
+    };
+
+    return [editStrategy, deleteStrategy, enableStrategy];
+  };
   return (
     <div className="alarm-strategy">
       <div className="top-button-group">
@@ -206,6 +226,7 @@ export default ({ scopeType, scopeId, commonPayload }: IProps) => {
           rowKey="id"
           columns={alertListColumns}
           dataSource={alertList}
+          actions={actions}
           pagination={{
             current: pageNo,
             pageSize,
@@ -218,3 +239,5 @@ export default ({ scopeType, scopeId, commonPayload }: IProps) => {
     </div>
   );
 };
+
+export default AlarmStrategyList;

--- a/shell/app/modules/cmp/stores/alarm-strategy.ts
+++ b/shell/app/modules/cmp/stores/alarm-strategy.ts
@@ -58,7 +58,7 @@ const alarmStrategy = createStore({
   state: initOrgState,
   effects: {
     async getAlerts({ call, update }, payload?: COMMON_STRATEGY_NOTIFY.IPageParam) {
-      const { list } = (await call(getAlerts, payload, { paging: { key: 'alarmPaging' } })) ?? {};
+      const { list = [] } = (await call(getAlerts, payload, { paging: { key: 'alarmPaging' } })) ?? {};
       update({ alertList: list });
     },
     async getAlertDetail({ call }, id: number) {

--- a/shell/app/modules/msp/alarm-manage/alarm-strategy/stores/alarm-strategy.ts
+++ b/shell/app/modules/msp/alarm-manage/alarm-strategy/stores/alarm-strategy.ts
@@ -58,7 +58,8 @@ const alarmStrategy = createStore({
   effects: {
     async getAlerts({ call, update, getParams }, payload?: COMMON_STRATEGY_NOTIFY.IPageParam) {
       const { tenantGroup } = getParams();
-      const { list } = (await call(getAlerts, { ...payload, tenantGroup }, { paging: { key: 'alarmPaging' } })) ?? {};
+      const { list = [] } =
+        (await call(getAlerts, { ...payload, tenantGroup }, { paging: { key: 'alarmPaging' } })) ?? {};
       update({ alertList: list });
     },
     async getAlertDetail({ call, getParams }, id: number) {

--- a/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
@@ -299,7 +299,7 @@ const Transaction = () => {
   }
 
   const traceSlowSlot = (
-    <div className="flex items-center flex-wrap justify-end">
+    <div className="flex items-center flex-wrap justify-start">
       <span>{i18n.t('msp:maximum number of queries')}：</span>
       <Select className="mr-3" value={limit} onChange={handleChangeLimit}>
         {limits.map((item) => (

--- a/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
@@ -14,7 +14,10 @@
 import React, { useCallback, useMemo } from 'react';
 import { map, differenceBy } from 'lodash';
 import i18n from 'i18n';
-import { Drawer, Radio, Select, Table, Tag, Tooltip } from 'antd';
+import DC from '@erda-ui/dashboard-configurator/dist';
+import { Drawer, Radio, Select, Tag, Tooltip } from 'antd';
+import Table from 'common/components/table';
+import { IActions } from 'common/components/table/interface';
 import { SimpleLog, DebounceSearch, Ellipsis } from 'common';
 import { useUpdate } from 'common/use-hooks';
 import monitorCommonStore from 'common/stores/monitorCommon';
@@ -251,36 +254,6 @@ const Transaction = () => {
         title: col.title,
         dataIndex: col.index,
       })),
-      {
-        title: i18n.t('operation'),
-        dataIndex: 'operation',
-        width: 180,
-        render: (_: any, record: any) => (
-          <div className="table-operations">
-            {currentProject?.type !== 'MSP' && (
-              <span
-                className="table-operations-btn"
-                onClick={() => {
-                  updater.traceId(record.requestId);
-                  updater.logVisible(true);
-                }}
-              >
-                {i18n.t('check log')}
-              </span>
-            )}
-            <span
-              className="table-operations-btn"
-              onClick={() => {
-                updater.traceId(record.requestId);
-                updater.startTime(new Date(record.time).getTime());
-                setIsShowTraceDetail(true);
-              }}
-            >
-              {i18n.t('check detail')}
-            </span>
-          </div>
-        ),
-      },
     ];
 
     return [c, traceSlowTranslation?.data];
@@ -324,6 +297,52 @@ const Transaction = () => {
   if (!serviceId) {
     return <NoServicesHolder />;
   }
+
+  const traceSlowSlot = (
+    <div className="flex items-center flex-wrap justify-end">
+      <span>{i18n.t('msp:maximum number of queries')}：</span>
+      <Select className="mr-3" value={limit} onChange={handleChangeLimit}>
+        {limits.map((item) => (
+          <Select.Option key={item} value={item}>
+            {item}
+          </Select.Option>
+        ))}
+      </Select>
+      <span>{i18n.t('msp:sort method')}：</span>
+      <Select value={sortType} onChange={handleChangeSortType}>
+        {map(sortButtonMap, (v, k) => (
+          <Select.Option key={k} value={k}>
+            {v}
+          </Select.Option>
+        ))}
+      </Select>
+    </div>
+  );
+
+  const renderMenu = (record: TOPOLOGY_SERVICE_ANALYZE.TranslationSlowRecord) => {
+    const { viewLog, viewDetail } = {
+      viewLog: {
+        title: i18n.t('check log'),
+        onClick: () => {
+          updater.traceId(record.requestId);
+          updater.logVisible(true);
+        },
+      },
+      viewDetail: {
+        title: i18n.t('check detail'),
+        onClick: () => {
+          updater.traceId(record.requestId);
+          setIsShowTraceDetail(true);
+        },
+      },
+    };
+
+    return currentProject?.type !== 'MSP' ? [viewLog, viewDetail] : [viewDetail];
+  };
+
+  const actions: IActions<TOPOLOGY_SERVICE_ANALYZE.TranslationSlowRecord> = {
+    render: (record: TOPOLOGY_SERVICE_ANALYZE.TranslationSlowRecord) => renderMenu(record),
+  };
 
   return (
     <div className="service-analyze flex flex-col h-full">
@@ -408,26 +427,10 @@ const Transaction = () => {
         visible={visible}
         onClose={() => updater.visible(false)}
       >
-        <div className="flex items-center flex-wrap justify-end mb-3">
-          <span>{i18n.t('msp:maximum number of queries')}：</span>
-          <Select className="mr-3" value={limit} onChange={handleChangeLimit}>
-            {limits.map((item) => (
-              <Select.Option key={item} value={item}>
-                {item}
-              </Select.Option>
-            ))}
-          </Select>
-          <span>{i18n.t('msp:sort method')}：</span>
-          <Select value={sortType} onChange={handleChangeSortType}>
-            {map(sortButtonMap, (v, k) => (
-              <Select.Option key={k} value={k}>
-                {v}
-              </Select.Option>
-            ))}
-          </Select>
-        </div>
         <Table
+          slot={traceSlowSlot}
           loading={isFetching}
+          actions={actions}
           rowKey="requestId"
           columns={columns}
           dataSource={dataSource}
@@ -436,7 +439,7 @@ const Transaction = () => {
         <Drawer
           destroyOnClose
           title={i18n.t('runtime:monitor log')}
-          width="50%"
+          width="80%"
           visible={logVisible}
           onClose={() => updater.logVisible(false)}
         >

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
@@ -13,7 +13,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Tree, Tooltip, Row, Col, Tabs } from 'antd';
+import { Tree, Tooltip, Row, Col, Tabs, Radio, RadioChangeEvent } from 'antd';
 import { TimeSelect, KeyValueList, Icon as CustomIcon, EmptyHolder, Ellipsis } from 'common';
 import Table from 'common/components/table';
 import { mkDurationStr } from 'trace-insight/common/utils/traceSummary';

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
@@ -13,8 +13,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Tree, Tooltip, Row, Col, Tabs, Table, Radio, RadioChangeEvent } from 'antd';
+import { Tree, Tooltip, Row, Col, Tabs } from 'antd';
 import { TimeSelect, KeyValueList, Icon as CustomIcon, EmptyHolder, Ellipsis } from 'common';
+import Table from 'common/components/table';
 import { mkDurationStr } from 'trace-insight/common/utils/traceSummary';
 import { getSpanAnalysis, getSpanEvents } from 'msp/services';
 import './index.scss';

--- a/shell/app/modules/msp/types/topology-service-analyze.d.ts
+++ b/shell/app/modules/msp/types/topology-service-analyze.d.ts
@@ -34,6 +34,12 @@ declare namespace TOPOLOGY_SERVICE_ANALYZE {
     data: Array<Record<string, any>>;
   }
 
+  interface TranslationSlowRecord {
+    avgElapsed: string;
+    requestId: string;
+    time: string;
+  }
+
   interface InstanceId {
     instanceId: string;
     status: boolean;


### PR DESCRIPTION
## What this PR does / why we need it:
use the new table in MSP, reopen [refactor: use new table in msp
#2040](https://github.com/erda-project/erda-ui/pull/2040).
some bugfixes about table related with [fix(common): table unsorting will be in descending order #2107](https://github.com/erda-project/erda-ui/pull/2107)

**1. alarm-strategy** 
**before:**
![image](https://user-images.githubusercontent.com/30014895/142200743-532c86f4-1ceb-449f-a7c7-1e301fc7af52.png)

**current:**
![image](https://user-images.githubusercontent.com/30014895/143202862-d2579dbb-d51f-4f32-b319-bf47aeeaeddb.png)

**2. events in trace-detail**
**before:**
![image](https://user-images.githubusercontent.com/30014895/142201142-49808c3b-8c3f-4247-81bf-3d37121f3608.png)

**current:**
![image](https://user-images.githubusercontent.com/30014895/143235898-05a26af1-eedf-437c-9dc8-2012c55cb786.png)

**3. link detail** 
**before:**
![image](https://user-images.githubusercontent.com/30014895/142202581-7f1e9238-8f1b-4235-80fd-c3066f7a92be.png)

**current:**
![image](https://user-images.githubusercontent.com/30014895/143236215-c69c1a37-b2cd-47bc-ba3c-31eec33e512b.png) 

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

