### PR TITLE
fix: trace detail go back to transaction in service monitor

### DIFF
--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -267,17 +267,17 @@ export enum pages {
   // 微服务-监控中心-服务监控
   mspServiceMonitor = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/monitor/{terminusKey}/service-analysis/{applicationId}/{serviceId}/{serviceName}',
 
-  // 微服务-事务分析页
-  mspServiceTransaction = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/service-list/{applicationId}/{serviceId}/{serviceName}/transaction',
+  // 微服务-具体事务分析页
+  mspServiceTransaction = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/monitor/{terminusKey}/service-analysis/{applicationId}/{serviceId}/{serviceName}/transaction',
 
   mspGatewayIngress = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/topology/gateway-ingress',
 
   mspExternalInsight = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/topology/ei/{hostName}/affairs',
 
-  mspServiceProcess = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/service-list/{applicationId}/{serviceId}/{serviceName}/process',
+  mspServiceProcess = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/service-analysis/{applicationId}/{serviceId}/{serviceName}/process',
 
   // 服务分析页-追踪详情
-  mspServiceTraceDetail = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/synopsis/{terminusKey}/service-list/{applicationId}/{serviceId}/{serviceName}/transaction/trace-detail/{traceId}',
+  mspServiceTraceDetail = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/monitor/{terminusKey}/service-analysis/{applicationId}/{serviceId}/{serviceName}/transaction/trace-detail/{traceId}',
 
   // 微服务-接入配置页
   mspConfigurationPage = '/{orgName}/msp/{projectId}/{env}/{tenantGroup}/environment/{terminusKey}/configuration',

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search-detail.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search-detail.tsx
@@ -21,6 +21,7 @@ import traceStore from '../../../../stores/trace';
 import routeInfoStore from 'core/stores/route';
 import { useLoading } from 'core/stores/loading';
 import i18n from 'i18n';
+import serviceAnalyticsStore from 'msp/stores/service-analytics';
 import './trace-search-detail.scss';
 import { goTo } from 'common/utils';
 
@@ -32,6 +33,11 @@ export default ({ traceId, startTime }: { traceId?: string; startTime?: number }
     s.params,
     s.currentRoute,
     s.query,
+  ]);
+  const [serviceId, serviceName, applicationId] = serviceAnalyticsStore.useStore((s) => [
+    s.serviceId,
+    s.serviceName,
+    s.applicationId,
   ]);
   const { setIsShowTraceDetail } = monitorCommonStore.reducers;
   const isShowTraceDetail = monitorCommonStore.useStore((s) => s.isShowTraceDetail);
@@ -70,7 +76,11 @@ export default ({ traceId, startTime }: { traceId?: string; startTime?: number }
             setIsShowTraceDetail(false);
             if (_traceId) {
               if (currentRoute?.path?.includes('transaction')) {
-                goTo(goTo.pages.mspServiceTransaction);
+                goTo(goTo.pages.mspServiceTransaction, {
+                  applicationId,
+                  serviceName,
+                  serviceId: window.encodeURIComponent(serviceId || ''),
+                });
               } else if (currentRoute?.path?.includes('trace/debug')) {
                 goTo(goTo.pages.mspTraceDebug);
               } else {


### PR DESCRIPTION
## What this PR does / why we need it:
fix that trace detail go back to transaction in service monitor

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
hotfix/12-21


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

