### PR TITLE
fix(common): configurable filter tags select style bug

### DIFF
--- a/shell/app/common/components/configurable-filter/index.scss
+++ b/shell/app/common/components/configurable-filter/index.scss
@@ -176,7 +176,8 @@
   .ant-select:not(.erda-tags-select)
     .ant-select-selection-overflow-item:not(:nth-last-child(2))
     .ant-select-selection-item:after {
-    content: '、';
+    content: ',';
+    margin-right: 0.5rem;
   }
 
   .erda-tags-select {

--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -79,7 +79,6 @@ const defaultProcessField = (item: IFormItem) => {
   if (type === 'select' || type === 'tagsSelect') {
     field.itemProps = {
       mode: 'multiple',
-      optionLabelProp: 'label',
       ...itemProps,
       showArrow: true,
       allowClear: true,
@@ -87,6 +86,10 @@ const defaultProcessField = (item: IFormItem) => {
       clearIcon: <span className="p-1">{i18n.t('common:clear')}</span>,
       getPopupContainer: (triggerNode: HTMLElement) => triggerNode.parentElement as HTMLElement,
     };
+
+    if (type === 'select') {
+      field.itemProps.optionLabelProp = 'label';
+    }
   } else if (type === 'dateRange') {
     field.itemProps = {
       customProps: {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter tags select style bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/146681182-4f4a8976-74e1-4c69-8b59-7be925e67e9f.png)
->
![image](https://user-images.githubusercontent.com/82502479/146681169-a33bb93c-30ef-43ba-aadf-78834542bf01.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

