### PR TITLE
add html escape

### DIFF
--- a/shell/app/common/utils/marked.ts
+++ b/shell/app/common/utils/marked.ts
@@ -53,6 +53,20 @@ hljs.registerLanguage('bash', bash);
 let inited = false;
 const renderer = new Markdown.Renderer();
 
+const escapeHtml = (unsafe: string) => {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+};
+
+// add escapeHtml so that html tag will not be rendered in MD, if not under code block
+renderer.html = function (html: string) {
+  return escapeHtml(html);
+};
+
 const removePreview = (el: HTMLElement | Element) => {
   el.remove();
   const originEle = document.getElementsByClassName('md-img-preview')[0];


### PR DESCRIPTION
## What this PR does / why we need it:
escape html to prevent html be rendered in MD

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/5175455/143235318-a39b261a-0060-4dad-a205-3792ac00e3e9.png)
previous
![image](https://user-images.githubusercontent.com/5175455/143235481-0e330d44-5bbc-4782-8e40-d8df5811fbd4.png)

now 
![image](https://user-images.githubusercontent.com/5175455/143235357-ab090c12-6693-40f8-9cd8-d864a066a77d.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?

❎ No



