### PR TITLE
fix: modify i18n about delete in alarm strategy list

### DIFF
--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -1771,6 +1771,7 @@
     "the parameter names cannot be the same": "the parameter names cannot be the same",
     "the project name displayed on the Erda platform, supports Chinese characters": "The name displayed on the Erda platform, supports Chinese naming",
     "the start date cannot be later than the end date": "the start date cannot be later than the end date",
+    "the alarm strategy will be permanently deleted": "the alarm strategy will be permanently deleted",
     "the use case will not be recovered after it is completely deleted, ": "the use case will not be recovered after it is completely deleted, ",
     "the {index} step in the steps and results is not completed": "the {index} step in the steps and results is not completed",
     "there are duplicates in the {index} interface": "there are duplicates in the {index} interface",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -1771,6 +1771,7 @@
     "the parameter names cannot be the same": "参数名称不能相同",
     "the project name displayed on the Erda platform, supports Chinese characters": "项目在 Erda 平台中显示的名称，支持中文命名",
     "the start date cannot be later than the end date": "开始日期不能晚于结束日期",
+    "the alarm strategy will be permanently deleted": "该告警策略将被永久删除",
     "the use case will not be recovered after it is completely deleted, ": "彻底删除后用例将无法恢复",
     "the {index} step in the steps and results is not completed": "步骤及结果中第 {index} 步未填写完整",
     "there are duplicates in the {index} interface": "第 {index} 个接口中有出参名重复",

--- a/shell/app/modules/cmp/common/alarm-strategy/index.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/index.tsx
@@ -93,7 +93,7 @@ const AlarmStrategyList = ({ scopeType, scopeId, commonPayload }: IProps) => {
   const handleDeleteAlarm = (id: number) => {
     confirm({
       title: i18n.t('dop:are you sure you want to delete this item?'),
-      content: i18n.t('dop:the notification will be permanently deleted'),
+      content: i18n.t('dop:the alarm strategy will be permanently deleted'),
       onOk() {
         deleteAlert(id);
       },


### PR DESCRIPTION
## What this PR does / why we need it:
modify i18n about deleteing in alarm strategy list

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No



## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

