### PR TITLE
fix: remove extra breadcrumbName which is from service list jump to service monitor

### DIFF
--- a/shell/app/modules/msp/env-overview/service-list/router.ts
+++ b/shell/app/modules/msp/env-overview/service-list/router.ts
@@ -92,14 +92,12 @@ export function serviceAnalysisRouter() {
       ...serviceAnalysisRoutes,
       {
         path: ':applicationId',
-        breadcrumbName: i18n.t('msp:service list'),
         routes: [
           {
             path: ':serviceId',
             routes: [
               {
                 path: ':serviceName',
-                breadcrumbName: i18n.t('msp:service monitor'),
                 tabs,
                 alwaysShowTabKey: 'overview',
                 pageNameInfo: ServiceNameSelect,


### PR DESCRIPTION
## What this PR does / why we need it:
fix that remove extra breadcrumbName which is from service list jump to service monitor

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

