### PR TITLE
Feat: export config page components mock data as default

### DIFF
--- a/shell/app/common/__tests__/utils/str-num-date.test.tsx
+++ b/shell/app/common/__tests__/utils/str-num-date.test.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
-  camel2Underscore,
+  camel2DashName,
   getStrRealLen,
   px2Int,
   getDateDuration,
@@ -30,8 +30,8 @@ import moment from 'moment';
 const title = 'erda cloud';
 
 describe('str-num-date', () => {
-  it('camel2Underscore', () => {
-    expect(camel2Underscore('ErdaCloud')).toBe('_erda_cloud');
+  it('camel2DashName', () => {
+    expect(camel2DashName('ErdaCloud')).toBe('erda-cloud');
   });
   it('getStrRealLen', () => {
     expect(getStrRealLen(title, true, 5)).toBe(4);

--- a/shell/app/common/utils/index.ts
+++ b/shell/app/common/utils/index.ts
@@ -18,6 +18,7 @@ import { PAGINATION } from 'app/constants';
 import moment from 'moment';
 import { Key, pathToRegexp, compile } from 'path-to-regexp';
 import { AxiosResponse } from 'axios';
+import AnsiUp from 'ansi_up';
 
 export { createCRUDStore, createCRUDService } from '../stores/_crud_module';
 
@@ -28,7 +29,7 @@ export { goTo, pages, resolvePath } from './go-to';
 export { qs, mergeSearch, updateSearch, setSearch } from './query-string';
 // 字符串、数字、时间工具
 export {
-  camel2Underscore,
+  camel2DashName,
   cutStr,
   secondsToTime,
   fromNow,
@@ -39,7 +40,6 @@ export {
   daysRange,
   formatTime,
 } from './str-num-date';
-import AnsiUp from 'ansi_up';
 
 export { getLabel } from './component-utils';
 

--- a/shell/app/common/utils/str-num-date.tsx
+++ b/shell/app/common/utils/str-num-date.tsx
@@ -29,7 +29,7 @@ moment.locale(momentLangMap[locale]);
  * transform camel case dash string: `CamelComponent -> camel-component / camel_component`
  */
 export const camel2DashName = (_str: string, symbol = '-') => {
-  const str = _str[0].toLowerCase() + _str.substr(1);
+  const str = `${_str[0].toLowerCase()}${_str.substr(1)}`;
   return str.replace(/([A-Z])/g, ($1) => `${symbol}${$1.toLowerCase()}`);
 };
 

--- a/shell/app/common/utils/str-num-date.tsx
+++ b/shell/app/common/utils/str-num-date.tsx
@@ -25,9 +25,12 @@ const momentLangMap = {
 };
 moment.locale(momentLangMap[locale]);
 
-export const camel2Underscore = (str: string, options = { upperCase: false }) => {
-  const underscoreStr = str.replace(/[A-Z]+/g, '_$&');
-  return options.upperCase ? underscoreStr.toUpperCase() : underscoreStr.toLowerCase();
+/**
+ * transform camel case dash string: `CamelComponent -> camel-component / camel_component`
+ */
+export const camel2DashName = (_str: string, symbol = '-') => {
+  const str = _str[0].toLowerCase() + _str.substr(1);
+  return str.replace(/([A-Z])/g, ($1) => `${symbol}${$1.toLowerCase()}`);
 };
 
 export function getStrRealLen(strr: string, isByte: boolean, byteLen: number) {

--- a/shell/app/config-page/components/bar-chart/bar-chart.mock.ts
+++ b/shell/app/config-page/components/bar-chart/bar-chart.mock.ts
@@ -23,7 +23,9 @@ const mockData: CP_BAR_CHART.Spec = {
     grayBg: true,
   },
   data: {
-    option: {},
+    option: {
+      series: [],
+    },
   },
   cId: 'string',
 };

--- a/shell/app/config-page/components/container/container.mock.ts
+++ b/shell/app/config-page/components/container/container.mock.ts
@@ -11,9 +11,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_CONTAINER.Spec = {
+const mockData: CP_CONTAINER.Spec = {
   type: 'RowContainer',
   props: {
     isTopHead: true,
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/contractive-filter/contractive-filter.mock.ts
+++ b/shell/app/config-page/components/contractive-filter/contractive-filter.mock.ts
@@ -11,9 +11,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_FILTER.Spec = {
+const mockData: CP_FILTER.Spec = {
   type: 'ContractiveFilter',
-  name: 'issueFilter',
   props: {
     delay: 300,
   },
@@ -96,3 +95,5 @@ export const mockData: CP_FILTER.Spec = {
     },
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/copy-button/copy-button.mock.ts
+++ b/shell/app/config-page/components/copy-button/copy-button.mock.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_COPY_BUTTON.Spec = {
+const mockData: CP_COPY_BUTTON.Spec = {
   type: 'CopyButton',
   props: {
     copyText: '复制的内容',
@@ -20,3 +20,5 @@ export const mockData: CP_COPY_BUTTON.Spec = {
     renderType: 'icon', // or button
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/dropdown-select/dropdown-select.mock.ts
+++ b/shell/app/config-page/components/dropdown-select/dropdown-select.mock.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_DROPDOWN_SELECT.Spec = {
+const mockData: CP_DROPDOWN_SELECT.Spec = {
   type: 'DropdownSelect',
   props: {
     visible: true,
@@ -86,3 +86,5 @@ export const mockData: CP_DROPDOWN_SELECT.Spec = {
     value: 'organizeA',
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/form-modal/form-modal.mock.ts
+++ b/shell/app/config-page/components/form-modal/form-modal.mock.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_FORM_MODAL.Spec = {
+const mockData: CP_FORM_MODAL.Spec = {
   type: 'FormModal',
   operations: {
     submit: {
@@ -54,3 +54,5 @@ export const mockData: CP_FORM_MODAL.Spec = {
     formData: undefined,
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/info-preview/info-preview.mock.ts
+++ b/shell/app/config-page/components/info-preview/info-preview.mock.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_INFO_PREVIEW.Spec = {
+const mockData: CP_INFO_PREVIEW.Spec = {
   type: 'InfoPreview',
   data: {
     info: {
@@ -111,3 +111,5 @@ export const mockData: CP_INFO_PREVIEW.Spec = {
     ],
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/input-select/input-select.mock.ts
+++ b/shell/app/config-page/components/input-select/input-select.mock.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData = {
+const mockData = {
   type: 'InputSelect',
   props: {
     options: [
@@ -40,3 +40,5 @@ export const mockData = {
     },
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/sort-drag-group/sort-drag-group.mock.ts
+++ b/shell/app/config-page/components/sort-drag-group/sort-drag-group.mock.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_SORT_GROUP.Spec = {
+const mockData: CP_SORT_GROUP.Spec = {
   type: 'SortGroup',
   state: {
     dragParams: {
@@ -130,3 +130,5 @@ export const mockData: CP_SORT_GROUP.Spec = {
     ],
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/components/tree-select/tree-select.mock.ts
+++ b/shell/app/config-page/components/tree-select/tree-select.mock.ts
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-export const mockData: CP_TREE_SELECT.Spec = {
+const mockData: CP_TREE_SELECT.Spec = {
   type: 'TreeSelect',
   data: {
     treeData: [
@@ -46,3 +46,5 @@ export const mockData: CP_TREE_SELECT.Spec = {
     },
   },
 };
+
+export default mockData;

--- a/shell/app/config-page/mock/gallery.tsx
+++ b/shell/app/config-page/mock/gallery.tsx
@@ -12,6 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import { Col, Row } from 'antd';
+import { camel2DashName } from 'app/common/utils';
 import { ErrorBoundary, FileEditor } from 'common';
 import React from 'react';
 import { containerMap as componentsMap } from '../components';
@@ -21,7 +22,7 @@ const Mock = () => {
   const [Comps, setComps] = React.useState({});
   React.useEffect(() => {
     Object.keys(componentsMap).map((key) => {
-      const filename = key.toLowerCase().replace('-', '');
+      const filename = camel2DashName(key);
       // /* @vite-ignore */
       import(`../components/${filename}/${filename}.mock`)
         .then((module) => {
@@ -38,7 +39,7 @@ const Mock = () => {
           }));
         })
         .catch(() => {
-          console.log(`component missing mock data: `, key);
+          console.log(`component missing mock data: `, filename);
         });
     });
   }, []);

--- a/shell/app/config-page/mock/gallery.tsx
+++ b/shell/app/config-page/mock/gallery.tsx
@@ -29,6 +29,7 @@ const Mock = () => {
           const mockData = module.default;
           let Component = componentsMap[key];
           Component = mockData ? Component : noop;
+          // eslint-disable-next-line no-console
           console.log('mock data', key, mockData);
           setComps((prev) => ({
             ...prev,
@@ -39,6 +40,7 @@ const Mock = () => {
           }));
         })
         .catch(() => {
+          // eslint-disable-next-line no-console
           console.log(`component missing mock data: `, filename);
         });
     });
@@ -76,7 +78,7 @@ const Mock = () => {
                 <FileEditor
                   fileExtension={'json'}
                   value={JSON.stringify(pureConfig, null, 2)}
-                  onChange={(v) => console.log(v)}
+                  // onChange={(v) => console.log(v)}
                   maxLines={20}
                 />
               </Col>


### PR DESCRIPTION
## What this PR does / why we need it:
Export config page components mock data as default to show all exist component in gallery.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

