### PR TITLE
fix(dop): project release management application release table scroll…

### DIFF
--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -41,6 +41,7 @@ interface IProps<T extends object = any> extends TableProps<T> {
   rowSelection?: IRowSelection<T>;
   hideHeader?: boolean;
   onReload?: (pageNo: number, pageSize: number) => void;
+  className?: string;
 }
 
 const sortIcon = {
@@ -67,6 +68,7 @@ function WrappedTable<T extends object = any>({
   rowSelection,
   hideHeader,
   rowKey,
+  className,
   ...props
 }: IProps<T>) {
   const dataSource = React.useMemo<T[]>(() => (ds as T[]) || [], [ds]);
@@ -285,7 +287,7 @@ function WrappedTable<T extends object = any>({
   }
 
   return (
-    <div className={`erda-table ${hideHeader ? 'hide-header' : ''}`}>
+    <div className={`flex flex-col erda-table ${hideHeader ? 'hide-header' : ''}`}>
       {!hideHeader && (
         <TableConfig
           slot={slot}
@@ -311,6 +313,7 @@ function WrappedTable<T extends object = any>({
         onRow={onRow}
         rowSelection={rowSelection}
         {...props}
+        className={`flex-1 min-h-0 overflow-y-auto ${className}`}
         tableLayout="auto"
         locale={{
           emptyText:

--- a/shell/app/modules/project/pages/release/application.tsx
+++ b/shell/app/modules/project/pages/release/application.tsx
@@ -37,7 +37,7 @@ const ProjectRelease = () => {
     <div className="h-full flex flex-col">
       <ErdaAlert showOnceKey="application-release-list" message={i18n.t('dop:Applications release list top desc')} />
 
-      <div className="flex-1 flex bg-white">
+      <div className="flex-1 flex bg-white min-h-0 mb-4">
         <div className="release-app-list overflow-y-auto px-2">
           <Spin spinning={loading}>
             <div className="px-2 py-4 leading-4 font-medium">{i18n.t('dop:applications')}</div>


### PR DESCRIPTION
… optimization

## What this PR does / why we need it:
Project release management application release table scroll optimization.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/147817726-3b014d38-c61b-40a1-93f8-9cea812b09c0.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

