### PR TITLE
feat: move header tabs align with page title

### DIFF
--- a/shell/app/common/components/menu/index.tsx
+++ b/shell/app/common/components/menu/index.tsx
@@ -22,7 +22,6 @@ interface IMenuItem {
   key: string;
   name: string;
   disabled?: boolean;
-  split?: boolean;
 }
 
 interface IMenu {
@@ -70,6 +69,7 @@ const PureMenu = (props: IMenu) => {
   }
   const tabClass = classnames({
     'tab-menu': true,
+    'tab-split-line-before': true,
     [className]: !!className,
   });
 
@@ -113,11 +113,10 @@ const PureMenu = (props: IMenu) => {
     <div className={tabClass}>
       <ul className="tab-item-wraps">
         {finalMenus.map((menu: Merge<IMenuItem, { hrefType: 'back' }>) => {
-          const { disabled, key, name, hrefType, split } = menu;
+          const { disabled, key, name, hrefType } = menu;
           const menuItemClass = classnames({
             'tab-menu-item': true,
             'tab-menu-disabled': disabled,
-            'tab-split-line-before': split,
             active: activeKey === key,
           });
           return (

--- a/shell/app/layout/pages/page-container/components/header.scss
+++ b/shell/app/layout/pages/page-container/components/header.scss
@@ -1,25 +1,17 @@
 .erda-header {
-  padding: 11px 24px 0 24px;
-  background-color: #fff;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0 16px 0 16px;
+  background-color: $white;
 
   &-breadcrumb {
     padding: 6px 0;
   }
 
   &-top {
-    height: 50px;
+    height: 34px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 12px 0;
-
-    &-left {
-      display: flex;
-      align-items: center;
-      max-width: calc(100% - 100px);
-      min-width: 200px;
-    }
+    max-width: calc(100% - 130px);
+    min-width: 200px;
 
     .erda-header-title-con {
       font-family: PingFangSC-Medium;
@@ -35,40 +27,30 @@
         align-items: center;
         width: 100%;
         font-size: 20px;
-
-        &-text {
-          color: rgba(9, 24, 33, 0.84);
-          font-size: 18px;
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        }
+        color: rgba(9, 24, 33, 0.84);
       }
     }
   }
 
-  &-content {
-    margin: 0;
-
-    .tab-item-wraps {
-      .active {
-        background: transparent;
-      }
+  .tab-split-line-before {
+    &::before {
+      position: relative;
+      content: '';
+      display: inline-block;
+      width: 15px;
+      height: 12px;
+      border-left: 1px solid rgba($color-default, 0.16);
+      top: -1px;
     }
+  }
 
-    .tab-menu .tab-menu-item {
-      height: 32px;
-      line-height: 32px;
-      &.tab-split-line-before {
-        &::before {
-          position: absolute;
-          content: '';
-          width: 1px;
-          height: 12px;
-          left: -20px;
-          top: 10px;
-          background-color: $color-text-desc;
-        }
+  .tab-menu-item {
+    height: 32px;
+    line-height: 32px;
+    margin-right: 24px;
+    &.tab-split-line-before {
+      &::before {
+        top: 1px;
       }
     }
   }

--- a/shell/app/layout/pages/page-container/components/header.tsx
+++ b/shell/app/layout/pages/page-container/components/header.tsx
@@ -75,7 +75,7 @@ const BreadcrumbItem = ({
 };
 
 const Header = () => {
-  const [headerInfo, currentApp] = layoutStore.useStore((s) => [s.headerInfo, s.currentApp]);
+  const [currentApp] = layoutStore.useStore((s) => [s.currentApp]);
   const routes: IRoute[] = routeInfoStore.useStore((s) => s.routes);
   const [pageName, setPageName] = React.useState<string>();
   const infoMap = breadcrumbStore.useStore((s) => s.infoMap);
@@ -186,10 +186,8 @@ const Header = () => {
       return <Comp />;
     }
     return (
-      <div className="erda-header-title">
-        <div className="erda-header-title-text">
-          <Tooltip title={pageName}>{pageName}</Tooltip>
-        </div>
+      <div className="erda-header-title truncate">
+        <Tooltip title={pageName}>{pageName}</Tooltip>
       </div>
     );
   };
@@ -208,12 +206,7 @@ const Header = () => {
       </div>
 
       <div className={'erda-header-top'}>
-        <div className={'erda-header-top-left'}>
-          <div className="erda-header-title-con">{pageName && displayPageName()}</div>
-        </div>
-      </div>
-      <div className={'erda-header-content'}>
-        {headerInfo && <div className="header-info">{React.cloneElement(headerInfo)}</div>}
+        <div className="erda-header-title-con">{pageName && displayPageName()}</div>
         <Tab />
       </div>
     </div>

--- a/shell/app/layout/pages/page-container/components/shell/index.scss
+++ b/shell/app/layout/pages/page-container/components/shell/index.scss
@@ -4,6 +4,5 @@
 
   .erda-main-content {
     flex: auto;
-    background: $color-bg;
   }
 }

--- a/shell/app/layout/pages/page-container/components/sub-sidebar.scss
+++ b/shell/app/layout/pages/page-container/components/sub-sidebar.scss
@@ -39,6 +39,7 @@
 .side-nav-menu {
   transition: width 0.3s cubic-bezier(0.2, 0, 0, 1) 0s;
   scrollbar-width: 0;
+  background-color: $white;
   .menu-container {
     .fold {
       height: auto;

--- a/shell/app/layout/stores/layout.ts
+++ b/shell/app/layout/stores/layout.ts
@@ -45,7 +45,6 @@ interface IState {
   announcementList: AnnouncementItem[];
   customMain: Function | JSX.Element | null;
   showMessage: boolean;
-  headerInfo: React.ReactElement | null;
   client: {
     height: number;
     width: number;
@@ -61,7 +60,6 @@ const initState: IState = {
   announcementList: [],
   customMain: null,
   showMessage: false,
-  headerInfo: null,
   sideFold: false,
   client: {
     height: 0,
@@ -207,12 +205,6 @@ const layout = createStore({
     },
     switchMessageCenter(state, payload) {
       state.showMessage = typeof payload === 'boolean' ? payload : !state.showMessage;
-    },
-    setHeaderInfo(state, payload) {
-      state.headerInfo = payload;
-    },
-    clearHeaderInfo(state) {
-      state.headerInfo = null;
     },
     setImagePreviewOpen(state, status: boolean) {
       state.isImagePreviewOpen = status;

--- a/shell/app/modules/application/pages/quality/index.tsx
+++ b/shell/app/modules/application/pages/quality/index.tsx
@@ -96,7 +96,6 @@ const CodeQuality = () => {
       }
     });
     return () => {
-      layoutStore.reducers.clearHeaderInfo();
       clearSonarResults();
     };
   });

--- a/shell/app/modules/project/tabs.tsx
+++ b/shell/app/modules/project/tabs.tsx
@@ -137,7 +137,6 @@ export const COLLABORATE_TABS = () => {
       key: 'plan',
       name: i18n.t('plan'),
       show: projectPerm.requirement.read.pass,
-      split: true,
     },
   ];
 };

--- a/shell/app/styles/_mixin.scss
+++ b/shell/app/styles/_mixin.scss
@@ -172,15 +172,8 @@ $lg-break-width: $sider-width + $subsider-width + $lg-content-break-width;
 
 %top-button-group {
   position: fixed;
-
-  top: 45px;
-  right: 16px;
-
-  @include md-width() {
-    & {
-      right: 12px;
-    }
-  }
+  top: 32px;
+  right: 12px;
 
   button {
     margin-left: $p8;

--- a/shell/app/styles/app.scss
+++ b/shell/app/styles/app.scss
@@ -53,6 +53,7 @@ html body {
   font-family: 'Roboto-Regular', 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Helvetica Neue',
     Arial, sans-serif;
   line-height: 18px;
+  background-color: $color-bg;
 }
 
 html body[lang='en'] {


### PR DESCRIPTION
## What this PR does / why we need it:
update page tabs position

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/145543078-65bd7f02-1407-4408-b11b-635070e72d5c.png)
->
![image](https://user-images.githubusercontent.com/3955437/145543118-33e456df-01bd-4fab-83b6-27a18498a1b6.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | move header tabs align with page title  |
| 🇨🇳 中文    | 移动页面选项卡到上面与标题对齐 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

