### PR TITLE
fix: enlarge the corresponding click image in issue drawer

### DIFF
--- a/shell/app/common/components/edit-field/index.tsx
+++ b/shell/app/common/components/edit-field/index.tsx
@@ -30,7 +30,7 @@ import layoutStore from 'layout/stores/layout';
 import './index.scss';
 
 const ScalableImage = ({ src, alt, ...rest }: ImgHTMLAttributes<HTMLImageElement>) => {
-  const isImagePreviewOpen = layoutStore.useStore((s) => s.isImagePreviewOpen);
+  const [isImagePreviewOpen, scalableImgSrc] = layoutStore.useStore((s) => [s.isImagePreviewOpen, s.scalableImgSrc]);
 
   const closePreview = React.useCallback((e?: MouseEvent) => {
     e?.stopPropagation();
@@ -41,6 +41,7 @@ const ScalableImage = ({ src, alt, ...rest }: ImgHTMLAttributes<HTMLImageElement
   const openPreview = (e: React.MouseEvent) => {
     e.stopPropagation();
     layoutStore.reducers.setImagePreviewOpen(true);
+    layoutStore.reducers.setScalableImgSrc(src || '');
     document.body.addEventListener('click', closePreview);
   };
 
@@ -74,7 +75,7 @@ const ScalableImage = ({ src, alt, ...rest }: ImgHTMLAttributes<HTMLImageElement
       />
       <span
         className={`${
-          isImagePreviewOpen
+          isImagePreviewOpen && src === scalableImgSrc
             ? 'fixed top-0 right-0 left-0 bottom-0 z-50 flex items-center justify-center overflow-auto bg-desc'
             : 'hidden'
         }`}

--- a/shell/app/layout/stores/layout.ts
+++ b/shell/app/layout/stores/layout.ts
@@ -50,6 +50,7 @@ interface IState {
     width: number;
   };
   isImagePreviewOpen: boolean;
+  scalableImgSrc: string;
 }
 
 const initState: IState = {
@@ -66,6 +67,7 @@ const initState: IState = {
     width: 0,
   },
   isImagePreviewOpen: false,
+  scalableImgSrc: '',
 };
 
 const layout = createStore({
@@ -208,6 +210,9 @@ const layout = createStore({
     },
     setImagePreviewOpen(state, status: boolean) {
       state.isImagePreviewOpen = status;
+    },
+    setScalableImgSrc(state, src: string) {
+      state.scalableImgSrc = src;
     },
     // 动态更改appList中具体某个app的属性值，e.g. { cmp: { href: 'xxxx' } } 来运行时改变href
     updateAppListProperty(state, payload: Obj<Obj>) {


### PR DESCRIPTION
## What this PR does / why we need it:
fix that enlarge the corresponding click image in issue drawer

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5-alpha.4


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

https://erda.cloud/erda/dop/projects/387/issues/all?id=263094&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=-1&type=BUG