### PR TITLE
add img loaded event listener

### DIFF
--- a/shell/app/common/components/edit-field/index.tsx
+++ b/shell/app/common/components/edit-field/index.tsx
@@ -54,6 +54,7 @@ const ScalableImage = ({ src, alt, ...rest }: ImgHTMLAttributes<HTMLImageElement
         src={src}
         onClick={enlargeImage}
         alt={alt || 'preview-image'}
+        {...rest}
       />
       <span
         className={`${
@@ -93,7 +94,7 @@ export const EditMd = ({ value, onChange, onSave, disabled, originalValue, maxHe
     } else {
       updater.expandBtnVisible(false);
     }
-  }, [isEditing, maxHeight, updater, value?.length]);
+  }, [isEditing, maxHeight, updater, value]);
 
   React.useEffect(() => {
     eventHub.on('md-img-loaded', checkContentHeight);


### PR DESCRIPTION
## What this PR does / why we need it:
Due to img load is async, check content height is not accurate when onmount 
so trigger img load event and subscribe by MD component to check height on demand

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## Does this PR need be patched to older version?
❎ No

