### PR TITLE
fix: add autoStartCron params when create pipeline

### DIFF
--- a/shell/app/modules/project/common/components/pipeline-manage/common/config-env-selector.tsx
+++ b/shell/app/modules/project/common/components/pipeline-manage/common/config-env-selector.tsx
@@ -217,6 +217,7 @@ const ConfigEnvSelector = (props: IProps) => {
       pipelineYmlName: caseDetail.inode,
       clusterName: curClusterName,
       autoRunAtOnce: true,
+      autoStartCron: true,
       labels: { orgID: `${orgId}`, projectID: projectId, projectName, orgName },
       ...p,
     }).then((res: any) => {

--- a/shell/app/modules/project/types/auto-test.d.ts
+++ b/shell/app/modules/project/types/auto-test.d.ts
@@ -88,6 +88,7 @@ declare namespace AUTO_TEST {
     clusterName: string;
     configManageNamespaces?: string[];
     autoRunAtOnce: boolean;
+    autoStartCron: boolean;
     runParams?: Array<{ name: string; value: string }>;
     labels?: { orgID: string; projectID: string };
   }


### PR DESCRIPTION
## What this PR does / why we need it:
fix: add autoStartCron params when create pipeline

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

