### PR TITLE
fix: not show operation when action is empty

### DIFF
--- a/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
@@ -330,7 +330,7 @@ const Transaction = () => {
       },
     };
 
-    return currentProject?.type !== 'MSP' ? [viewLog] : [];
+    return [viewLog];
   };
 
   const actions: IActions<TOPOLOGY_SERVICE_ANALYZE.TranslationSlowRecord> = {
@@ -423,7 +423,7 @@ const Transaction = () => {
         <Table
           slot={traceSlowSlot}
           loading={isFetching}
-          actions={actions}
+          actions={currentProject?.type !== 'MSP' ? actions : null}
           rowKey="requestId"
           onRow={(record) => {
             return {


### PR DESCRIPTION
## What this PR does / why we need it:
Don't show operation when action is empty

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

