### PR TITLE
fix: public project changed to personal project after update project quota or rollback point

### DIFF
--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -71,7 +71,7 @@ const Info = () => {
   const { rollbackConfig } = info;
 
   const updatePrj = (values: Obj) => {
-    const { isPublic, resourceConfig } = values;
+    const { isPublic = String(info.isPublic), resourceConfig } = values;
     if (resourceConfig) {
       Object.keys(values.resourceConfig)
         .filter((key) => resourceConfig[key])
@@ -426,7 +426,9 @@ const Info = () => {
         formData={{ ...info, isPublic: `${info.isPublic || 'false'}` }}
       />
       <FormModal
-        onOk={(result) => updateProject(result).then(() => setProjectRollbackEditVisible(false))}
+        onOk={(result) =>
+          updateProject({ ...result, isPublic: info.isPublic }).then(() => setProjectRollbackEditVisible(false))
+        }
         onCancel={() => setProjectRollbackEditVisible(false)}
         name={i18n.t('dop:rollback point')}
         visible={projectRollbackEditVisible}


### PR DESCRIPTION
## What this PR does / why we need it:
fix that public project changed to personal project after update project quota or rollback point

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.5


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[更新项目配额会将公开项目设置成 私有项目](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?id=270929&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
