### PR TITLE
fix(common): msp project detail display bug in orgCenter

### DIFF
--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -193,13 +193,15 @@ const Info = () => {
         header={
           <div>
             {i18n.t('dop:basic information')}
-            <Tooltip title={i18n.t('projects')}>
-              <CustomIcon
-                type="link1"
-                className="ml-2 hover-active"
-                onClick={() => goTo(goTo.pages.project, { projectId: info.id })}
-              />
-            </Tooltip>
+            {notMSP ? (
+              <Tooltip title={i18n.t('projects')}>
+                <CustomIcon
+                  type="link1"
+                  className="ml-2 hover-active"
+                  onClick={() => goTo(goTo.pages.project, { projectId: info.id })}
+                />
+              </Tooltip>
+            ) : null}
           </div>
         }
         actions={
@@ -329,24 +331,30 @@ const Info = () => {
       <Card
         header={i18n.t('advanced settings')}
         actions={
-          <span className="hover-active" onClick={() => setProjectRollbackEditVisible(true)}>
-            <ErdaIcon type="edit" size={16} className="mr-2 align-middle" />
-          </span>
+          notMSP ? (
+            <span className="hover-active" onClick={() => setProjectRollbackEditVisible(true)}>
+              <ErdaIcon type="edit" size={16} className="mr-2 align-middle" />
+            </span>
+          ) : null
         }
       >
-        <div className="label">{i18n.t('dop:rollback setting')}</div>
-        <Row className="erda-panel-list">
-          {Object.keys(info.rollbackConfig || {}).map((key: string) => (
-            <Col span={6} className="flex">
-              <div className="flex mr-3">{resourceIconMap[key]}</div>
-              <div>
-                <div className="label">{info.rollbackConfig[key]}</div>
-                <div className="text-xs">{resourceMap[key]}</div>
-              </div>
-            </Col>
-          ))}
-        </Row>
-        <div className="label">{i18n.t('other settings')}</div>
+        {notMSP ? (
+          <>
+            <div className="label">{i18n.t('dop:rollback setting')}</div>
+            <Row className="erda-panel-list">
+              {Object.keys(info.rollbackConfig || {}).map((key: string) => (
+                <Col span={6} className="flex">
+                  <div className="flex mr-3">{resourceIconMap[key]}</div>
+                  <div>
+                    <div className="label">{info.rollbackConfig[key]}</div>
+                    <div className="text-xs">{resourceMap[key]}</div>
+                  </div>
+                </Col>
+              ))}
+            </Row>
+            <div className="label">{i18n.t('other settings')}</div>
+          </>
+        ) : null}
         <Row>
           <Col span={12} className="pr-2">
             <div className="erda-panel-list flex justify-between items-center">


### PR DESCRIPTION
## What this PR does / why we need it:
Fix msp project detail display bug in orgCenter.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
hotifx/12-21

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=267696&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=680&type=BUG

