### PR TITLE
fix: modify menu in effeciency measure

### DIFF
--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -150,6 +150,8 @@ export enum pages {
   projectIssue = '/{orgName}/dop/projects/{projectId}/issues/{type}',
   projectIssueDetail = '/{orgName}/dop/projects/{projectId}/issues/{type}?id={id}&type={type}',
   projectIssueRoot = '/{orgName}/dop/projects/{projectId}/issues',
+  projectMeasureDashboard = '/{orgName}/dop/projects/{projectId}/measure/dashboard',
+  projectMeasure = '/{orgName}/dop/projects/{projectId}/measure',
   projectManualTestRoot = '/{orgName}/dop/projects/{projectId}/manual',
   projectAutoTestRoot = '/{orgName}/dop/projects/{projectId}/auto',
   projectManualTestCase = '/{orgName}/dop/projects/{projectId}/manual/testCase',

--- a/shell/app/menus/project.tsx
+++ b/shell/app/menus/project.tsx
@@ -38,7 +38,8 @@ export const getProjectMenu = (projectId: string, pathname: string) => {
         projectPerm.backLog.viewBackLog.pass ||
         projectPerm.iteration.read.pass ||
         projectPerm.issue.viewIssue.pass ||
-        projectPerm.epic.read.pass,
+        projectPerm.epic.read.pass ||
+        projectPerm.dashboard.viewDashboard.pass,
       subMenu: [
         {
           href: goTo.resolve.projectAllIssue(),
@@ -46,9 +47,10 @@ export const getProjectMenu = (projectId: string, pathname: string) => {
           prefix: `${goTo.resolve.projectIssueRoot()}/`,
         },
         {
-          href: goTo.resolve.projectTestDashboard(),
+          href: goTo.resolve.projectMeasureDashboard(),
           text: i18n.t('dop:efficiency measure'),
-          prefix: goTo.resolve.projectTestStatisticsRoot(),
+          show: projectPerm.dashboard.viewDashboard.pass,
+          prefix: goTo.resolve.projectMeasure(),
         },
       ],
     },
@@ -66,6 +68,11 @@ export const getProjectMenu = (projectId: string, pathname: string) => {
       subtitle: i18n.t('Test'),
       show: projectPerm.testManage.viewTest.pass,
       subMenu: [
+        {
+          href: goTo.resolve.projectTestDashboard(),
+          text: i18n.t('dop:statistics'),
+          prefix: goTo.resolve.projectTestStatisticsRoot(),
+        },
         {
           href: goTo.resolve.projectManualTestCase(),
           text: i18n.t('dop:manual test'),

--- a/shell/app/modules/project/router.ts
+++ b/shell/app/modules/project/router.ts
@@ -110,16 +110,15 @@ function getProjectRouter(): RouteConfigItem[] {
               getComp: (cb) => cb(import('project/pages/milestone'), 'Milestone'),
               layout: { noWrapper: true, fullHeight: true },
             },
-            {
-              path: 'dashboard',
-              tabs: PROJECT_TABS,
-              ignoreTabQuery: true,
-              getComp: (cb) => cb(import('project/pages/issue/issue-dashboard')),
-              layout: {
-                noWrapper: true,
-              },
-            },
           ],
+        },
+        {
+          path: 'measure/dashboard',
+          breadcrumbName: i18n.t('dop:efficiency measure'),
+          getComp: (cb) => cb(import('project/pages/issue/issue-dashboard')),
+          layout: {
+            noWrapper: true,
+          },
         },
         {
           path: 'ticket',
@@ -246,13 +245,13 @@ function getProjectRouter(): RouteConfigItem[] {
         },
         {
           path: 'statistics',
-          pageName: i18n.t('dop:efficiency measure'),
+          pageName: i18n.t('dop:statistics'),
           routes: [
             {
               path: 'code-coverage',
               tabs: TEST_STATISTICS_TABS,
               ignoreTabQuery: true,
-              breadcrumbName: i18n.t('dop:efficiency measure'),
+              breadcrumbName: i18n.t('dop:statistics'),
               getComp: (cb) => cb(import('project/pages/statistics/code-coverage')),
             },
             {
@@ -262,7 +261,7 @@ function getProjectRouter(): RouteConfigItem[] {
               },
               tabs: TEST_STATISTICS_TABS,
               ignoreTabQuery: true,
-              breadcrumbName: i18n.t('dop:efficiency measure'),
+              breadcrumbName: i18n.t('dop:statistics'),
               getComp: (cb) => cb(import('project/pages/statistics/test-dashboard')),
             },
           ],

--- a/shell/app/modules/project/tabs.tsx
+++ b/shell/app/modules/project/tabs.tsx
@@ -132,11 +132,6 @@ export const PROJECT_TABS = () => {
       name: i18n.t('bug'),
       show: projectPerm.bug.read.pass,
     },
-    {
-      key: 'dashboard',
-      name: i18n.t('dop:statistics'),
-      show: projectPerm.dashboard.viewDashboard.pass,
-    },
   ];
 };
 


### PR DESCRIPTION
## What this PR does / why we need it:
fix that modify menu in the efficiency measure(wrong understanding of requirements), related with [feat: modify project management menu #2115](https://github.com/erda-project/erda-ui/pull/2115)

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

