### PR TITLE
fix(common): table pagination bug

### DIFF
--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -64,12 +64,14 @@ function WrappedTable<T extends object = any>({
   onRow,
   rowSelection,
   hideHeader,
+  rowKey,
   ...props
 }: IProps<T>) {
-  const dataSource = React.useMemo(() => ds || [], [ds]);
+  const dataSource = React.useMemo<T[]>(() => (ds as T[]) || [], [ds]);
   const [columns, setColumns] = React.useState<Array<ColumnProps<T>>>(allColumns);
   const [sort, setSort] = React.useState<SorterResult<T>>({});
   const sortCompareRef = React.useRef<((a: T, b: T) => number) | null>(null);
+  const preDataSourceRef = React.useRef<T[]>([]);
   const [defaultPagination, setDefaultPagination] = React.useState<TablePaginationConfig>({
     current: 1,
     total: dataSource.length || 0,
@@ -83,8 +85,19 @@ function WrappedTable<T extends object = any>({
   const { current = 1, pageSize = PAGINATION.pageSize } = pagination;
 
   React.useEffect(() => {
-    setDefaultPagination((before) => ({ ...before, total: dataSource.length || 0 }));
-  }, [dataSource]);
+    if (isFrontendPaging) {
+      const newRowKeys =
+        dataSource.map((item) => item[typeof rowKey === 'function' ? rowKey(item) : rowKey || 'id']) || [];
+      const preRowKeys =
+        preDataSourceRef.current.map((item) => item[typeof rowKey === 'function' ? rowKey(item) : rowKey || 'id']) ||
+        [];
+      if (newRowKeys.join(',') !== preRowKeys.join(',')) {
+        setDefaultPagination((before) => ({ ...before, current: 1, total: dataSource.length || 0 }));
+      }
+
+      preDataSourceRef.current = [...dataSource];
+    }
+  }, [dataSource, rowKey, isFrontendPaging]);
 
   const onTableChange = React.useCallback(
     ({ pageNo, pageSize: size, sorter: currentSorter }) => {


### PR DESCRIPTION
## What this PR does / why we need it:
table pagination bug:
In frontend paging table, pageNo does not change when dataSource change.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

