### PR TITLE
fix: normal branch name display

### DIFF
--- a/shell/app/modules/application/pages/repo/repo-branch.tsx
+++ b/shell/app/modules/application/pages/repo/repo-branch.tsx
@@ -25,6 +25,7 @@ import './repo-branch.scss';
 import repoStore from 'application/stores/repo';
 import { useLoading } from 'core/stores/loading';
 import appStore from 'application/stores/application';
+import DOMPurify from 'dompurify';
 
 const { Search } = Input;
 
@@ -120,7 +121,10 @@ const RepoBranch = () => {
                     {i18n.t('compare')}
                   </Button>
                   <DeleteConfirm
-                    title={i18n.t('common:confirm to delete {name} ?', { name: `${name} ${i18n.t('dop:branch')}` })}
+                    title={i18n.t('common:confirm to delete {name} ?', {
+                      name: `${name} ${i18n.t('dop:branch')}`,
+                      interpolation: { escape: (str) => DOMPurify.sanitize(str) },
+                    })}
                     onConfirm={() => {
                       deleteBranch({ branch: name });
                     }}


### PR DESCRIPTION
## What this PR does / why we need it:
prevent to escape `/` in normal branch name.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

