### PR TITLE
fix: last task in gantt not fully displayed

### DIFF
--- a/shell/app/config-page/components/gantt/components/gantt/gantt.tsx
+++ b/shell/app/config-page/components/gantt/components/gantt/gantt.tsx
@@ -383,7 +383,11 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
     showRange = [0, barTasks.length];
   } else if (verticalRange[1] > barTasks.length) {
     // there is also space left, move forward
-    const offset = verticalRange[1] - barTasks.length;
+    let offset = verticalRange[1] - barTasks.length;
+    // if last task show more than half height, move forward to show full
+    if (ganttFullHeight - ganttHeight - scrollY < rowHeight / 2) {
+      offset -= 1;
+    }
     showRange = [Math.max(0, verticalRange[0] - offset), verticalRange[1] - offset];
   }
   const visibleTaskList = barTasks.slice(...showRange);

--- a/shell/app/config-page/components/gantt/components/task-list/task-list.scss
+++ b/shell/app/config-page/components/gantt/components/task-list/task-list.scss
@@ -1,8 +1,4 @@
 .erda-gantt-task-list-box {
   border-right: 1px solid $border-color;
   z-index: 100;
-
-  &.on-scroll {
-    box-shadow: 0 1px 3px 0 $color-shadow;
-  }
 }

--- a/shell/app/config-page/components/gantt/components/task-list/task-list.tsx
+++ b/shell/app/config-page/components/gantt/components/task-list/task-list.tsx
@@ -87,7 +87,7 @@ export const TaskList: React.FC<TaskListProps> = ({
   };
 
   return (
-    <div ref={taskListRef} className={`erda-gantt-task-list-box ${scrollX > 1 ? 'on-scroll' : ''}`}>
+    <div ref={taskListRef} className={`erda-gantt-task-list-box ${scrollX > 1 ? 'shadow-card' : ''}`}>
       <TaskListHeader {...headerProps} />
       <TaskListTable {...tableProps} />
     </div>


### PR DESCRIPTION
## What this PR does / why we need it:
last task in gantt not show full.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/147311007-dfc3a127-e193-4021-8844-cde5e00d07bd.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix last task in gantt not fully displayed |
| 🇨🇳 中文    |  修复甘特图上最后一个任务没有完整显示问题 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

