### PR TITLE
fix(common): hidden replace show to decide whether to display table c…

### DIFF
--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -244,7 +244,7 @@ function WrappedTable<T extends object = any>({
           ellipsis: true,
           onCell: () => ({ style: { maxWidth: width }, className: align === 'right' && sorter ? 'pr-8' : '' }),
           render: columnRender,
-          hidden: show === false,
+          hidden: show === false, // TODO: change to false after all show has been replaced
           ...args,
         };
       }),

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -176,7 +176,7 @@ function WrappedTable<T extends object = any>({
 
   React.useEffect(() => {
     setColumns(
-      allColumns.map(({ width = 300, sorter, title, render, icon, align, ...args }: ColumnProps<T>) => {
+      allColumns.map(({ width = 300, sorter, title, render, icon, align, show, ...args }: ColumnProps<T>) => {
         const { subTitle } = args;
         let sortTitle;
         if (sorter) {
@@ -244,7 +244,7 @@ function WrappedTable<T extends object = any>({
           ellipsis: true,
           onCell: () => ({ style: { maxWidth: width }, className: align === 'right' && sorter ? 'pr-8' : '' }),
           render: columnRender,
-          show: true,
+          hidden: show === false,
           ...args,
         };
       }),
@@ -280,7 +280,7 @@ function WrappedTable<T extends object = any>({
       <Table
         scroll={{ x: '100%' }}
         columns={[
-          ...columns.filter((item) => item.show).map((item) => ({ ...item, title: item.sortTitle || item.title })),
+          ...columns.filter((item) => !item.hidden).map((item) => ({ ...item, title: item.sortTitle || item.title })),
           ...renderActions(actions),
         ]}
         rowClassName={onRow ? `cursor-pointer ${rowClassName || ''}` : rowClassName}

--- a/shell/app/common/components/table/interface.ts
+++ b/shell/app/common/components/table/interface.ts
@@ -38,6 +38,7 @@ export interface ColumnProps<T> extends AntdColumnProps<T> {
   subTitle?: ((text: string, record: T, index: number) => React.ReactNode) | React.ReactNode;
   icon?: ((text: string, record: T, index: number) => React.ReactNode) | React.ReactNode;
   show?: boolean;
+  hidden?: boolean;
   sortTitle?: React.ReactNode;
 }
 

--- a/shell/app/common/components/table/table-config.tsx
+++ b/shell/app/common/components/table/table-config.tsx
@@ -25,12 +25,12 @@ function TableConfig<T extends object = any>({
 }: TableConfigProps<T>) {
   const { column, order } = sortColumn;
   const onCheck = (checked: boolean, title: string) => {
-    const newColumns = columns.map((item) => (item.title === title ? { ...item, show: checked } : item));
+    const newColumns = columns.map((item) => (item.title === title ? { ...item, hidden: !checked } : item));
 
     setColumns(newColumns);
   };
 
-  const showLength = columns.filter((item) => item.show).length;
+  const showLength = columns.filter((item) => !item.hidden).length;
 
   const columnsFilter = columns
     .filter((item) => item.title)
@@ -38,9 +38,9 @@ function TableConfig<T extends object = any>({
       <div>
         <Checkbox
           className="whitespace-nowrap"
-          checked={item.show}
+          checked={!item.hidden}
           onChange={(e) => onCheck(e.target.checked, item.title as string)}
-          disabled={showLength === 1 && item.show}
+          disabled={showLength === 1 && !item.hidden}
         >
           {typeof item.title === 'function' ? item.title({ sortColumn: column, sortOrder: order }) : item.title}
         </Checkbox>


### PR DESCRIPTION
…olumns

## What this PR does / why we need it:
hidden replace show to decide whether to display table columns.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

