### PR TITLE
style: modify style of tooltip in chart

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.5
+      '@erda-ui/dashboard-configurator': 2.0.6
       '@erda-ui/react-markdown-editor-lite': ^1.4.7
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -472,7 +472,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.5_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.6_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -5722,8 +5722,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.5_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-nfg4sV4iz2dcjayBZKrD3O0M7LrFrjkSgqrU1g9uRhJuJjcaM95w4CxdC2Bte7R6T50HcAlBeQKKwyvrrd/x6g==}
+  /@erda-ui/dashboard-configurator/2.0.6_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-AX7igyo2BUYYAR825mWcz7ztMvR2ovmJOJCcPTnLQbQjDu1AZ65KuixVjxjIo5WEM8fWzO3inIELLle0qikLbw==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -9003,7 +9003,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.7.0_ba633acb38016457254722d87c7e8964
+      webpack-cli: 4.7.0_6256c4c7530243cf24a1ff746ee9d921
     dev: true
 
   /@webpack-cli/serve/1.4.0_webpack-cli@4.7.0:
@@ -9015,7 +9015,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.7.0_ba633acb38016457254722d87c7e8964
+      webpack-cli: 4.7.0_6256c4c7530243cf24a1ff746ee9d921
     dev: true
 
   /@xobotyi/scrollbar-width/1.9.5:

--- a/shell/app/charts/components/monitor-chart-new.jsx
+++ b/shell/app/charts/components/monitor-chart-new.jsx
@@ -178,9 +178,10 @@ class MonitorChartNew extends React.PureComponent {
 
     const genTTArray = (param) =>
       param.map((unit, i) => {
-        return `<span style='color: ${unit.color}'>${cutStr(unit.seriesName, 20)} : ${getFormatter(
-          ...getTTUnitType(i),
-        ).format(unit.value, 2)}</span><br/>`;
+        return `<span'>${unit.marker} ${cutStr(unit.seriesName, 20)} : ${getFormatter(...getTTUnitType(i)).format(
+          unit.value,
+          2,
+        )}</span><br/>`;
       });
 
     let defaultTTFormatter = (param) => `${param[0].name}<br/>${genTTArray(param).join('')}`;

--- a/shell/app/charts/components/pie-chart.jsx
+++ b/shell/app/charts/components/pie-chart.jsx
@@ -34,7 +34,10 @@ class PieChart extends React.Component {
       tooltip: {
         trigger: 'item',
         confine: true,
-        formatter: '{a} <br/>{b} : {c} ({d}%)',
+        formatter: (params) => {
+          const { seriesName, name, value, percent, marker } = params;
+          return `${seriesName} <br/> <span> ${marker}${name} : ${value?.toFixed(2)} (${percent}%) </span>`;
+        },
       },
       legend: {
         orient: 'vertical',

--- a/shell/package.json
+++ b/shell/package.json
@@ -47,7 +47,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.5",
+    "@erda-ui/dashboard-configurator": "2.0.6",
     "@erda-ui/react-markdown-editor-lite": "^1.4.7",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:

 1. fix: fetch 'https://geo.datav.aliyun.com/areas_v2/bound' without header to solve CORS problem
 2. style:modify tooltip style in chart
![image](https://user-images.githubusercontent.com/30014895/146304811-0f0575be-9808-4c63-8501-896639ce89d3.png)

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | modify the style of tooltip in chart |
| 🇨🇳 中文    | 更改图表的 tooltip 样式 |


## Does this PR need be patched to older version?
✅ Yes(version is required)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

