### PR TITLE
feat(dop): project release management application release edit

### DIFF
--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -230,9 +230,9 @@ const ConfigurableFilter = ({
           {i18n.t('cancel')}
         </Button>
         <Button className="mx-1" onClick={setAllOpen}>
-          {i18n.t('dop:set it to open all')}
+          {hideSave ? i18n.t('clear') : i18n.t('dop:set it to open all')}
         </Button>
-        <Button type="primary" className="mx-1" onClick={onFilter}>
+        <Button type="primary" className="mx-1 bg-purple-deep border-purple-deep" onClick={onFilter}>
           {i18n.t('common:filter')}
         </Button>
       </div>

--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -169,9 +169,11 @@ export enum pages {
   projectTestReport = '/{orgName}/dop/projects/{projectId}/test-report',
   projectTestReportCreate = '/{orgName}/dop/projects/{projectId}/test-report/create',
   projectMemberManagement = '/{orgName}/dop/projects/{projectId}/setting?tabKey=projectMember',
-  projectRelease = '/{orgName}/dop/projects/{projectId}/release/project',
+  projectRelease = '/{orgName}/dop/projects/{projectId}/release',
+  projectReleaseList = '/{orgName}/dop/projects/{projectId}/release/project',
   projectReleaseCreate = '/{orgName}/dop/projects/{projectId}/release/createRelease',
   projectReleaseDetail = '/{orgName}/dop/projects/{projectId}/release/project/{releaseId}',
+  applicationReleaseList = '/{orgName}/dop/projects/{projectId}/release/application',
   applicationReleaseDetail = '/{orgName}/dop/projects/{projectId}/release/application/{releaseId}',
 
   // app

--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -171,7 +171,8 @@ export enum pages {
   projectMemberManagement = '/{orgName}/dop/projects/{projectId}/setting?tabKey=projectMember',
   projectRelease = '/{orgName}/dop/projects/{projectId}/release/project',
   projectReleaseCreate = '/{orgName}/dop/projects/{projectId}/release/createRelease',
-  projectReleaseDetail = '/{orgName}/dop/projects/{projectId}/release/releaseDetail/{id}',
+  projectReleaseDetail = '/{orgName}/dop/projects/{projectId}/release/project/{releaseId}',
+  applicationReleaseDetail = '/{orgName}/dop/projects/{projectId}/release/application/{releaseId}',
 
   // app
   app = '/{orgName}/dop/projects/{projectId}/apps/{appId}',

--- a/shell/app/menus/project.tsx
+++ b/shell/app/menus/project.tsx
@@ -96,9 +96,9 @@ export const getProjectMenu = (projectId: string, pathname: string) => {
           prefix: `${goTo.resolve.projectApps()}`,
         },
         {
-          href: goTo.resolve.projectRelease(),
+          href: goTo.resolve.projectReleaseList(),
           text: i18n.t('artifact management'),
-          prefix: `${goTo.resolve.projectRelease()}`,
+          prefix: `${goTo.resolve.projectRelease()}/`,
         },
       ],
     },

--- a/shell/app/modules/project/pages/release/components/application-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/application-detail.tsx
@@ -12,29 +12,30 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Button, Tabs, Modal, message } from 'antd';
+import { Button, Tabs, Modal, message, Form } from 'antd';
 import moment from 'moment';
 import i18n from 'i18n';
 import { goTo } from 'common/utils';
-import { UserInfo, FileEditor } from 'common';
+import { UserInfo, FileEditor, RenderFormItem, MarkdownEditor } from 'common';
 import Table from 'common/components/table';
 import routeInfoStore from 'core/stores/route';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import FileContainer from 'application/common/components/file-container';
-import { getReleaseDetail, formalRelease } from 'project/services/release';
+import { getReleaseDetail, formalRelease, updateRelease } from 'project/services/release';
 
 import './form.scss';
 
 const { TabPane } = Tabs;
 
-const ReleaseApplicationDetail = () => {
+const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
   const [params] = routeInfoStore.useStore((s) => [s.params]);
-  const { releaseID } = params;
+  const { releaseID, projectId } = params;
   const [releaseDetail, setReleaseDetail] = React.useState<RELEASE.ReleaseDetail>({} as RELEASE.ReleaseDetail);
+  const [form] = Form.useForm();
 
   const {
-    releaseName,
+    version,
     applicationName,
     userId,
     createdAt,
@@ -48,19 +49,26 @@ const ReleaseApplicationDetail = () => {
     if (releaseID) {
       const res = await getReleaseDetail({ releaseID });
       if (res.success) {
-        setReleaseDetail(res.data);
+        const { data } = res;
+        setReleaseDetail(data);
+        if (isEdit) {
+          form.setFieldsValue({
+            version: data.version,
+            changelog: data.changelog,
+          });
+        }
       }
     }
-  }, [releaseID, setReleaseDetail]);
+  }, [releaseID, setReleaseDetail, isEdit, form]);
 
   React.useEffect(() => {
     getDetail();
   }, [getDetail]);
 
-  const submit = () => {
+  const formal = () => {
     Modal.confirm({
       title: i18n.t('dop:be sure to make {name} official?', {
-        name: releaseName,
+        name: version,
         interpolation: { escapeValue: false },
       }),
       onOk: async () => {
@@ -73,60 +81,111 @@ const ReleaseApplicationDetail = () => {
     });
   };
 
+  const submit = () => {
+    form.validateFields().then(async (values) => {
+      const params = {
+        ...values,
+        isStable: true,
+        isFormal: false,
+        isProjectRelease: false,
+        releaseID,
+        projectID: +projectId,
+      };
+      const res = await updateRelease(params);
+      if (res.success) {
+        message.success(i18n.t('edited successfully'));
+        goTo(goTo.pages.projectRelease);
+      }
+    });
+  };
+
   return (
-    <div className="release-releaseDetail">
-      <Tabs defaultActiveKey="1">
-        <TabPane tab={i18n.t('dop:basic information')} key="1">
-          <div className="mb-4">
-            <div className="mb-2">
-              <div className="text-black-400 mb-2">{i18n.t('name')}</div>
-              <div>{releaseName || '-'}</div>
-            </div>
-            <div className="mb-2">
-              <div className="text-black-400 mb-2">{i18n.t('dop:app name')}</div>
-              <div>{applicationName || '-'}</div>
-            </div>
-            <div className="mb-2">
-              <div className="text-black-400 mb-2">{i18n.t('creator')}</div>
-              <div>{userId ? <UserInfo id={userId} /> : '-'}</div>
-            </div>
-            <div className="mb-2">
-              <div className="text-black-400 mb-2">{i18n.t('create time')}</div>
-              <div>{(createdAt && moment(createdAt).format('YYYY/MM/DD HH:mm:ss')) || '-'}</div>
-            </div>
-            <div className="mb-2">
-              <div className="text-black-400 mb-2">{i18n.t('dop:code branch')}</div>
-              <div>{labels.gitBranch || '-'}</div>
-            </div>
-            <div className="mb-2">
-              <div className="text-black-400 mb-2">commitId</div>
-              <div>{labels.gitCommitId || '-'}</div>
-            </div>
-            <div className="mb-2">
-              <div className="text-black-400 mb-2">{i18n.t('content')}</div>
-              <div>
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{changelog || i18n.t('dop:no content yet')}</ReactMarkdown>
+    <div className="release-releaseDetail release-form">
+      <Form layout="vertical" form={form}>
+        <Tabs defaultActiveKey="1">
+          <TabPane tab={i18n.t('dop:basic information')} key="1">
+            <div className="mb-4 pl-0.5">
+              {isEdit ? (
+                <div className="w-2/5">
+                  <RenderFormItem
+                    label={i18n.t('dop:version name')}
+                    name="version"
+                    type="input"
+                    rules={[
+                      { required: true, message: i18n.t('please enter {name}', { name: i18n.t('dop:version name') }) },
+                      { max: 30, message: i18n.t('dop:no more than 30 characters') },
+                      {
+                        pattern: /^[A-Za-z0-9._-]+$/,
+                        message: i18n.t('dop:Must be composed of letters, numbers, underscores, hyphens and dots.'),
+                      },
+                    ]}
+                  />
+                </div>
+              ) : (
+                <div className="mb-2">
+                  <div className="text-black-400 mb-2">{i18n.t('dop:version name')}</div>
+                  <div>{version || '-'}</div>
+                </div>
+              )}
+              <div className="mb-2">
+                <div className="text-black-400 mb-2">{i18n.t('dop:app name')}</div>
+                <div>{applicationName || '-'}</div>
               </div>
+              <div className="mb-2">
+                <div className="text-black-400 mb-2">{i18n.t('creator')}</div>
+                <div>{userId ? <UserInfo id={userId} /> : '-'}</div>
+              </div>
+              <div className="mb-2">
+                <div className="text-black-400 mb-2">{i18n.t('create time')}</div>
+                <div>{(createdAt && moment(createdAt).format('YYYY/MM/DD HH:mm:ss')) || '-'}</div>
+              </div>
+              <div className="mb-2">
+                <div className="text-black-400 mb-2">{i18n.t('dop:code branch')}</div>
+                <div>{labels.gitBranch || '-'}</div>
+              </div>
+              <div className="mb-2">
+                <div className="text-black-400 mb-2">commitId</div>
+                <div>{labels.gitCommitId || '-'}</div>
+              </div>
+              {isEdit ? (
+                <div className="w-2/5">
+                  <RenderFormItem label={i18n.t('content')} name="changelog" type="custom" getComp={() => <EditMd />} />
+                </div>
+              ) : (
+                <div className="mb-2">
+                  <div className="text-black-400 mb-2">{i18n.t('content')}</div>
+                  <div>
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {changelog || i18n.t('dop:no content yet')}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              )}
             </div>
-          </div>
-        </TabPane>
-        <TabPane tab={i18n.t('dop:images list')} key="2">
-          <Table
-            columns={[{ title: i18n.t('dop:image name'), dataIndex: 'name' }]}
-            dataSource={images.map((item: string) => ({ name: item }))}
-            onChange={() => getReleaseDetail({ releaseID })}
-          />
-        </TabPane>
-        <TabPane tab="dice.yml" key="3">
-          <FileContainer className="mt-3" name="dice.yml">
-            <FileEditor name="dice.yml" fileExtension="yml" value={releaseDetail.diceyml} readOnly />
-          </FileContainer>
-        </TabPane>
-      </Tabs>
+          </TabPane>
+          <TabPane tab={i18n.t('dop:images list')} key="2">
+            <Table
+              columns={[{ title: i18n.t('dop:image name'), dataIndex: 'name' }]}
+              dataSource={images.map((item: string) => ({ name: item }))}
+              onChange={() => getReleaseDetail({ releaseID })}
+            />
+          </TabPane>
+          <TabPane tab="dice.yml" key="3">
+            <FileContainer className="mt-3" name="dice.yml">
+              <FileEditor name="dice.yml" fileExtension="yml" value={releaseDetail.diceyml} readOnly />
+            </FileContainer>
+          </TabPane>
+        </Tabs>
+      </Form>
 
       <div className="mb-2 mt-4">
-        {!isFormal ? (
+        {isEdit ? (
           <Button className="mr-3 bg-default" type="primary" onClick={submit}>
+            {i18n.t('submit')}
+          </Button>
+        ) : null}
+        {!isFormal ? (
+          <Button className="mr-3 bg-default" type="primary" onClick={formal}>
             {i18n.t('dop:be formal')}
           </Button>
         ) : null}
@@ -136,6 +195,10 @@ const ReleaseApplicationDetail = () => {
       </div>
     </div>
   );
+};
+
+const EditMd = ({ value, onChange, ...itemProps }: { value: string; onChange: (value: string) => void }) => {
+  return <MarkdownEditor value={value} onChange={onChange} {...itemProps} defaultHeight={400} />;
 };
 
 export default ReleaseApplicationDetail;

--- a/shell/app/modules/project/pages/release/components/application-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/application-detail.tsx
@@ -83,7 +83,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
 
   const submit = () => {
     form.validateFields().then(async (values) => {
-      const params = {
+      const payload = {
         ...values,
         isStable: true,
         isFormal: false,
@@ -91,16 +91,16 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
         releaseID,
         projectID: +projectId,
       };
-      const res = await updateRelease(params);
+      const res = await updateRelease(payload);
       if (res.success) {
         message.success(i18n.t('edited successfully'));
-        goTo(goTo.pages.projectRelease);
+        goTo(goTo.pages.applicationReleaseList);
       }
     });
   };
 
   return (
-    <div className="release-releaseDetail release-form">
+    <div className="release-releaseDetail release-form h-full overflow-y-auto pb-18">
       <Form layout="vertical" form={form}>
         <Tabs defaultActiveKey="1">
           <TabPane tab={i18n.t('dop:basic information')} key="1">
@@ -148,7 +148,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
                 <div>{labels.gitCommitId || '-'}</div>
               </div>
               {isEdit ? (
-                <div className="w-2/5">
+                <div className="w-4/5">
                   <RenderFormItem label={i18n.t('content')} name="changelog" type="custom" getComp={() => <EditMd />} />
                 </div>
               ) : (
@@ -178,7 +178,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
         </Tabs>
       </Form>
 
-      <div className="mb-2 mt-4">
+      <div className="absolute bottom-0 left-4 right-0 bg-white z-10 py-4">
         {isEdit ? (
           <Button className="mr-3 bg-default" type="primary" onClick={submit}>
             {i18n.t('submit')}
@@ -189,7 +189,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
             {i18n.t('dop:be formal')}
           </Button>
         ) : null}
-        <Button className="bg-default-06 border-default-06" onClick={() => goTo(goTo.pages.projectRelease)}>
+        <Button className="bg-default-06 border-default-06" onClick={() => goTo(goTo.pages.applicationReleaseList)}>
           {i18n.t('return to previous page')}
         </Button>
       </div>

--- a/shell/app/modules/project/pages/release/components/application-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/application-detail.tsx
@@ -48,8 +48,8 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
   const getDetail = React.useCallback(async () => {
     if (releaseID) {
       const res = await getReleaseDetail({ releaseID });
-      if (res.success) {
-        const { data } = res;
+      const { data } = res;
+      if (data) {
         setReleaseDetail(data);
         if (isEdit) {
           form.setFieldsValue({
@@ -72,11 +72,11 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
         interpolation: { escapeValue: false },
       }),
       onOk: async () => {
-        const res = await formalRelease({ releaseID });
-        if (res.success) {
-          message.success(i18n.t('{action} successfully', { action: i18n.t('dop:be formal') }));
-          getReleaseDetail({ releaseID });
-        }
+        await formalRelease({
+          releaseID,
+          $options: { successMsg: i18n.t('{action} successfully', { action: i18n.t('dop:be formal') }) },
+        });
+        getDetail();
       },
     });
   };
@@ -91,11 +91,8 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
         releaseID,
         projectID: +projectId,
       };
-      const res = await updateRelease(payload);
-      if (res.success) {
-        message.success(i18n.t('edited successfully'));
-        goTo(goTo.pages.applicationReleaseList);
-      }
+      await updateRelease({ ...payload, $options: { successMsg: i18n.t('edited successfully') } });
+      goTo(goTo.pages.applicationReleaseList);
     });
   };
 

--- a/shell/app/modules/project/pages/release/components/form.scss
+++ b/shell/app/modules/project/pages/release/components/form.scss
@@ -1,4 +1,8 @@
 .release-form {
+  .render-form.ant-form-vertical {
+    width: 80%;
+  }
+
   .ant-btn {
     background-color: $color-default-06;
     border-color: $color-default-06;
@@ -10,7 +14,8 @@
     color: $white;
   }
 
-  input {
+  .ant-form-item-control-input-content > input {
+    width: 50%;
     background-color: $color-default-04 !important;
     border: none;
   }

--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -49,8 +49,8 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
   const getDetail = React.useCallback(async () => {
     if (releaseID) {
       const res = await getReleaseDetail({ releaseID });
-      if (res.success) {
-        const { data } = res;
+      const { data } = res;
+      if (data) {
         setReleaseDetail({
           ...data,
           applicationReleaseList: data.applicationReleaseList.map((item) => ({ ...item, releaseId: item.releaseID })),
@@ -78,9 +78,9 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
         isStable: true,
         q: query,
       });
-
-      if (res.success) {
-        const { list, total } = res.data;
+      const { data } = res;
+      if (data) {
+        const { list, total } = data;
         setReleaseList(list);
         setReleaseTotal(total);
       }
@@ -233,17 +233,15 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
         projectID: +projectId,
       };
       if (releaseID) {
-        const res = await updateRelease({ ...payload, releaseID });
-        if (res.success) {
-          message.success(i18n.t('edited successfully'));
-          goTo(goTo.pages.projectReleaseList);
-        }
+        await updateRelease({
+          ...payload,
+          releaseID,
+          $options: { successMsg: i18n.t('edited successfully') },
+        });
+        goTo(goTo.pages.projectReleaseList);
       } else {
-        const res = await addRelease({ ...payload });
-        if (res.success) {
-          message.success(i18n.t('created successfully'));
-          goTo(goTo.pages.projectReleaseList);
-        }
+        await addRelease({ ...payload, $options: { successMsg: i18n.t('created successfully') } });
+        goTo(goTo.pages.projectReleaseList);
       }
     });
   };

--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -236,13 +236,13 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
         const res = await updateRelease({ ...payload, releaseID });
         if (res.success) {
           message.success(i18n.t('edited successfully'));
-          goTo(goTo.pages.projectRelease);
+          goTo(goTo.pages.projectReleaseList);
         }
       } else {
         const res = await addRelease({ ...payload });
         if (res.success) {
           message.success(i18n.t('created successfully'));
-          goTo(goTo.pages.projectRelease);
+          goTo(goTo.pages.projectReleaseList);
         }
       }
     });
@@ -259,7 +259,7 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
           <Button className="mr-3" type="primary" onClick={submit}>
             {i18n.t('submit')}
           </Button>
-          <Button onClick={() => goTo(goTo.pages.projectRelease)}>{i18n.t('return to previous page')}</Button>
+          <Button onClick={() => goTo(goTo.pages.projectReleaseList)}>{i18n.t('return to previous page')}</Button>
         </div>
       ) : null}
     </div>

--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -140,8 +140,12 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
           return (
             <div className="flex justify-between items-center">
               <div className="flex-1 min-w-0">
-                <div className="text-hover truncate" title={item.releaseName}>
-                  {item.releaseName}
+                <div
+                  className="text-hover truncate cursor-pointer"
+                  title={item.version}
+                  onClick={() => window.open(goTo.resolve.applicationReleaseDetail({ releaseId: item.releaseId }))}
+                >
+                  {item.version}
                 </div>
                 <div className="text-xs flex mt-1">
                   <div className="desc">{i18n.t('dop:owned application')}</div>
@@ -158,8 +162,8 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
           return (
             <div className="flex justify-between items-center">
               <div className="flex-1 min-w-0">
-                <div className="truncate" title={item.releaseName}>
-                  {item.releaseName}
+                <div className="truncate" title={item.version}>
+                  {item.version}
                 </div>
                 <div className="text-xs flex">
                   <div className="desc">{i18n.t('dop:owned application')}</div>
@@ -193,7 +197,7 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
         return (value || []).map((item: RELEASE.ReleaseDetail) => (
           <div className="flex justify-between items-center bg-default-01 p-2">
             <div>
-              <div>{item.releaseName}</div>
+              <div>{item.version}</div>
               <div className="text-xs flex mt-1">
                 <div className="text-default-6">{i18n.t('dop:owned application')}</div>
                 <div className="ml-2">{item.applicationName}</div>

--- a/shell/app/modules/project/pages/release/components/project-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/project-detail.tsx
@@ -28,8 +28,8 @@ const ReleaseProjectDetail = () => {
   const getDetail = React.useCallback(async () => {
     if (releaseID) {
       const res = await getReleaseDetail({ releaseID });
-      if (res.success) {
-        const { data } = res;
+      const { data } = res;
+      if (data) {
         setReleaseDetail(data);
       }
     }
@@ -46,11 +46,11 @@ const ReleaseProjectDetail = () => {
         interpolation: { escapeValue: false },
       }),
       onOk: async () => {
-        const res = await formalRelease({ releaseID });
-        if (res.success) {
-          message.success(i18n.t('{action} successfully', { action: i18n.t('dop:be formal') }));
-          getReleaseDetail({ releaseID });
-        }
+        await formalRelease({
+          releaseID,
+          $options: { successMsg: i18n.t('{action} successfully', { action: i18n.t('dop:be formal') }) },
+        });
+        getDetail();
       },
     });
   };

--- a/shell/app/modules/project/pages/release/components/project-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/project-detail.tsx
@@ -65,7 +65,7 @@ const ReleaseProjectDetail = () => {
           </Button>
         ) : null}
 
-        <Button className="bg-default-06 border-default-06" onClick={() => goTo(goTo.pages.projectRelease)}>
+        <Button className="bg-default-06 border-default-06" onClick={() => goTo(goTo.pages.projectReleaseList)}>
           {i18n.t('return to previous page')}
         </Button>
       </div>

--- a/shell/app/modules/project/pages/release/components/update.tsx
+++ b/shell/app/modules/project/pages/release/components/update.tsx
@@ -26,8 +26,8 @@ const ReleaseUpdate = () => {
   const getDetail = React.useCallback(async () => {
     if (releaseID) {
       const res = await getReleaseDetail({ releaseID });
-      if (res.success) {
-        const { data } = res;
+      const { data } = res;
+      if (data) {
         setReleaseDetail(data);
       }
     }

--- a/shell/app/modules/project/router.tsx
+++ b/shell/app/modules/project/router.tsx
@@ -409,6 +409,7 @@ function getProjectRouter(): RouteConfigItem[] {
               path: 'application/:releaseID',
               pageName: `${i18n.t('Artifact')}${i18n.t('detail')}`,
               getComp: (cb) => cb(import('project/pages/release/components/application-detail')),
+              layout: { fullHeight: true },
             },
             {
               path: 'createRelease',

--- a/shell/app/modules/project/services/release.ts
+++ b/shell/app/modules/project/services/release.ts
@@ -12,6 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import agent from 'agent';
+import { apiCreator } from 'core/service';
 
 interface ReleaseListQuery {
   projectId?: string;
@@ -39,40 +40,41 @@ interface UpdateReleaseParams extends AddReleaseParams {
   releaseID: string;
 }
 
-export const getReleaseDetail = ({ releaseID }: { releaseID?: string }): RAW_RESPONSE<RELEASE.ReleaseDetail> => {
-  return agent.get(`/api/releases/${releaseID}`).then((response: any) => response.body);
+const apis = {
+  getReleaseDetail: {
+    api: 'get@/api/releases/:releaseID',
+  },
+  getAppList: {
+    api: 'get@/api/applications',
+  },
+  getReleaseList: {
+    api: 'get@/api/releases',
+  },
+  addRelease: {
+    api: 'post@/api/releases',
+  },
+  updateRelease: {
+    api: 'put@/api/releases/:releaseID',
+  },
+  formalRelease: {
+    api: 'put@/api/releases/:releaseID/actions/formal',
+  },
 };
 
-export const getAppList = (payload: { projectId: string; q?: string }): { list: RELEASE.AppDetail[] } => {
-  return agent
-    .get(`/api/applications`)
-    .query(payload)
-    .then((response: any) => response.body);
-};
+export const getReleaseDetail = apiCreator<(payload: { releaseID?: string }) => RELEASE.ReleaseDetail>(
+  apis.getReleaseDetail,
+);
 
-export const getReleaseList = (
-  payload: ReleaseListQuery,
-): RAW_RESPONSE<{ list: RELEASE.ReleaseDetail[]; total: number }> => {
-  return agent
-    .get(`/api/releases`)
-    .query({ ...payload, pageSize: payload.pageSize || 10 })
-    .then((response: any) => response.body);
-};
+export const getAppList = apiCreator<(payload: { projectId: string; q?: string }) => { list: RELEASE.AppDetail[] }>(
+  apis.getAppList,
+);
 
-export function addRelease(payload: AddReleaseParams): RAW_RESPONSE {
-  return agent
-    .post('/api/releases')
-    .send(payload)
-    .then((response: any) => response.body);
-}
+export const getReleaseList = apiCreator<
+  (payload: ReleaseListQuery) => { list: RELEASE.ReleaseDetail[]; total: number }
+>(apis.getReleaseList);
 
-export function updateRelease({ releaseID, ...payload }: UpdateReleaseParams): RAW_RESPONSE {
-  return agent
-    .put(`/api/releases/${releaseID}`)
-    .send(payload)
-    .then((response: any) => response.body);
-}
+export const addRelease = apiCreator<(payload: AddReleaseParams) => RAW_RESPONSE>(apis.addRelease);
 
-export function formalRelease({ releaseID }: { releaseID: string }): RAW_RESPONSE {
-  return agent.put(`/api/releases/${releaseID}/actions/formal`).then((response: any) => response.body);
-}
+export const updateRelease = apiCreator<(payload: UpdateReleaseParams) => RAW_RESPONSE>(apis.updateRelease);
+
+export const formalRelease = apiCreator<(payload: { releaseID: string }) => RAW_RESPONSE>(apis.formalRelease);

--- a/shell/app/modules/project/types/release.d.ts
+++ b/shell/app/modules/project/types/release.d.ts
@@ -23,6 +23,7 @@ declare namespace RELEASE {
     releaseID?: string;
     applicationName: string;
     releaseName: string;
+    version: string;
     userId: string;
     createdAt: string;
     labels: Labels;


### PR DESCRIPTION
## What this PR does / why we need it:
- Project release management application release edit
- Project release management application release left menu close bug
- Filter style bug
- Add markdown width in create release page
- release list name display bug in create release

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/147719900-1c8cf835-f615-4439-8882-af3722275a92.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Application release editing of project - level release.  |
| 🇨🇳 中文    |  项目级制品的应用制品编辑。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

