### PR TITLE
fix: clear page protocol interval timer when unmount

### DIFF
--- a/shell/app/config-page/index.tsx
+++ b/shell/app/config-page/index.tsx
@@ -141,7 +141,6 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
 
   React.useEffect(() => {
     pageConfigRef.current = pageConfig;
-    clearInterval(timerRef.current);
     if (pageConfig?.protocol?.options?.syncIntervalSecond) {
       timerRef.current = setInterval(() => {
         execOperation('', {
@@ -150,6 +149,9 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
         });
       }, pageConfig?.protocol?.options?.syncIntervalSecond * 1000);
     }
+    return () => {
+      clearInterval(timerRef.current);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageConfig]);
 


### PR DESCRIPTION
## What this PR does / why we need it:
Fix timer still running after leave component-protocol page.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

