### PR TITLE
fix: member select style in milestone page 

### DIFF
--- a/shell/app/common/components/contractive-filter/index.scss
+++ b/shell/app/common/components/contractive-filter/index.scss
@@ -96,6 +96,18 @@
       cursor: pointer;
     }
   }
+
+  .contractive-member-selector {
+    .results {
+      padding: 4px 0;
+      border: 0;
+
+      &:hover {
+        border: 0;
+        box-shadow: unset;
+      }
+    }
+  }
 }
 
 .contractive-filter-item-dropdown {
@@ -188,18 +200,6 @@
     }
     .option-item {
       padding: 6px 10px 6px 30px;
-    }
-  }
-}
-
-.contractive-member-selector {
-  .results {
-    padding: 4px 0;
-    border: 0;
-
-    &:hover {
-      border: 0;
-      box-shadow: unset;
     }
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it:
overwrite style affected by compress order

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/147050484-47e7dd90-1133-45b8-8152-b57a11bbc4b7.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix member select style in milestone page  |
| 🇨🇳 中文    | 修复里程碑页面选人组件的样式问题  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

