### PR TITLE
fix(common): table unsorting will be in descending order

### DIFF
--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -71,7 +71,7 @@ function WrappedTable<T extends object = any>({
   const sortCompareRef = React.useRef<((a: T, b: T) => number) | null>(null);
   const [defaultPagination, setDefaultPagination] = React.useState<TablePaginationConfig>({
     current: 1,
-    total: dataSource.length,
+    total: dataSource?.length || 0,
     ...PAGINATION,
   });
   const isFrontendPaging = !(paginationProps && paginationProps.current) && paginationProps !== false; // Determine whether front-end paging
@@ -82,7 +82,7 @@ function WrappedTable<T extends object = any>({
   const { current = 1, pageSize = PAGINATION.pageSize } = pagination;
 
   React.useEffect(() => {
-    setDefaultPagination((before) => ({ ...before, current: 1, total: dataSource.length }));
+    setDefaultPagination((before) => ({ ...before, current: 1, total: dataSource?.length || 0 }));
   }, [dataSource]);
 
   const onTableChange = React.useCallback(
@@ -136,7 +136,7 @@ function WrappedTable<T extends object = any>({
       const onSort = (order?: 'ascend' | 'descend') => {
         setSort({ ...sorter, order });
         const { sorter: columnSorter } = column as { sorter: { compare: (a: T, b: T) => number } };
-        if (columnSorter?.compare) {
+        if (order && columnSorter?.compare) {
           sortCompareRef.current = (a: T, b: T) => {
             if (order === 'ascend') {
               return columnSorter?.compare?.(a, b);
@@ -250,7 +250,7 @@ function WrappedTable<T extends object = any>({
     );
   }, [allColumns, sorterMenu, sort, onRow]);
 
-  let data = [...dataSource] as T[];
+  let data: T[] = dataSource ? [...dataSource] : [];
 
   if (sortCompareRef.current) {
     data = data.sort(sortCompareRef.current);


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of table unsorting will be in descending order.

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=252476&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG

