### PR TITLE
fix(common): get announcements list at initialization

### DIFF
--- a/shell/app/org-home/stores/org.tsx
+++ b/shell/app/org-home/stores/org.tsx
@@ -79,6 +79,13 @@ const org = createStore({
         }
       });
     });
+
+    const orgId = org.getState((s) => s.currentOrg.id);
+    if (orgId) {
+      announcementStore.effects.getAllNoticeListByStatus('published').then((list) => {
+        layoutStore.reducers.setAnnouncementList(list);
+      });
+    }
   },
   effects: {
     async updateOrg({ call, update }, payload: Merge<Partial<ORG.IOrg>, { id: number }>) {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of page does not get announcements list at initialization.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

