### PR TITLE
fix(common): config page table operations style bug

### DIFF
--- a/shell/app/config-page/components/table/render-types.tsx
+++ b/shell/app/config-page/components/table/render-types.tsx
@@ -612,6 +612,10 @@ const getTableOperation = (val: any, record: any, extra: any) => {
   //   });
   // }
 
+  if (!operationList.length) {
+    return null;
+  }
+
   return (
     <div className="table-operations">
       <Dropdown overlay={<Menu>{operationList}</Menu>} align={{ offset: [0, 5] }} trigger={['click']}>


### PR DESCRIPTION
## What this PR does / why we need it:
Fix style bug of config page table operations when operate is an empty array.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

