### PR TITLE
fix: prevent scroll today after clicking expander

### DIFF
--- a/shell/app/config-page/components/gantt/components/gantt/gantt.tsx
+++ b/shell/app/config-page/components/gantt/components/gantt/gantt.tsx
@@ -279,11 +279,11 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
 
   useLayoutEffect(() => {
     // If isHandleFullScreen action, prevent scrollToToday
-    if (!isHandleFullScreen) {
+    if (!isHandleFullScreen && !onExpanderClick) {
       scrollToToday();
     }
     setIsHandleFullScreen(false);
-  }, [dateSetup, scrollToToday]);
+  }, [isHandleFullScreen, onExpanderClick, scrollToToday]);
 
   // useEffect(() => {
   //   if (wrapperRef.current) {

--- a/shell/app/modules/project/common/components/issue/issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-drawer.tsx
@@ -80,6 +80,7 @@ export const IssueDrawer = (props: IProps) => {
     projectId,
     setData,
     footer = IssueDrawer.Empty,
+    ...rest
   } = props;
   const [title = IssueDrawer.Empty, main = IssueDrawer.Empty, tabs = IssueDrawer.Empty, meta = IssueDrawer.Empty] =
     React.Children.toArray(children);
@@ -153,6 +154,7 @@ export const IssueDrawer = (props: IProps) => {
       onClose={onClose}
       maskClosable={maskClosable || !isChanged}
       keyboard={false}
+      {...rest}
     >
       <Spin spinning={loading}>
         <IF check={title !== IssueDrawer.Empty}>


### PR DESCRIPTION
## What this PR does / why we need it:
prevent scroll today after clicking expander

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【甘特图】滑动任意事项超过屏幕距离会自动定位到今日](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?id=269371&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
