### PR TITLE
fix: hide email and label columns of member table

### DIFF
--- a/shell/app/common/components/members-table/index.tsx
+++ b/shell/app/common/components/members-table/index.tsx
@@ -440,7 +440,6 @@ const MembersTable = ({
         {
           title: i18n.t('cellphone'),
           dataIndex: 'mobile',
-          hidden: true,
           render: (value: string | number) => (
             <span className="cursor-copy" data-clipboard-tip={i18n.t('cellphone')} data-clipboard-text={value}>
               {value || '-'}
@@ -467,6 +466,7 @@ const MembersTable = ({
           {
             title: i18n.t('member label'),
             dataIndex: 'labels',
+            hidden: true,
             render: (val: string[]) => {
               const curLabels = map(val, (item) => {
                 const labelObj = find(memberLabels, { label: item }) || { name: item, label: item };


### PR DESCRIPTION
## What this PR does / why we need it:
fix that hide email and label columns of member table

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
hotfix/12-21


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

