### PR TITLE
Hotfix/reset addon plan after change addon type

### DIFF
--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -186,7 +186,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          {/* <MessageCenter show={showMessage} /> */}
+          <MessageCenter show={showMessage} />
         </Shell>
       </div>
     </>

--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -186,7 +186,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          <MessageCenter show={showMessage} />
+          {/* <MessageCenter show={showMessage} /> */}
         </Shell>
       </div>
     </>

--- a/shell/app/modules/project/pages/third-service/components/third-addon-form.tsx
+++ b/shell/app/modules/project/pages/third-service/components/third-addon-form.tsx
@@ -63,6 +63,7 @@ const ThirdAddonForm = (props: IProps) => {
       itemProps: {
         onChange(v: string) {
           onFieldChange('addonName', v);
+          form.setFieldsValue({ plan: undefined });
         },
         disabled: editData !== null || query.addon === AddonType.APIGateway,
       },


### PR DESCRIPTION
## What this PR does / why we need it:
Reset plan field after change addon type, otherwise the plan value will not match the option.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

