### PR TITLE
fix: not display cursor after selection

### DIFF
--- a/shell/app/common/components/edit-field/index.tsx
+++ b/shell/app/common/components/edit-field/index.tsx
@@ -292,7 +292,6 @@ const EditField = React.forwardRef((props: IProps, _compRef) => {
         <Select
           ref={compRef}
           showArrow={false}
-          showSearch
           allowClear
           className="w-full"
           value={editValue}


### PR DESCRIPTION
## What this PR does / why we need it:
fix that not display cursor after selection, these selects have no search function
before:
![2021-12-20 16 18 31](https://user-images.githubusercontent.com/30014895/146735320-85050f6b-f689-49e3-a0d2-6ba1f48fb7ff.gif)


current:
![2021-12-20 16 17 31](https://user-images.githubusercontent.com/30014895/146735210-cc564d5a-33e3-4b29-8a6a-c68d26c740ad.gif)


## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

