### PR TITLE
fix(common): table reset bug

### DIFF
--- a/core/src/service/index.ts
+++ b/core/src/service/index.ts
@@ -198,6 +198,9 @@ export function enhanceAPI<T extends FN>(_apiFn: T, config?: APIConfig<T>) {
 
       if (isObject(data) && Object.keys(params ?? {}).includes('pageNo')) {
         if ('list' in data && 'total' in data) {
+          if (data.list === null) {
+            data.list = [];
+          }
           const { total } = data;
           const { pageNo, pageSize } = params ?? ({} as Parameters<T>[0]);
           const hasMore = Math.ceil(total / +pageSize) > +pageNo;

--- a/shell/app/common/components/contractive-filter/index.tsx
+++ b/shell/app/common/components/contractive-filter/index.tsx
@@ -45,6 +45,7 @@ export interface ICondition {
   disabled?: boolean;
   emptyText?: string;
   required?: boolean;
+  firstShowLength?: number;
   split?: boolean;
   value?: string | number | string[] | number[] | Obj;
   fixed?: boolean;
@@ -72,6 +73,7 @@ interface IFilterItemProps {
   itemData: ICondition;
   value: any;
   active: boolean;
+
   onVisibleChange: (visible: boolean) => void;
   onChange: (data: { key: string; value: any }, extra?: { forceChange?: boolean }) => void;
   onQuickOperation: (data: { key: string; value: any }) => void;
@@ -138,13 +140,14 @@ const OptionItem = (props: IOptionItemProps) => {
     </div>
   );
 };
-const firstShowLength = 200;
+
 const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuickOperation }: IFilterItemProps) => {
   const {
     key,
     label,
     haveFilter,
     type,
+    firstShowLength = 200,
     placeholder,
     quickSelect,
     disabled,
@@ -159,7 +162,7 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
   const [filterMap, setFilterMap] = React.useState({});
   const memberSelectorRef = React.useRef(null as any);
   const [inputVal, setInputVal] = React.useState(value);
-  const [hasMore, setHasMore] = React.useState((options?.length || 0) > firstShowLength);
+  const [hasMore, setHasMore] = React.useState(firstShowLength ? (options?.length || 0) > firstShowLength : false);
   // const inputRef = React.useRef(null);
 
   const debouncedChange = React.useRef(debounce(onChange, 500));
@@ -212,8 +215,8 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
         .map((a) => a.label)
         .join(',') || emptyText;
 
-    const useableOptions = getSelectOptions(_options, filterMap[key]);
-    const useOption = hasMore ? useableOptions?.slice(0, firstShowLength) : useableOptions;
+    const filterOptions = getSelectOptions(_options, filterMap[key]);
+    const useOptions = hasMore ? filterOptions?.slice(0, firstShowLength) : filterOptions;
     const ops = (
       <Menu>
         {haveFilter && [
@@ -277,7 +280,7 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
             ]
           : null}
         <Menu.Item key="options" className="p-0 options-container options-item block">
-          {useOption.map((op) => {
+          {useOptions.map((op) => {
             if (has(op, 'children') && !op.children?.length) {
               return null;
             }
@@ -312,6 +315,7 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
                 <GroupOpt
                   key={op.value || op.label}
                   value={_value}
+                  firstShowLength={firstShowLength}
                   onDelete={onDelete}
                   onClickOptItem={onClickOptItem}
                   option={op}
@@ -585,14 +589,17 @@ const QuickSave = (props: IQuickSaveProps) => {
 interface IGroupOptProps {
   value: Array<string | number>;
   option: Option;
+  firstShowLength?: number;
   onClickOptItem: (option: Option) => void;
   onDelete?: (option: Option) => void;
 }
 
 const GroupOpt = (props: IGroupOptProps) => {
-  const { option, onClickOptItem, value, onDelete } = props;
+  const { option, onClickOptItem, value, onDelete, firstShowLength } = props;
   const [expand, setExpand] = React.useState(true);
-  const [hasMore, setHasMore] = React.useState((option.children?.length || 0) > firstShowLength);
+  const [hasMore, setHasMore] = React.useState(
+    firstShowLength ? (option.children?.length || 0) > firstShowLength : false,
+  );
 
   const useOption = hasMore ? option.children?.slice(0, firstShowLength) : option.children;
 

--- a/shell/app/common/components/contractive-filter/index.tsx
+++ b/shell/app/common/components/contractive-filter/index.tsx
@@ -138,7 +138,7 @@ const OptionItem = (props: IOptionItemProps) => {
     </div>
   );
 };
-
+const firstShowLength = 200;
 const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuickOperation }: IFilterItemProps) => {
   const {
     key,
@@ -159,6 +159,7 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
   const [filterMap, setFilterMap] = React.useState({});
   const memberSelectorRef = React.useRef(null as any);
   const [inputVal, setInputVal] = React.useState(value);
+  const [hasMore, setHasMore] = React.useState((options?.length || 0) > firstShowLength);
   // const inputRef = React.useRef(null);
 
   const debouncedChange = React.useRef(debounce(onChange, 500));
@@ -212,6 +213,7 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
         .join(',') || emptyText;
 
     const useableOptions = getSelectOptions(_options, filterMap[key]);
+    const useOption = hasMore ? useableOptions?.slice(0, firstShowLength) : useableOptions;
     const ops = (
       <Menu>
         {haveFilter && [
@@ -275,7 +277,7 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
             ]
           : null}
         <Menu.Item key="options" className="p-0 options-container options-item block">
-          {useableOptions.map((op) => {
+          {useOption.map((op) => {
             if (has(op, 'children') && !op.children?.length) {
               return null;
             }
@@ -327,6 +329,11 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
               );
             }
           })}
+          {hasMore ? (
+            <div className="fake-link hover-active py-1 pl-3  load-more" onClick={() => setHasMore(false)}>
+              {`${i18n.t('load more')}...`}
+            </div>
+          ) : null}
         </Menu.Item>
       </Menu>
     );
@@ -585,6 +592,9 @@ interface IGroupOptProps {
 const GroupOpt = (props: IGroupOptProps) => {
   const { option, onClickOptItem, value, onDelete } = props;
   const [expand, setExpand] = React.useState(true);
+  const [hasMore, setHasMore] = React.useState((option.children?.length || 0) > firstShowLength);
+
+  const useOption = hasMore ? option.children?.slice(0, firstShowLength) : option.children;
 
   return (
     <div className={'option-group'}>
@@ -596,7 +606,7 @@ const GroupOpt = (props: IGroupOptProps) => {
         <IconDown className={`expand-icon flex items-center ${expand ? 'expand' : ''}`} theme="outline" size="16" />
       </div>
       <div className={`option-group-content ${expand ? '' : 'no-expand'}`}>
-        {option.children?.map((cItem) => {
+        {useOption?.map((cItem) => {
           return (
             <OptionItem
               onDelete={onDelete}
@@ -607,6 +617,11 @@ const GroupOpt = (props: IGroupOptProps) => {
             />
           );
         })}
+        {hasMore ? (
+          <div className="fake-link hover-active py-1 pl-8  load-more" onClick={() => setHasMore(false)}>
+            {`${i18n.t('load more')}...`}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -269,13 +269,7 @@ function WrappedTable<T extends object = any>({
           sortColumn={sort}
           setColumns={(val) => setColumns(val)}
           onTableChange={onTableChange}
-          showReset={
-            !!(
-              paginationProps &&
-              paginationProps.current &&
-              (onChange || (paginationProps && paginationProps.onChange))
-            )
-          }
+          showReset={!!(paginationProps && paginationProps.current && (onChange || paginationProps?.onChange))}
         />
       )}
 
@@ -341,13 +335,12 @@ function renderActions<T extends object = any>(actions?: IActions<T> | null): Ar
 
           return (
             <span className="operate-list" onClick={(e) => e.stopPropagation()}>
-              {list.length ? (
+              {(list.length && (
                 <Dropdown overlay={menu} align={{ offset: [0, 5] }} trigger={['click']}>
                   <ErdaIcon type="more" className="cursor-pointer p-1 bg-hover rounded-sm" />
                 </Dropdown>
-              ) : (
-                ''
-              )}
+              )) ||
+                ''}
             </span>
           );
         },

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -99,7 +99,7 @@ function WrappedTable<T extends object = any>({
           if (isFrontendPaging) {
             setDefaultPagination({ ...pagination, current: pageNo || current, pageSize: size || pageSize });
           } else {
-            onPageChange?.(pageNo, size);
+            onPageChange?.(pageNo || current, size || pageSize);
             onChange?.(
               { ...pagination, current: pageNo || current, pageSize: size || pageSize },
               {},
@@ -269,7 +269,13 @@ function WrappedTable<T extends object = any>({
           sortColumn={sort}
           setColumns={(val) => setColumns(val)}
           onTableChange={onTableChange}
-          showReset={!!(onChange || (paginationProps && paginationProps.onChange))}
+          showReset={
+            !!(
+              paginationProps &&
+              paginationProps.current &&
+              (onChange || (paginationProps && paginationProps.onChange))
+            )
+          }
         />
       )}
 
@@ -321,25 +327,27 @@ function renderActions<T extends object = any>(actions?: IActions<T> | null): Ar
         ellipsis: true,
         fixed: 'right',
         render: (_: any, record: T) => {
-          const list = render(record);
+          const list = render(record).filter((item) => item.show !== false);
 
           const menu = (
             <Menu>
-              {list
-                .filter((item) => item.show !== false)
-                .map((item) => (
-                  <Menu.Item key={item.title} onClick={item.onClick}>
-                    <span className="fake-link mr-1">{item.title}</span>
-                  </Menu.Item>
-                ))}
+              {list.map((item) => (
+                <Menu.Item key={item.title} onClick={item.onClick}>
+                  <span className="fake-link mr-1">{item.title}</span>
+                </Menu.Item>
+              ))}
             </Menu>
           );
 
           return (
             <span className="operate-list" onClick={(e) => e.stopPropagation()}>
-              <Dropdown overlay={menu} align={{ offset: [0, 5] }} trigger={['click']}>
-                <ErdaIcon type="more" className="cursor-pointer p-1 bg-hover rounded-sm" />
-              </Dropdown>
+              {list.length ? (
+                <Dropdown overlay={menu} align={{ offset: [0, 5] }} trigger={['click']}>
+                  <ErdaIcon type="more" className="cursor-pointer p-1 bg-hover rounded-sm" />
+                </Dropdown>
+              ) : (
+                ''
+              )}
             </span>
           );
         },


### PR DESCRIPTION
## What this PR does / why we need it:
Fix  table reset bug:
- reset bug
- Front page does not display reset
- Give data.list a default value of an empty array
- operations icon does not display when operates is []

filter selector add load more.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

