### PR TITLE
fix: modify color in kanban

### DIFF
--- a/shell/app/common/components/tags/index.scss
+++ b/shell/app/common/components/tags/index.scss
@@ -17,7 +17,7 @@
     text-align: center;
 
     &:hover {
-      background-color: $color-active;
+      background-color: $color-purple-deep;
       color: $white;
     }
 
@@ -25,6 +25,11 @@
       width: 20px;
       height: 20px;
       line-height: 24px;
+
+      &:hover {
+        background-color: $color-purple-deep;
+        color: $white;
+      }
     }
   }
 

--- a/shell/app/config-page/components/issue-kanban.scss
+++ b/shell/app/config-page/components/issue-kanban.scss
@@ -51,6 +51,7 @@
     .issue-kanban-label-input {
       padding-left: 0;
       border: 1px solid transparent;
+      background: transparent;
 
       &:hover {
         border: 1px solid $primary;

--- a/shell/app/config-page/components/issue-kanban.tsx
+++ b/shell/app/config-page/components/issue-kanban.tsx
@@ -293,7 +293,7 @@ const Kanban = (props: IKanbanProps) => {
                   {priority && (
                     <span className="flex items-center">
                       <IssueIcon type={priority} iconMap="PRIORITY" size="16px" />
-                      <span className="ml-1">{ISSUE_PRIORITY_MAP[priority].label}</span>
+                      <span className="ml-1 text-default">{ISSUE_PRIORITY_MAP[priority].label}</span>
                     </span>
                   )}
                 </span>

--- a/shell/app/config-page/components/issue-kanban.tsx
+++ b/shell/app/config-page/components/issue-kanban.tsx
@@ -266,7 +266,7 @@ const Kanban = (props: IKanbanProps) => {
   });
 
   const changeData = (item: any) => {
-    const { id, title, operations, assignee, labels, type, priority, status } = item;
+    const { id, title, operations, assignee, type, priority } = item;
     const assigneeObj = userMap[assignee] || {};
     return {
       ...item,
@@ -278,17 +278,11 @@ const Kanban = (props: IKanbanProps) => {
         operations,
         extraInfo: (
           <div className="issue-kanban-info mt-1 flex flex-col text-desc">
-            {labels?.value?.length > 0 && (
-              <Tags labels={labels.value} size="small" maxShowCount={labels?.maxShowCount} />
-            )}
             <div className="flex justify-between items-center mt-1">
               <div className="flex justify-between items-center">
                 <span className="flex items-center mr-2">
                   <IssueIcon type={type} size="16px" />
                 </span>
-                {status && Object.keys(status).length > 0 && (
-                  <Badge status={status.status} text={status.text} showDot={false} className="mr-2" />
-                )}
                 <span className="w-20 mr-1">
                   {priority && (
                     <span className="flex items-center">


### PR DESCRIPTION
## What this PR does / why we need it:
1. modify color in kanban
2. remove labels and status in kanban

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | remove  labels and status in kanban |
| 🇨🇳 中文    | 将看板上的标签及状态信息去除  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

