### PR TITLE
add no desc holder

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -592,6 +592,7 @@
     "new password": "new password",
     "nickname": "nickname",
     "no available version": "no available version",
+    "no description yet": "no description yet",
     "no items selected": "no items selected",
     "no more data": "no more data",
     "no more than {size} characters": "no more than {size} characters",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -592,6 +592,7 @@
     "new password": "新密码",
     "nickname": "昵称",
     "no available version": "暂无可用版本",
+    "no description yet": "暂无描述",
     "no items selected": "未选中任何项",
     "no more data": "没有更多数据",
     "no more than {size} characters": "不超过{size}字符",

--- a/shell/app/common/components/edit-field/index.tsx
+++ b/shell/app/common/components/edit-field/index.tsx
@@ -147,7 +147,7 @@ export const EditMd = ({ value, onChange, onSave, disabled, originalValue, maxHe
         <div className="overflow-hidden" style={{ maxHeight: 'inherit' }}>
           <div ref={mdContentRef} className="md-content">
             <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ img: ScalableImage }}>
-              {value || ''}
+              {value || i18n.t('no description yet')}
             </ReactMarkdown>
             <div
               className={`absolute left-0 bottom-0 w-full h-16 bg-gradient-to-b from-transparent to-white flex justify-center items-center ${


### PR DESCRIPTION
## What this PR does / why we need it:
add no desc holder in MD viewer, otherwise there would be blank

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/5175455/143390786-89557704-d1bb-4d78-abeb-2c1a7a3f44dc.png)




## Does this PR need be patched to older version?
❎ No


