### PR TITLE
Hotfix/disable esc close drawer when image preview is open

### DIFF
--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -186,7 +186,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          {/* <MessageCenter show={showMessage} /> */}
+          <MessageCenter show={showMessage} />
         </Shell>
       </div>
     </>

--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -186,7 +186,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          <MessageCenter show={showMessage} />
+          {/* <MessageCenter show={showMessage} /> */}
         </Shell>
       </div>
     </>

--- a/shell/app/layout/stores/layout.ts
+++ b/shell/app/layout/stores/layout.ts
@@ -50,6 +50,7 @@ interface IState {
     height: number;
     width: number;
   };
+  isImagePreviewOpen: boolean;
 }
 
 const initState: IState = {
@@ -66,6 +67,7 @@ const initState: IState = {
     height: 0,
     width: 0,
   },
+  isImagePreviewOpen: false,
 };
 
 const layout = createStore({
@@ -211,6 +213,9 @@ const layout = createStore({
     },
     clearHeaderInfo(state) {
       state.headerInfo = null;
+    },
+    setImagePreviewOpen(state, status: boolean) {
+      state.isImagePreviewOpen = status;
     },
     // 动态更改appList中具体某个app的属性值，e.g. { cmp: { href: 'xxxx' } } 来运行时改变href
     updateAppListProperty(state, payload: Obj<Obj>) {

--- a/shell/app/modules/project/common/components/issue/issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-drawer.tsx
@@ -21,6 +21,7 @@ import { isEqual, find } from 'lodash';
 import { Drawer, Spin, Popconfirm, Input, message, Popover, Button, Modal } from 'antd';
 import { Close as IconCheck, ShareOne as IconShareOne, Copy as IconCopy, Delete as IconDelete } from '@icon-park/react';
 import { SubscribersSelector } from './subscribers-selector';
+import layoutStore from 'layout/stores/layout';
 import './issue-drawer.scss';
 
 type ElementChild = React.ElementType | JSX.Element | string;
@@ -85,6 +86,7 @@ export const IssueDrawer = (props: IProps) => {
   const [title = IssueDrawer.Empty, main = IssueDrawer.Empty, tabs = IssueDrawer.Empty, meta = IssueDrawer.Empty] =
     React.Children.toArray(children);
   const customFieldDetail = issueStore.useStore((s) => s.customFieldDetail);
+  const isImagePreviewOpen = layoutStore.useStore((s) => s.isImagePreviewOpen);
   const [copyTitle, setCopyTitle] = React.useState('');
   const [isChanged, setIsChanged] = React.useState(false);
   const [showCopy, setShowCopy] = React.useState(false);
@@ -94,6 +96,9 @@ export const IssueDrawer = (props: IProps) => {
   const escClose = React.useCallback(
     (e) => {
       if (e.keyCode === 27) {
+        if (isImagePreviewOpen) {
+          return;
+        }
         if (isChanged && confirmCloseTip) {
           Modal.confirm({
             title: confirmCloseTip,
@@ -106,7 +111,7 @@ export const IssueDrawer = (props: IProps) => {
         }
       }
     },
-    [isChanged, confirmCloseTip, onClose],
+    [isChanged, confirmCloseTip, isImagePreviewOpen, onClose],
   );
 
   useEvent('keydown', escClose);


### PR DESCRIPTION
## What this PR does / why we need it:
Support press esc to close image preview, and disable esc to close drawer at the same time.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
cherry-pick release/1.5-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

