### PR TITLE
fix(common): table reset always show and pageSizeOptions change

### DIFF
--- a/shell/app/App-vite.tsx
+++ b/shell/app/App-vite.tsx
@@ -37,6 +37,7 @@ import '@icon-park/react/styles/index.css';
 import '@erda-ui/dashboard-configurator/dist/index.css';
 import { IconProvider, DEFAULT_ICON_CONFIGS } from '@icon-park/react/es/runtime';
 import { initAxios } from 'common/utils/axios-config';
+import { PAGINATION } from 'app/constants';
 import 'tailwindcss/tailwind.css';
 import 'antd/dist/antd.less';
 
@@ -56,8 +57,8 @@ const momentLangMap = {
 Pagination.defaultProps = {
   showSizeChanger: false,
   ...Pagination.defaultProps,
-  pageSize: 15,
-  pageSizeOptions: ['15', '30', '45', '60'],
+  pageSize: PAGINATION.pageSize,
+  pageSizeOptions: PAGINATION.pageSizeOptions,
   showTotal: (total) => (isZh() ? `共计 ${total} 条` : `total ${total} items`),
 };
 

--- a/shell/app/App.tsx
+++ b/shell/app/App.tsx
@@ -37,6 +37,7 @@ import '@icon-park/react/styles/index.css';
 import '@erda-ui/dashboard-configurator/dist/index.css';
 import { IconProvider, DEFAULT_ICON_CONFIGS } from '@icon-park/react/es/runtime';
 import { initAxios } from 'common/utils/axios-config';
+import { PAGINATION } from 'app/constants';
 import 'tailwindcss/tailwind.css';
 
 import antd_zhCN from 'antd/es/locale-provider/zh_CN';
@@ -55,8 +56,8 @@ const momentLangMap = {
 Pagination.defaultProps = {
   showSizeChanger: false,
   ...Pagination.defaultProps,
-  pageSize: 15,
-  pageSizeOptions: ['15', '30', '45', '60'],
+  pageSize: PAGINATION.pageSize,
+  pageSizeOptions: PAGINATION.pageSizeOptions,
   showTotal: (total) => (isZh() ? `共计 ${total} 条` : `total ${total} items`),
 };
 

--- a/shell/app/common/components/pagination/index.tsx
+++ b/shell/app/common/components/pagination/index.tsx
@@ -24,7 +24,6 @@ import './index.scss';
     total // 总数，默认为0
     current // 当前页码，默认为1
     pageSize // 每页行数默认为PAGINATION.pageSize
-    pageSizeOptions // pageSize的下拉选择项，默认为PAGINATION.pageSizeOptions，当为空数组时不显示下拉选择
     showSizeChanger // 是否选择pageSize的下拉选择框，默认为true
     onChange // 翻页或者pageSize选择时触发，第一个参数为current，第二个参数为pageSize
  */
@@ -32,8 +31,6 @@ interface IPaginationProps {
   total: number;
   current: number;
   pageSize?: number;
-  pageSizeOptions?: string[];
-  showSizeChanger?: boolean;
   onChange: (page: number, pageSize?: number) => void;
 }
 
@@ -43,14 +40,7 @@ export interface IPaginationJumpProps {
 }
 
 const Pagination = (pagination: IPaginationProps) => {
-  const {
-    total = 0,
-    current = 1,
-    pageSize = PAGINATION.pageSize,
-    pageSizeOptions = PAGINATION.pageSizeOptions,
-    showSizeChanger = true,
-    onChange,
-  } = pagination;
+  const { total = 0, current = 1, pageSize = PAGINATION.pageSize, onChange } = pagination;
 
   const [goToVisible, setGoToVisible] = React.useState(false);
 
@@ -72,15 +62,13 @@ const Pagination = (pagination: IPaginationProps) => {
 
   const pageSizeMenu = (
     <Menu>
-      {(pageSizeOptions || [])
-        .filter((item) => item)
-        .map((item: string | number) => {
-          return (
-            <Menu.Item key={item} onClick={() => onChange?.(1, +item)}>
-              <span className="fake-link mr-1">{i18n.t('{size} items / page', { size: item })}</span>
-            </Menu.Item>
-          );
-        })}
+      {PAGINATION.pageSizeOptions.map((item: string | number) => {
+        return (
+          <Menu.Item key={item} onClick={() => onChange?.(1, +item)}>
+            <span className="fake-link mr-1">{i18n.t('{size} items / page', { size: item })}</span>
+          </Menu.Item>
+        );
+      })}
     </Menu>
   );
 
@@ -102,17 +90,15 @@ const Pagination = (pagination: IPaginationProps) => {
           <ErdaIcon type="right" size={18} color="currentColor" />
         </div>
       </div>
-      {showSizeChanger && pageSizeOptions?.length && (
-        <Dropdown
-          trigger={['click']}
-          overlay={pageSizeMenu}
-          align={{ offset: [0, 5] }}
-          overlayStyle={{ minWidth: 120 }}
-          getPopupContainer={(triggerNode) => triggerNode.parentElement as HTMLElement}
-        >
-          <span className="bg-hover px-3 py-1 cursor-pointer">{i18n.t('{size} items / page', { size: pageSize })}</span>
-        </Dropdown>
-      )}
+      <Dropdown
+        trigger={['click']}
+        overlay={pageSizeMenu}
+        align={{ offset: [0, 5] }}
+        overlayStyle={{ minWidth: 120 }}
+        getPopupContainer={(triggerNode) => triggerNode.parentElement as HTMLElement}
+      >
+        <span className="bg-hover px-3 py-1 cursor-pointer">{i18n.t('{size} items / page', { size: pageSize })}</span>
+      </Dropdown>
     </div>
   );
 };

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -82,7 +82,7 @@ function WrappedTable<T extends object = any>({
   const { current = 1, pageSize = PAGINATION.pageSize } = pagination;
 
   React.useEffect(() => {
-    setDefaultPagination((before) => ({ ...before, current: 1, total: dataSource?.length || 0 }));
+    setDefaultPagination((before) => ({ ...before, total: dataSource?.length || 0 }));
   }, [dataSource]);
 
   const onTableChange = React.useCallback(
@@ -90,7 +90,7 @@ function WrappedTable<T extends object = any>({
       const { onChange: onPageChange } = pagination as TablePaginationConfig;
       const action: TableAction = currentSorter ? 'sort' : 'paginate';
       const extra = {
-        currentDataSource: (action === 'sort' && dataSource) as T[],
+        currentDataSource: (action === 'sort' && dataSource) || [],
         action,
       };
 
@@ -250,6 +250,10 @@ function WrappedTable<T extends object = any>({
     );
   }, [allColumns, sorterMenu, sort, onRow]);
 
+  const onReload = () => {
+    onChange?.({ current, pageSize }, {}, sort, { action: 'paginate', currentDataSource: [] });
+  };
+
   let data: T[] = dataSource ? [...dataSource] : [];
 
   if (sortCompareRef.current) {
@@ -268,8 +272,7 @@ function WrappedTable<T extends object = any>({
           columns={columns}
           sortColumn={sort}
           setColumns={(val) => setColumns(val)}
-          onTableChange={onTableChange}
-          showReset={!!(paginationProps && paginationProps.current && (onChange || paginationProps?.onChange))}
+          onReload={onReload}
         />
       )}
 

--- a/shell/app/common/components/table/interface.ts
+++ b/shell/app/common/components/table/interface.ts
@@ -58,12 +58,11 @@ interface IAction {
   show?: boolean;
 }
 
-export interface ITableConfigProps<T> {
+export interface TableConfigProps<T> {
   slot?: React.ReactNode;
   columns: Array<ColumnProps<T>>;
   setColumns: (val: Array<ColumnProps<T>>) => void;
-  onTableChange: ([key]: any) => void;
-  showReset: boolean;
+  onReload: ([key]: any) => void;
   sortColumn: SorterResult<T>;
 }
 

--- a/shell/app/common/components/table/table-config.tsx
+++ b/shell/app/common/components/table/table-config.tsx
@@ -14,16 +14,15 @@
 import React from 'react';
 import { Checkbox, Popover } from 'antd';
 import { ErdaIcon } from 'common';
-import { ITableConfigProps, ColumnProps } from './interface';
+import { TableConfigProps, ColumnProps } from './interface';
 
 function TableConfig<T extends object = any>({
   slot,
   columns,
   setColumns,
-  onTableChange,
-  showReset,
+  onReload,
   sortColumn = {},
-}: ITableConfigProps<T>) {
+}: TableConfigProps<T>) {
   const { column, order } = sortColumn;
   const onCheck = (checked: boolean, title: string) => {
     const newColumns = columns.map((item) => (item.title === title ? { ...item, show: checked } : item));
@@ -51,15 +50,13 @@ function TableConfig<T extends object = any>({
         <div className="flex-1">{slot}</div>
       </div>
       <div className="erda-table-filter-ops flex items-center">
-        {showReset && (
-          <ErdaIcon
-            size="20"
-            className={`icon-hover ml-3 bg-hover p-1`}
-            type="refresh"
-            color="currentColor"
-            onClick={() => onTableChange({})}
-          />
-        )}
+        <ErdaIcon
+          size="20"
+          className={`icon-hover ml-3 bg-hover p-1`}
+          type="refresh"
+          color="currentColor"
+          onClick={onReload}
+        />
         <Popover
           content={columnsFilter}
           trigger="click"

--- a/shell/app/constants.ts
+++ b/shell/app/constants.ts
@@ -17,6 +17,6 @@ interface IPagination {
 }
 
 export const PAGINATION: IPagination = {
-  pageSize: 15,
-  pageSizeOptions: ['15', '30', '45', '60'],
+  pageSize: 10,
+  pageSizeOptions: ['10', '20', '50', '100'],
 };

--- a/shell/app/modules/dcos/pages/cluster-dashboard/resources-summary.tsx
+++ b/shell/app/modules/dcos/pages/cluster-dashboard/resources-summary.tsx
@@ -196,12 +196,17 @@ const PureResourceTable = React.memo(({ rankType }: { rankType: string }) => {
   const { cpuPerNode, memPerNode } = cpuAndMem.current;
 
   const [data, loading] = getResourceTable.useState();
-  React.useEffect(() => {
+
+  const getResourceList = React.useCallback(() => {
     if (clusters.length) {
       const curCluster = clusterName?.length ? clusterName : clusters.map((item) => item.name);
       getResourceTable.fetch({ clusterName: curCluster, cpuPerNode, memPerNode, groupBy: rankType });
     }
   }, [clusters, clusterName, rankType, cpuPerNode, memPerNode]);
+
+  React.useEffect(() => {
+    getResourceList();
+  }, [getResourceList]);
 
   const mergedList = (data?.list || []).map((item) => ({
     ...item,
@@ -467,6 +472,7 @@ const PureResourceTable = React.memo(({ rankType }: { rankType: string }) => {
         loading={loading}
         columns={columns}
         dataSource={filterData}
+        onChange={() => getResourceList()}
       />
 
       <Modal


### PR DESCRIPTION
## What this PR does / why we need it:
Table reset always show and pageSizeOptions change

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/143542449-ed807c77-f74d-43aa-b350-4e2127bb4af5.png)
![image](https://user-images.githubusercontent.com/82502479/143542479-cb54d86e-1aab-4d8c-8a26-8334a967f0ed.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

