### PR TITLE
fix(common): cluster list style optimization

### DIFF
--- a/shell/app/common/components/list/index.scss
+++ b/shell/app/common/components/list/index.scss
@@ -115,7 +115,7 @@
 
     .body-extra-info {
       margin-top: 4px;
-      line-height: 1;
+      line-height: 1.2;
     }
 
     &.middle &-container {

--- a/shell/app/common/components/list/list-item.tsx
+++ b/shell/app/common/components/list/list-item.tsx
@@ -145,8 +145,13 @@ const ListItem = (props: ERDA_LIST.IListItemProps) => {
         <div className="py-1">{extraContent}</div>
         {menuOverlay ? (
           <div className="erda-list-item-operations absolute top-2 right-2" onClick={(e) => e?.stopPropagation()}>
-            <Dropdown overlay={menuOverlay} overlayStyle={{ zIndex: 1000 }}>
-              <ErdaIcon type="more" size={20} className="hover-active pr-4 pt-2" />
+            <Dropdown overlay={menuOverlay} overlayStyle={{ zIndex: 1000 }} trigger={['click']}>
+              <ErdaIcon
+                type="more"
+                size={20}
+                className="hover-active px-2 py-1 rounded hover:bg-hover-gray-bg"
+                onClick={(e) => e.stopPropagation()}
+              />
             </Dropdown>
           </div>
         ) : null}


### PR DESCRIPTION
## What this PR does / why we need it:
Cluster list style optimization:
- extraInfos line height  is too small
- operations icon add hover background
- operations changed to click trigger

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/143364940-9499e814-6c2e-4ce2-a973-922b44f2586f.png)
->
![image](https://user-images.githubusercontent.com/82502479/143364961-0501fe5e-c5e0-4605-aeb5-1626ab1ca504.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

