### PR TITLE
feat: insert ta init script when start scheduler

### DIFF
--- a/scheduler/src/filters/not-found.filter.ts
+++ b/scheduler/src/filters/not-found.filter.ts
@@ -25,12 +25,30 @@ if (!fs.existsSync(indexHtmlPath)) {
 const indexHtmlContent = fs.readFileSync(indexHtmlPath, { encoding: 'utf8' });
 const newIndexHtmlPath = path.join(staticDir, 'shell', 'index-new.html');
 
-const { UC_PUBLIC_URL = '', ENABLE_BIGDATA = '', ENABLE_EDGE = '' } = process.env;
+const {
+  UC_PUBLIC_URL = '',
+  ENABLE_BIGDATA = '',
+  ENABLE_EDGE = '',
+  TERMINUS_KEY = '',
+  TERMINUS_TA_ENABLE = false,
+  TERMINUS_TA_URL = '',
+  TERMINUS_TA_COLLECTOR_URL = '',
+} = process.env;
 
-const newContent = indexHtmlContent.replace(
+let newContent = indexHtmlContent.replace(
   '<!-- $ -->',
   `<script>window.erdaEnv={UC_PUBLIC_URL:"${UC_PUBLIC_URL}",ENABLE_BIGDATA:"${ENABLE_BIGDATA}",ENABLE_EDGE:"${ENABLE_EDGE}"}</script>`,
 );
+if (TERMINUS_TA_ENABLE) {
+  const taContent = `
+<script>
+var _taConfig = window._taConfig;
+!function(e,n,r,t,a,o,c){e[a]=e[a]||function(){(e[a].q=e[a].q||[]).push(arguments)},e.onerror=function(n,r,t,o,c){e[a]("sendExecError",n,r,t,o,c)},n.addEventListener("error",function(n){e[a]("sendError",n)},!0),o=n.createElement(r),c=n.getElementsByTagName(r)[0],o.async=1,o.src=t,c.parentNode.insertBefore(o,c)}(window,document,"script",${TERMINUS_TA_URL},"$ta");
+$ta('start', { udata: { uid: 0 }, ak: ${TERMINUS_KEY}, url: ${TERMINUS_TA_COLLECTOR_URL}, ck: true });
+</script>
+`;
+  newContent = indexHtmlContent.replace('<!-- $ta -->', taContent);
+}
 fs.writeFileSync(newIndexHtmlPath, newContent, { encoding: 'utf8' });
 
 @Catch(NotFoundException)

--- a/shell/app/views/index.ejs
+++ b/shell/app/views/index.ejs
@@ -13,16 +13,7 @@
   <style type="text/css">
     <%=htmlWebpackPlugin.options.css %>
   </style>
-  <%if(htmlWebpackPlugin.options.isProd) {%>
-    <script src="/ta"></script>
-    <script>
-      var _taConfig = window._taConfig;
-      if (_taConfig && _taConfig.enabled) {
-        !function(e,n,r,t,a,o,c){e[a]=e[a]||function(){(e[a].q=e[a].q||[]).push(arguments)},e.onerror=function(n,r,t,o,c){e[a]("sendExecError",n,r,t,o,c)},n.addEventListener("error",function(n){e[a]("sendError",n)},!0),o=n.createElement(r),c=n.getElementsByTagName(r)[0],o.async=1,o.src=t,c.parentNode.insertBefore(o,c)}(window,document,"script",_taConfig.url,"$ta");
-        $ta('start', { udata: { uid: 0 }, ak: _taConfig.ak, url: _taConfig.collectorUrl, ck: true });
-      }
-    </script>
-  <%}%>
+  <!-- $ta -->
 </head>
 
 <body>


### PR DESCRIPTION
## What this PR does / why we need it:
Add ta for erda-ui

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

