### PR TITLE
style: display avatar and not show loadMore when dragging in kanban

### DIFF
--- a/shell/app/config-page/components/issue-kanban.tsx
+++ b/shell/app/config-page/components/issue-kanban.tsx
@@ -18,7 +18,7 @@ import { Card } from './kanban-card/card';
 import { Input, Button, Popconfirm, Tooltip, Avatar } from 'antd';
 import { EmptyHolder, Badge, ErdaIcon } from 'common';
 import { getAvatarChars } from 'app/common/utils';
-import { notify } from 'common/utils';
+import { notify, ossImg } from 'common/utils';
 import { WithAuth } from 'user/common';
 import { Delete as IconDelete, Plus as IconPlus } from '@icon-park/react';
 import { useUserMap } from 'core/stores/userMap';
@@ -247,7 +247,9 @@ const Kanban = (props: IKanbanProps) => {
         operations,
         extraInfo: (
           <div className="issue-kanban-info mt-1 flex flex-col text-desc">
-            {labels?.value?.length > 0 && <Tags labels={labels.value} size="small" showCount={labels?.showCount} />}
+            {labels?.value?.length > 0 && (
+              <Tags labels={labels.value} size="small" maxShowCount={labels?.maxShowCount} />
+            )}
             <div className="flex justify-between items-center mt-1">
               <div className="flex justify-between items-center">
                 <span className="flex items-center mr-2">
@@ -268,7 +270,9 @@ const Kanban = (props: IKanbanProps) => {
               </div>
               {Object.keys(assigneeObj).length > 0 ? (
                 <span>
-                  <Avatar size={24}>{getAvatarChars(assigneeObj.nick || assigneeObj.name)}</Avatar>
+                  <Avatar src={assigneeObj.avatar ? ossImg(assigneeObj.avatar, { w: 24 }) : undefined} size={24}>
+                    {getAvatarChars(assigneeObj.nick || assigneeObj.name)}
+                  </Avatar>
                 </span>
               ) : (
                 <ErdaIcon size={24} type="morentouxiang" />
@@ -380,7 +384,7 @@ const Kanban = (props: IKanbanProps) => {
             />
           );
         })}
-        {hasMore ? (
+        {hasMore && !isDrag ? (
           <div className="hover-active py-1 text-center load-more" onClick={() => loadMore()}>
             {i18n.t('load more')}
           </div>


### PR DESCRIPTION
## What this PR does / why we need it:
displaying avatar and not show loadMore when dragging in kanban

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

