### PR TITLE
fix: close site message when go to personal home

### DIFF
--- a/shell/app/layout/pages/page-container/components/navigation/index.tsx
+++ b/shell/app/layout/pages/page-container/components/navigation/index.tsx
@@ -124,6 +124,8 @@ const Navigation = () => {
           className="absolute workbench-icon"
           size={32}
           onClick={() => {
+            // close message site
+            layoutStore.reducers.switchMessageCenter(null);
             const isIncludeOrg = !!orgs.find((x) => x.name === curOrgName);
             if (isAdminRoute) {
               const lastOrg = window.localStorage.getItem('lastOrg');


### PR DESCRIPTION
## What this PR does / why we need it:
close site message when go to personal home

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[在站内信页面点击个人工作台无效](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?id=271327&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
