### PR TITLE
fix: display total duration in flame graph

### DIFF
--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
@@ -450,7 +450,7 @@ export function TraceGraph(props: IProps) {
                 />
                 <div className="text-sub">
                   {i18n.t('current')} span {mkDurationStr(tooltipState?.content.selfDuration / 1000)} -{' '}
-                  {i18n.t('total')} span {mkDurationStr(tooltipState?.content.selfDuration / 1000)}
+                  {i18n.t('total')} span {mkDurationStr(tooltipState?.content.value / 1000)}
                 </div>
               </div>
             )}

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-graph/index.tsx
@@ -282,16 +282,12 @@ export function TraceGraph(props: IProps) {
       };
       forEach(roots[0].children, (span) => flameData.children.push(formatFlameDataChild(span)));
     } else {
-      let time = 0;
-      forEach(roots, (item) => {
-        time += item.duration;
-      });
       flameData = {
         name: 'root',
-        value: time,
+        value: dataSource?.duration,
         children: [],
         serviceName: '',
-        selfDuration: time,
+        selfDuration: dataSource?.duration,
         spanKind: '',
         component: '',
       };


### PR DESCRIPTION
## What this PR does / why we need it:
display total duration in the flame graph

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

