### PR TITLE
fix(dop): project release management text adjustment

### DIFF
--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -1664,6 +1664,7 @@
     "related to existing issues": "related to existing issues",
     "related to these issues": "related to these issues",
     "relation added successfully": "relation added successfully",
+    "release name": "release name",
     "release relationship": "release relationship",
     "release version": "release version",
     "remark": "remark",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -1664,6 +1664,7 @@
     "related to existing issues": "关联已有事项",
     "related to these issues": "关联了以下事项",
     "relation added successfully": "添加关联成功",
+    "release name": "制品名称",
     "release relationship": "解除关系",
     "release version": "发布版本",
     "remark": "备注",

--- a/shell/app/modules/project/pages/release/components/application-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/application-detail.tsx
@@ -105,11 +105,11 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
               {isEdit ? (
                 <div className="w-2/5">
                   <RenderFormItem
-                    label={i18n.t('dop:version name')}
+                    label={i18n.t('dop:release name')}
                     name="version"
                     type="input"
                     rules={[
-                      { required: true, message: i18n.t('please enter {name}', { name: i18n.t('dop:version name') }) },
+                      { required: true, message: i18n.t('please enter {name}', { name: i18n.t('dop:release name') }) },
                       { max: 30, message: i18n.t('dop:no more than 30 characters') },
                       {
                         pattern: /^[A-Za-z0-9._-]+$/,
@@ -120,7 +120,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
                 </div>
               ) : (
                 <div className="mb-2">
-                  <div className="text-black-400 mb-2">{i18n.t('dop:version name')}</div>
+                  <div className="text-black-400 mb-2">{i18n.t('dop:release name')}</div>
                   <div>{version || '-'}</div>
                 </div>
               )}

--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -115,14 +115,14 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
 
   const list = [
     {
-      label: i18n.t('dop:version name'),
+      label: i18n.t('dop:release name'),
       name: 'version',
       type: 'input',
       itemProps: {
-        placeholder: i18n.t('please enter {name}', { name: i18n.t('dop:version name') }),
+        placeholder: i18n.t('please enter {name}', { name: i18n.t('dop:release name') }),
       },
       rules: [
-        { required: true, message: i18n.t('please enter {name}', { name: i18n.t('dop:version name') }) },
+        { required: true, message: i18n.t('please enter {name}', { name: i18n.t('dop:release name') }) },
         { max: 30, message: i18n.t('dop:no more than 30 characters') },
         {
           pattern: /^[A-Za-z0-9._-]+$/,


### PR DESCRIPTION
## What this PR does / why we need it:
Project release management text adjustment.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/147814433-e3c46acb-b239-4812-ae75-be02c95f3289.png)
->
![image](https://user-images.githubusercontent.com/82502479/147814512-b07908ec-080e-4a5b-92f4-25d90064efcd.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Version name replace with release name. |
| 🇨🇳 中文    |  版本名称改成制品名称  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

