### PR TITLE
fix(msp): average throughput does not wrap

### DIFF
--- a/shell/app/modules/msp/env-overview/service-list/pages/index.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/index.tsx
@@ -216,7 +216,7 @@ const MicroServiceOverview = () => {
                       listDetail(id, name);
                     }}
                   >
-                    <Col span={10} className="flex items-center">
+                    <Col span={8} className="flex items-center">
                       <div className="rounded-sm w-14 h-14 mr-2 language-wrapper">
                         <ErdaIcon type={ERDA_ICON[language]} size="56" />
                       </div>
@@ -227,7 +227,7 @@ const MicroServiceOverview = () => {
                         </Tag>
                       </div>
                     </Col>
-                    <Col span={14} className="flex items-center">
+                    <Col span={16} className="flex items-center">
                       <Row gutter={8} className="flex-1">
                         {map(views, ({ data, type, view }) => {
                           const timeStamp: number[] = [];
@@ -264,7 +264,7 @@ const MicroServiceOverview = () => {
                           return (
                             <Col span={8} className="flex">
                               <div className="py-2">
-                                <p className="mb-0 text-xl leading-8 font-number">
+                                <p className="mb-0 text-xl whitespace-nowrap leading-8 font-number">
                                   {type === 'RPS' ? (data === null ? '-' : `${data} reqs/s`) : null}
                                   {type === 'AvgDuration'
                                     ? data === null


### PR DESCRIPTION
## What this PR does / why we need it:
average throughput does not wrap

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/48612739/145560182-86801eef-0c47-4c98-9d51-aa9ed2df9faa.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Average throughput does not wrap             |
| 🇨🇳 中文    |  平均吞吐量不换行  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

