### PR TITLE
feat: add startTime in params of trace detail api

### DIFF
--- a/shell/app/common/components/board-grid/index.tsx
+++ b/shell/app/common/components/board-grid/index.tsx
@@ -25,7 +25,7 @@ import Table from 'common/components/table';
 import { theme } from 'app/charts/theme';
 
 registTheme('erda', theme);
-dcRegisterComp.use('table', Table);
+// dcRegisterComp.use('table', Table);
 
 export const BoardGrid = ({ ...restProps }: DC.BoardGridProps) => {
   const locale = window.localStorage.getItem('locale') || 'zh';

--- a/shell/app/common/components/board-grid/index.tsx
+++ b/shell/app/common/components/board-grid/index.tsx
@@ -25,7 +25,7 @@ import Table from 'common/components/table';
 import { theme } from 'app/charts/theme';
 
 registTheme('erda', theme);
-// dcRegisterComp.use('table', Table);
+dcRegisterComp.use('table', Table);
 
 export const BoardGrid = ({ ...restProps }: DC.BoardGridProps) => {
   const locale = window.localStorage.getItem('locale') || 'zh';

--- a/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
@@ -125,6 +125,7 @@ interface IState {
   url?: string;
   traceSlowTranslation?: TOPOLOGY_SERVICE_ANALYZE.TranslationSlowResp;
   traceId?: string;
+  startTime: number;
   visible: boolean;
   detailVisible: boolean;
   logVisible: boolean;
@@ -157,6 +158,7 @@ const Transaction = () => {
       traceSlowTranslation,
       detailVisible,
       traceId,
+      startTime,
       logVisible,
       sortType,
       callType,
@@ -172,6 +174,7 @@ const Transaction = () => {
     url: undefined,
     traceSlowTranslation: undefined,
     traceId: undefined,
+    startTime: 0,
     visible: false,
     detailVisible: false,
     logVisible: false,
@@ -269,6 +272,7 @@ const Transaction = () => {
               className="table-operations-btn"
               onClick={() => {
                 updater.traceId(record.requestId);
+                updater.startTime(new Date(record.time).getTime());
                 setIsShowTraceDetail(true);
               }}
             >
@@ -439,7 +443,7 @@ const Transaction = () => {
           <SimpleLog requestId={traceId} applicationId={params?.applicationId || _applicationId} />
         </Drawer>
       </Drawer>
-      <TraceSearchDetail traceId={traceId} />
+      <TraceSearchDetail traceId={traceId} startTime={startTime} />
     </div>
   );
 };

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-history-list.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-history-list.tsx
@@ -39,11 +39,13 @@ const TraceHistoryList = ({
     const isNewId = currentTraceRequestId !== requestId;
     // 点击已选中的 item 取消选中，currentTraceRequestId 置空
     setCurrentTraceRequestId(isNewId ? requestId : '');
+    const requestItem = dataSource.find((item) => item.requestId === requestId);
+    const startTime = new Date(requestItem.updateTime).getTime();
     if (isNewId) {
       form.setFieldsValue({ url });
       setInputUrl(url);
       getTraceDetail({ requestId });
-      getTraceStatusDetail({ requestId });
+      getTraceStatusDetail({ requestId, startTime });
     } else {
       form.setFieldsValue({ url: '' });
       setInputUrl('');

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { map as _map, now, pickBy } from 'lodash';
+import { map as _map, pickBy } from 'lodash';
 import { Row, Col, Input, Select, Button, Tabs, Form, Popconfirm, Tooltip } from 'antd';
 import { Copy, KeyValueEditor, IF } from 'common';
 import { regRules, notify, qs } from 'common/utils';
@@ -159,7 +159,7 @@ const TraceInsightQuerier = () => {
           payload.header = headersEditor.getEditData();
         }
         await handleSetRequestTraceParams(payload);
-        requestTrace({ startTime });
+        requestTrace({ startTime: new Date().getTime() });
       })
       .catch(() => {
         notify('warning', i18n.t('msp:param-error-check'));

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-querier.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { map as _map, pickBy } from 'lodash';
+import { map as _map, now, pickBy } from 'lodash';
 import { Row, Col, Input, Select, Button, Tabs, Form, Popconfirm, Tooltip } from 'antd';
 import { Copy, KeyValueEditor, IF } from 'common';
 import { regRules, notify, qs } from 'common/utils';
@@ -90,11 +90,12 @@ const TraceInsightQuerier = () => {
     };
   });
 
-  const { method, url, body, query, header } = requestTraceParams;
+  const { method, url, body, query, header, updateTime } = requestTraceParams;
   const queryStr = qs.stringify(query);
   const { validateFields } = form;
   const { requestId } = urlQuery;
 
+  const [startTime, setStartTime] = React.useState(0);
   const [activeTab, setActiveTab] = React.useState('1');
   const [traceRecords, setTraceRecords] = React.useState({});
   const [inputUrl, setInputUrl] = React.useState('');
@@ -119,6 +120,12 @@ const TraceInsightQuerier = () => {
   React.useEffect(() => {
     form.setFieldsValue({ method });
   }, [method, form]);
+
+  React.useEffect(() => {
+    if (updateTime) {
+      setStartTime(new Date(updateTime).getTime());
+    }
+  }, [updateTime]);
 
   const resetRequestTrace = () => {
     form.resetFields();
@@ -152,7 +159,7 @@ const TraceInsightQuerier = () => {
           payload.header = headersEditor.getEditData();
         }
         await handleSetRequestTraceParams(payload);
-        requestTrace();
+        requestTrace({ startTime });
       })
       .catch(() => {
         notify('warning', i18n.t('msp:param-error-check'));
@@ -376,7 +383,7 @@ const TraceInsightQuerier = () => {
           {renderStatusList()}
         </Col>
       </Row>
-      {isShowTraceDetail && <TraceSearchDetail traceId={traceStatusDetail?.requestId} />}
+      {isShowTraceDetail && <TraceSearchDetail traceId={traceStatusDetail?.requestId} startTime={startTime} />}
     </div>
   );
 };

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search-detail.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search-detail.tsx
@@ -25,7 +25,7 @@ import i18n from 'i18n';
 import './trace-search-detail.scss';
 import { goTo } from 'common/utils';
 
-export default ({ traceId }: { traceId?: string }) => {
+export default ({ traceId, startTime }: { traceId?: string; startTime?: number }) => {
   const { getTraceDetailContent } = traceStore;
   const [loading] = useLoading(traceStore, ['getTraceDetailContent']);
   const [{ traceRecords }, updater] = useUpdate({ traceRecords: {} });
@@ -41,7 +41,7 @@ export default ({ traceId }: { traceId?: string }) => {
       setIsShowTraceDetail(true);
     }
     if (id) {
-      getTraceDetailContent({ traceId: id }).then((content) => {
+      getTraceDetailContent({ traceId: id, startTime }).then((content) => {
         updater.traceRecords(content);
       });
     }

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search-detail.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search-detail.tsx
@@ -29,19 +29,25 @@ export default ({ traceId, startTime }: { traceId?: string; startTime?: number }
   const { getTraceDetailContent } = traceStore;
   const [loading] = useLoading(traceStore, ['getTraceDetailContent']);
   const [{ traceRecords }, updater] = useUpdate({ traceRecords: {} });
-  const [{ traceId: _traceId }, currentRoute] = routeInfoStore.useStore((s) => [s.params, s.currentRoute]);
+  const [{ traceId: _traceId }, currentRoute, { startTime: _startTime }] = routeInfoStore.useStore((s) => [
+    s.params,
+    s.currentRoute,
+    s.query,
+  ]);
   const { setIsShowTraceDetail } = monitorCommonStore.reducers;
   const isShowTraceDetail = monitorCommonStore.useStore((s) => s.isShowTraceDetail);
   const id = traceId || _traceId;
   const [pathname, query] = window.location.href.split('?');
-  const copyPath = _traceId ? pathname : `${pathname}/trace-detail/${traceId}${query ? `?${query}` : ''}`;
+  const copyPath = _traceId
+    ? pathname
+    : `${pathname}/trace-detail/${traceId}${query ? `?${query}&startTime=${startTime}` : `?startTime=${startTime}`}`;
 
   React.useEffect(() => {
     if (_traceId) {
       setIsShowTraceDetail(true);
     }
     if (id) {
-      getTraceDetailContent({ traceId: id, startTime }).then((content) => {
+      getTraceDetailContent({ traceId: id, startTime: startTime || _startTime }).then((content) => {
         updater.traceRecords(content);
       });
     }

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search.tsx
@@ -100,6 +100,7 @@ interface IState {
   defaultQuery: Obj;
   query: Obj;
   layout: DC.Layout;
+  startTime: number;
 }
 
 type IQuery = {
@@ -117,12 +118,13 @@ const TraceSearch = () => {
   const { getTraceSummary } = traceStore;
   const [loading] = useLoading(traceStore, ['getTraceSummary']);
   const { setIsShowTraceDetail } = monitorCommonStore.reducers;
-  const [{ traceId, filter, defaultQuery, query, layout }, updater, update] = useUpdate<IState>({
+  const [{ traceId, filter, defaultQuery, query, layout, startTime }, updater, update] = useUpdate<IState>({
     filter: [],
     traceId: undefined,
     defaultQuery: {},
     query: {},
     layout: [],
+    startTime: 0,
   });
   const [routeQuery, params] = routeInfoStore.useStore((s) => [s.query, s.params]);
   const globalVariable = React.useMemo(() => {
@@ -220,9 +222,10 @@ const TraceSearch = () => {
     });
   };
 
-  const handleCheckTraceDetail = (e: any, id: string) => {
+  const handleCheckTraceDetail = (e: any, id: string, time: number) => {
     e.stopPropagation();
     updater.traceId(id as string);
+    updater.startTime(time);
     setIsShowTraceDetail(true);
   };
 
@@ -258,7 +261,10 @@ const TraceSearch = () => {
       fixed: 'right',
       render: (_: any, record: RecordType) => (
         <div className="table-operations">
-          <span onClick={(e) => handleCheckTraceDetail(e, record.id)} className="table-operations-btn">
+          <span
+            onClick={(e) => handleCheckTraceDetail(e, record.id, record.startTime)}
+            className="table-operations-btn"
+          >
             {i18n.t('check detail')}
           </span>
         </div>
@@ -280,7 +286,7 @@ const TraceSearch = () => {
         <DashBoard layout={layout} globalVariable={globalVariable} />
       </div>
       <Table loading={loading} rowKey="id" columns={columns} dataSource={traceSummary} scroll={{ x: 1100 }} />
-      <TraceSearchDetail traceId={traceId} />
+      <TraceSearchDetail traceId={traceId} startTime={startTime} />
     </>
   );
 };

--- a/shell/app/modules/msp/monitor/trace-insight/stores/trace-querier.ts
+++ b/shell/app/modules/msp/monitor/trace-insight/stores/trace-querier.ts
@@ -148,7 +148,7 @@ const traceQuerier = createStore({
         await traceQuerier.effects.getTraceStatusDetail({ requestId: payload.requestId });
       }
       if (traceStatusDetail.status === 1) {
-        await traceQuerier.effects.getTraceDetailContent({ traceId: payload.requestId, startTime: payload?.startTime });
+        await traceQuerier.effects.getTraceDetailContent({ traceId: payload.requestId, startTime: payload.startTime });
       }
     },
     async cancelTraceStatus({ select, call, getParams }, payload: { requestId: string }) {

--- a/shell/app/modules/msp/monitor/trace-insight/types/index.d.ts
+++ b/shell/app/modules/msp/monitor/trace-insight/types/index.d.ts
@@ -41,6 +41,7 @@ declare namespace MONITOR_TRACE {
     status: number;
     statusName: string;
     updateTime: string;
+    startTime: number;
   }
 
   interface IStatus {
@@ -154,6 +155,7 @@ declare namespace MONITOR_TRACE {
     traceId: string;
     scopeId: string;
     limit?: number;
+    startTime?: number;
   }
 
   interface ISpan extends ITraceSpan {


### PR DESCRIPTION
## What this PR does / why we need it:
add startTime in params of trace detail api

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

