### PR TITLE
fix(common): configurable filter bug

### DIFF
--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -68,7 +68,7 @@ const sortObj = (obj: Obj) => {
 const getItemByValues = (val: Obj, list: Obj[]) => {
   const values = sortObj(val);
 
-  return list?.find((item) => JSON.stringify(sortObj(item.values)) === JSON.stringify(values));
+  return list?.find((item) => JSON.stringify(sortObj(item.values || {})) === JSON.stringify(values));
 };
 
 const defaultProcessField = (item: IFormItem) => {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter bug:
page error when values of filterSet doesn't exist.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

