### PR TITLE
fix: msp project with applicationId in service overview

### DIFF
--- a/shell/app/modules/msp/env-overview/service-list/pages/service-list-dashboard.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/service-list-dashboard.tsx
@@ -18,6 +18,7 @@ import dashboardStore from 'common/stores/dashboard';
 import routeInfoStore from 'core/stores/route';
 import { isEqual } from 'lodash';
 import serviceAnalyticsStore from 'msp/stores/service-analytics';
+import mspStore from 'msp/stores/micro-service';
 
 type IProps = Merge<
   Partial<DC.PureBoardGridProps>,
@@ -36,6 +37,7 @@ const ServiceListDashboard: React.FC<IProps> = ({ timeSpan: times, dashboardId, 
   const { getCustomDashboard } = dashboardStore;
   const [layout, setLayout] = useState<DC.Layout>([]);
   const [serviceId, serviceName] = serviceAnalyticsStore.useStore((s) => [s.serviceId, s.serviceName]);
+  const type = mspStore.useStore((s) => s.currentProject.type);
 
   const globalVariable = useMemo(() => {
     const { terminusKey, applicationId } = params;
@@ -46,7 +48,7 @@ const ServiceListDashboard: React.FC<IProps> = ({ timeSpan: times, dashboardId, 
       serviceId: window.decodeURIComponent(serviceId),
       startTime: startTimeMs,
       endTime: endTimeMs,
-      applicationId,
+      applicationId: type === 'MSP' ? undefined : applicationId,
       ...extraGlobalVariable,
     };
   }, [params, timeSpan, serviceName, serviceId, extraGlobalVariable]);


### PR DESCRIPTION
## What this PR does / why we need it:
msp project without applicationId to request in service overview

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

