### PR TITLE
fix(common): table columns config cannot be hidden entirely

### DIFF
--- a/shell/app/common/components/table/table-config.tsx
+++ b/shell/app/common/components/table/table-config.tsx
@@ -30,6 +30,8 @@ function TableConfig<T extends object = any>({
     setColumns(newColumns);
   };
 
+  const showLength = columns.filter((item) => item.show).length;
+
   const columnsFilter = columns
     .filter((item) => item.title)
     .map((item: ColumnProps<T>) => (
@@ -38,6 +40,7 @@ function TableConfig<T extends object = any>({
           className="whitespace-nowrap"
           checked={item.show}
           onChange={(e) => onCheck(e.target.checked, item.title as string)}
+          disabled={showLength === 1 && item.show}
         >
           {typeof item.title === 'function' ? item.title({ sortColumn: column, sortOrder: order }) : item.title}
         </Checkbox>


### PR DESCRIPTION
## What this PR does / why we need it:
Table columns config cannot be hidden entirely

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/144535143-75a89b50-2ea6-4df9-b469-96dfc0efe83e.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

