### PR TITLE
fix: valueOptions is  empty when operator is match or notMatch can not be saved

### DIFF
--- a/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
@@ -879,7 +879,11 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
       let isIncomplete = false;
       state.triggerCondition.forEach((item) => {
         for (const key in item) {
-          if ((!item[key] && item.operator !== 'all') || (isArray(item[key]) && item[key].length === 0)) {
+          // the third box is input when type is 'match' or 'notMatch', valueOptions is empty array
+          if (
+            (!item[key] && item.operator !== 'all') ||
+            (!['match', 'notMatch'].includes(item.operator) && isArray(item[key]) && item[key].length === 0)
+          ) {
             isIncomplete = true;
           }
         }


### PR DESCRIPTION
## What this PR does / why we need it:
fix that valueOptions is  empty when operator is match or notMatch can not be saved

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

