### PR TITLE
fix(dop): issue table filter close icon color bug

### DIFF
--- a/shell/app/common/components/contractive-filter/index.scss
+++ b/shell/app/common/components/contractive-filter/index.scss
@@ -78,12 +78,8 @@
     left: -6px;
     z-index: 2;
     display: none;
-    color: $lightgray;
+    color: rgba($color-default, 0.4);
     cursor: pointer;
-
-    &:hover {
-      color: $gray;
-    }
   }
 
   .ant-input {


### PR DESCRIPTION
## What this PR does / why we need it:
Issue table filter close icon color bug

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/145532628-1660b689-c176-47cd-938f-435750a378f3.png)
->
![image](https://user-images.githubusercontent.com/82502479/145532602-e2563104-c655-49f6-ae6f-45373a07a6da.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=263470&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=-1&type=BUG

