### PR TITLE
style: update tab to normal style

### DIFF
--- a/shell/app/modules/org/pages/setting/notice-channel.tsx
+++ b/shell/app/modules/org/pages/setting/notice-channel.tsx
@@ -577,7 +577,6 @@ const NotifyChannel = () => {
             updater.activeTab(key);
             updater.paging({ pageSize: 15, current: 1 });
           }}
-          type="card"
         >
           <TabPane key="dingtalk_work_notice" tab={i18n.t('dingding work notice')} />
           <TabPane key="short_message" tab={i18n.t('SMS')} />


### PR DESCRIPTION
## What this PR does / why we need it:
update tab to the normal style

before:
![image](https://user-images.githubusercontent.com/30014895/143366307-a0edc479-d3ee-4c41-a6db-219d8a795a13.png)

current:
![image](https://user-images.githubusercontent.com/30014895/143366241-f50d707c-91e3-4933-a8e6-df38f2c37426.png)

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

