### PR TITLE
fix(common): config page container style bug

### DIFF
--- a/shell/app/config-page/components/list/list.tsx
+++ b/shell/app/config-page/components/list/list.tsx
@@ -111,7 +111,7 @@ const List = (props: CP_LIST.Props) => {
             );
           })}
           {!isLoadMore && pagination ? (
-            <Pagination className="flex items-center flex-wrap justify-end mt-3" {...pagination} />
+            <Pagination className="flex items-center flex-wrap justify-end mt-3 mb-1" {...pagination} />
           ) : null}
           {isLoadMore && total > Math.max(state.combineList?.length, 0) && (
             <div className="hover-active load-more" onClick={loadMore}>

--- a/shell/app/config-page/index.tsx
+++ b/shell/app/config-page/index.tsx
@@ -322,7 +322,7 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
 
   return showLoading ? (
     <Spin spinning={showLoading && fetching} wrapperClassName={`${fullHeight ? 'full-spin-height' : ''}`}>
-      <div className="h-full">{Content}</div>
+      <div className="h-full overflow-auto">{Content}</div>
     </Spin>
   ) : (
     Content


### PR DESCRIPTION
## What this PR does / why we need it:
Fix config page container style bug of two scroll bars appear on the page or jump to the top of the page when updated.


## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/143975596-83567a0c-e3cc-46b9-a022-910a6e154cd6.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=258272&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0IiwiMjQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjQsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG

