### PR TITLE
Feature/show last two characters for Chinese user name

### DIFF
--- a/shell/app/config-page/components/table/render-types.tsx
+++ b/shell/app/config-page/components/table/render-types.tsx
@@ -25,6 +25,7 @@ import { Download as IconDownLoad, Info as IconInfo, DownOne as IconDownOne } fr
 
 import { WithAuth } from 'user/common';
 import Text from '../text/text';
+import { getAvatarChars } from 'app/common/utils';
 
 const alignMap = {
   center: 'justify-center',
@@ -217,7 +218,7 @@ export const getRender = (val: any, record: CP_TABLE.RowData, extra: any) => {
                   <span key={idx}>
                     {val.showIcon === false ? null : (
                       <Avatar src={cU.avatar} size="small">
-                        {cU.nick ? cU.nick.slice(0, 2) : i18n.t('none')}
+                        {cU.nick ? getAvatarChars(cU.nick) : i18n.t('none')}
                       </Avatar>
                     )}
                     <span className="ml-0.5 mr-1" title={cU.name}>
@@ -473,7 +474,7 @@ const memberSelectorValueItem = (user: any) => {
   return (
     <div className="flex items-center dice-config-table-member-field-selector">
       <Avatar src={avatar || undefined} size="small" className="flex-shrink-0">
-        {nick ? nick.slice(0, 2) : i18n.t('none')}
+        {nick ? getAvatarChars(nick) : i18n.t('none')}
       </Avatar>
       <span className={'ml-1 text-sm nowrap'} title={name}>
         {displayName}

--- a/shell/app/layout/pages/page-container/components/globalNavigation/userMenu.tsx
+++ b/shell/app/layout/pages/page-container/components/globalNavigation/userMenu.tsx
@@ -14,8 +14,10 @@
 import React from 'react';
 import { Popover, Menu, Avatar } from 'antd';
 import { UserMenuProps } from './interface';
+import { getAvatarChars } from 'app/common/utils';
 
 const UserMenu = ({ avatar, name, operations }: UserMenuProps) => {
+  const nick = getAvatarChars(avatar?.chars || '');
   return (
     <Popover
       placement={'rightBottom'}
@@ -25,7 +27,7 @@ const UserMenu = ({ avatar, name, operations }: UserMenuProps) => {
           <div className="user-info flex">
             <div className="avatar">
               <Avatar src={avatar?.src} size={48}>
-                {avatar?.chars || ''}
+                {nick}
               </Avatar>
             </div>
             <div className="desc-container flex items-baseline justify-center flex-col truncate">
@@ -47,7 +49,7 @@ const UserMenu = ({ avatar, name, operations }: UserMenuProps) => {
         </div>
       }
     >
-      <Avatar src={avatar?.src}>{avatar?.chars || ''}</Avatar>
+      <Avatar src={avatar?.src}>{nick}</Avatar>
     </Popover>
   );
 };

--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -186,7 +186,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          {/* <MessageCenter show={showMessage} /> */}
+          <MessageCenter show={showMessage} />
         </Shell>
       </div>
     </>

--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -186,7 +186,7 @@ const PageContainer = ({ route }: IProps) => {
           >
             {MainContent}
           </div>
-          <MessageCenter show={showMessage} />
+          {/* <MessageCenter show={showMessage} /> */}
         </Shell>
       </div>
     </>

--- a/shell/app/modules/project/common/components/issue/subscribers-selector.tsx
+++ b/shell/app/modules/project/common/components/issue/subscribers-selector.tsx
@@ -24,6 +24,7 @@ import {
   Plus as IconPlus,
   Right as IconRight,
 } from '@icon-park/react';
+import { getAvatarChars } from 'app/common/utils';
 
 interface IProps {
   subscribers: string[];
@@ -158,7 +159,7 @@ export const SubscribersSelector = (props: IProps) => {
               return (
                 <div key={user.id}>
                   <Avatar src={user.avatar} size="small">
-                    {user.nick ? user.nick.slice(0, 2) : i18n.t('none')}
+                    {user.nick ? getAvatarChars(user.nick) : i18n.t('none')}
                   </Avatar>
                   <span className="ml-1">{user.nick ?? ''}</span>
                 </div>

--- a/shell/app/modules/project/pages/issue/component/table-view.tsx
+++ b/shell/app/modules/project/pages/issue/component/table-view.tsx
@@ -20,7 +20,7 @@ import issueWorkflowStore from 'project/stores/issue-workflow';
 import { MemberSelector, Icon as CustomIcon, FilterGroup } from 'common';
 import { useUpdate } from 'common/use-hooks';
 import { ColumnProps } from 'core/common/interface';
-import { updateSearch, insertWhen } from 'common/utils';
+import { updateSearch, insertWhen, getAvatarChars } from 'common/utils';
 import IssueTitleLabel from './title-label';
 import {
   ISSUE_ICON,
@@ -74,7 +74,7 @@ export const memberSelectorValueItem = (user: any) => {
   return (
     <div className="flex items-center hover-active issue-field-selector">
       <Avatar src={avatar} size="small">
-        {nick ? nick.slice(0, 2) : i18n.t('none')}
+        {nick ? getAvatarChars(nick) : i18n.t('none')}
       </Avatar>
       <span className={'ml-2 text-sm'} title={name}>
         {displayName}

--- a/shell/app/modules/project/pages/issue/plan/index.tsx
+++ b/shell/app/modules/project/pages/issue/plan/index.tsx
@@ -112,7 +112,7 @@ const TreeNodeRender = (props: ITreeNodeProps) => {
         <>
           <div className="truncate flex-1 ml-1">{name}</div>
           <div className="flex items-center ml-2">
-            <Avatar size={16}>{user.slice(0, 1)}</Avatar>
+            <Avatar size={16}>{getAvatarChars(user || '')}</Avatar>
             {status ? (
               <div className="ml-1">
                 <Badge showDot={false} text={status.text} status={status?.status || 'default'} />

--- a/shell/app/modules/project/pages/issue/plan/index.tsx
+++ b/shell/app/modules/project/pages/issue/plan/index.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import DiceConfigPage, { useMock } from 'app/config-page';
 import { ISSUE_TYPE } from 'project/common/components/issue/issue-config';
 import { getUrlQuery, statusColorMap } from 'config-page/utils';
-import { updateSearch } from 'common/utils';
+import { getAvatarChars, updateSearch } from 'common/utils';
 import { Badge, ErdaIcon } from 'common';
 import { useUpdate, useSwitch } from 'common/use-hooks';
 import { IssueIcon } from 'project/common/components/issue/issue-icon';


### PR DESCRIPTION
## What this PR does / why we need it:
show last two characters for Chinese user name

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  show last two characters for Chinese user name when no avatar image  |
| 🇨🇳 中文    |  没有头像时展示中文名称的后两个字母  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

