### PR TITLE
fix(dop): project release management application release detail style…

### DIFF
--- a/shell/app/modules/project/pages/release/components/application-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/application-detail.tsx
@@ -41,7 +41,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
     createdAt,
     labels = {} as RELEASE.Labels,
     changelog,
-    images = [],
+    serviceImages = [],
     isFormal,
   } = releaseDetail;
 
@@ -97,7 +97,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
   };
 
   return (
-    <div className="release-releaseDetail release-form h-full overflow-y-auto pb-18">
+    <div className="release-releaseDetail release-form h-full overflow-y-auto pb-16">
       <Form layout="vertical" form={form}>
         <Tabs defaultActiveKey="1">
           <TabPane tab={i18n.t('dop:basic information')} key="1">
@@ -162,8 +162,11 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
           </TabPane>
           <TabPane tab={i18n.t('dop:images list')} key="2">
             <Table
-              columns={[{ title: i18n.t('dop:image name'), dataIndex: 'name' }]}
-              dataSource={images.map((item: string) => ({ name: item }))}
+              columns={[
+                { title: i18n.t('dop:image name'), dataIndex: 'image' },
+                { title: i18n.t('service name'), dataIndex: 'name' },
+              ]}
+              dataSource={serviceImages}
               onChange={() => getReleaseDetail({ releaseID })}
             />
           </TabPane>


### PR DESCRIPTION
… optimization

## What this PR does / why we need it:
In project release management, application release detail style optimization:
- dice.yml scroll bug
- images table add service name column

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/147810455-d4177b07-cefa-4bfa-a56e-52c91149911e.png)
![image](https://user-images.githubusercontent.com/82502479/147810431-e5ac67e7-c248-4bb9-8d65-0176e772a07c.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

