### PR TITLE
style: add highlight animation to card after dragging successful in kanban

### DIFF
--- a/shell/app/config-page/components/issue-kanban.scss
+++ b/shell/app/config-page/components/issue-kanban.scss
@@ -95,6 +95,16 @@
       opacity: 0.5;
     }
 
+    .dragged-card {
+      animation: changeCardBg 0.5s linear 0.3s;
+    }
+
+    @keyframes changeCardBg {
+      50% {
+        background-color: rgba($color-purple-deep, 0.1);
+      }
+    }
+
     .list-item {
       margin-bottom: 12px;
       background-color: $white;

--- a/shell/app/config-page/components/issue-kanban.scss
+++ b/shell/app/config-page/components/issue-kanban.scss
@@ -96,7 +96,7 @@
     }
 
     .dragged-card {
-      animation: changeCardBg 0.5s linear 0.3s;
+      animation: changeCardBg 1s linear 0.3s;
     }
 
     @keyframes changeCardBg {

--- a/shell/app/config-page/components/issue-kanban.tsx
+++ b/shell/app/config-page/components/issue-kanban.tsx
@@ -165,8 +165,8 @@ interface IKanbanProps extends CONFIG_PAGE.ICommonProps {
   setBoard: Function;
   isDrag: boolean;
   setIsDrag: (isDrag: boolean) => void;
-  currentCard: CardData;
-  setCurrentCard: (item: CardData) => void;
+  currentCard: CardData | null;
+  setCurrentCard: (value: CardData | null) => void;
   exitLabel: string[];
   refreshBoard?: boolean;
 }
@@ -211,6 +211,7 @@ const Kanban = (props: IKanbanProps) => {
       // same state, do nothing
       const { drag } = item.data.operations;
       if (!drag.targetKeys[labelKey]) {
+        setCurrentCard(null);
         return;
       }
       setCurrentCard(item.data);

--- a/shell/app/config-page/components/kanban-card/card.tsx
+++ b/shell/app/config-page/components/kanban-card/card.tsx
@@ -59,7 +59,7 @@ export const Card = (props: CP_CARD.Props) => {
 
   return (
     <div className={`${className} ${cls} boxShadow-card`} onClick={() => clickNode(data)}>
-      <div className="info-card-content p-2" key={id} ref={drag}>
+      <div className="info-card-content px-4 py-3" key={id} ref={drag}>
         <div className={'flex justify-between items-start mb-1'}>
           {isString(titleIcon) ? <CustomIcon type={titleIcon} color className="head-icon mr-1" /> : titleIcon || null}
 


### PR DESCRIPTION
## What this PR does / why we need it:
1. add highlight animation to card after dragging successful in kanban
2. modify card padding
3. remove issue id of card

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![2021-12-09 11 18 24](https://user-images.githubusercontent.com/30014895/145328892-49753523-243b-4342-aa7f-dc491a9a7ebc.gif)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | highlight card after dragging successful in kanban |
| 🇨🇳 中文    | 卡片拖拽成功后添加高亮动画至此卡片 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

