### PR TITLE
feat: update table operation dropdown theme

### DIFF
--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -88,7 +88,7 @@
   }
 
   .ant-table-tbody td {
-    line-height: 30px !important;
+    line-height: 41px !important;
   }
 
   .ant-table-tbody tr:not(.ant-table-measure-row) {

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -88,7 +88,7 @@
   }
 
   .ant-table-tbody td {
-    line-height: 41px !important;
+    line-height: 30px !important;
   }
 
   .ant-table-tbody tr:not(.ant-table-measure-row) {

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -232,7 +232,7 @@ function WrappedTable<T extends object = any>({
               <div
                 className={`
                     erda-table-compose-td flex items-center
-                    ${icon ? 'erda-table-icon-td' : ''} 
+                    ${icon ? 'erda-table-icon-td' : ''}
                     ${(Object.keys(args).includes('subTitle') && 'double-row') || ''}
                   `}
               >
@@ -350,7 +350,7 @@ function renderActions<T extends object = any>(actions?: IActions<T> | null): Ar
           const list = render(record).filter((item) => item.show !== false);
 
           const menu = (
-            <Menu>
+            <Menu theme="dark">
               {list.map((item) => (
                 <Menu.Item key={item.title} onClick={item.onClick}>
                   <span className="fake-link mr-1">{item.title}</span>

--- a/shell/app/config-page/components/gantt/components/gantt/gantt.scss
+++ b/shell/app/config-page/components/gantt/components/gantt/gantt.scss
@@ -1,4 +1,6 @@
 .erda-gantt-vertical-container {
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   margin: 0;
   font-size: 0;

--- a/shell/app/config-page/components/table/render-types.tsx
+++ b/shell/app/config-page/components/table/render-types.tsx
@@ -614,7 +614,7 @@ const getTableOperation = (val: any, record: any, extra: any) => {
       return (
         <Menu.Item key={key} className="p-0">
           <WithAuth noAuthTip={disabledTip} key={key} pass={false}>
-            <span className="table-operations-btn px-3 py-1 block">{text}</span>
+            <span className="table-operations-btn px-4 py-1 block">{text}</span>
           </WithAuth>
         </Menu.Item>
       );
@@ -632,7 +632,7 @@ const getTableOperation = (val: any, record: any, extra: any) => {
             onCancel={(e: any) => e && e.stopPropagation()}
             zIndex={1100}
           >
-            <span className="table-operations-btn px-3 py-1 block" onClick={(e: any) => e.stopPropagation()}>
+            <span className="table-operations-btn px-4 py-1 block" onClick={(e: any) => e.stopPropagation()}>
               {text}
             </span>
           </Popconfirm>
@@ -643,7 +643,7 @@ const getTableOperation = (val: any, record: any, extra: any) => {
       return (
         <Menu.Item key={key} className="p-0">
           <span
-            className="table-operations-btn px-3 py-1 block"
+            className="table-operations-btn px-4 py-1 block"
             key={key}
             onClick={(e: any) => {
               e.stopPropagation();
@@ -687,7 +687,15 @@ const getTableOperation = (val: any, record: any, extra: any) => {
 
   return (
     <div className="table-operations">
-      <Dropdown overlay={<Menu>{operationList}</Menu>} align={{ offset: [0, 5] }} trigger={['click']}>
+      <Dropdown
+        overlay={
+          <Menu theme="dark" style={{ minWidth: 160, padding: '8px 0' }}>
+            {operationList}
+          </Menu>
+        }
+        align={{ offset: [0, 5] }}
+        trigger={['click']}
+      >
         <ErdaIcon type="more" className="cursor-pointer p-1 bg-hover rounded-sm" onClick={(e) => e.stopPropagation()} />
       </Dropdown>
     </div>

--- a/shell/app/config-page/components/table/table.tsx
+++ b/shell/app/config-page/components/table/table.tsx
@@ -277,7 +277,7 @@ const BatchOperation = (props: IBatchProps) => {
   }, [batchOperations, chosenItems, operations, selectedRowKeys]);
 
   const dropdownMenu = (
-    <Menu>
+    <Menu theme="dark">
       {map(optMenus, (mItem) => {
         return (
           <Menu.Item key={mItem.key} disabled={mItem.disabled}>

--- a/shell/app/modules/cmp/router.ts
+++ b/shell/app/modules/cmp/router.ts
@@ -240,7 +240,7 @@ function getCmpRouter(): RouteConfigItem[] {
             {
               path: 'add',
               breadcrumbName: i18n.t('cmp:new O & M dashboard'),
-              layout: { fullHeight: true, noWrapper: true },
+              layout: { fullHeight: true },
               getComp: (cb) => cb(import('cmp/pages/alarm-report/custom-dashboard/custom-dashboard')),
             },
             {
@@ -250,6 +250,7 @@ function getCmpRouter(): RouteConfigItem[] {
               getComp: (cb) => cb(import('cmp/pages/alarm-report/custom-dashboard/custom-dashboard')),
             },
             {
+              layout: { noWrapper: true },
               getComp: (cb) => cb(import('cmp/pages/alarm-report/custom-dashboard')),
             },
           ],

--- a/shell/app/modules/ecp/router.ts
+++ b/shell/app/modules/ecp/router.ts
@@ -24,7 +24,7 @@ const getEcpRouter = () => [
         breadcrumbName: i18n.t('ecp:application'),
         routes: [
           {
-            layout: { fullHeight: true },
+            layout: { fullHeight: true, noWrapper: true },
             getComp: (cb: RouterGetComp) => cb(import('./pages/application')),
           },
           {
@@ -52,7 +52,7 @@ const getEcpRouter = () => [
         routes: [
           {
             breadcrumbName: i18n.t('ecp:site management'),
-            layout: { fullHeight: true },
+            layout: { fullHeight: true, noWrapper: true },
             getComp: (cb: RouterGetComp) => cb(import('./pages/resource')),
           },
           {
@@ -68,7 +68,7 @@ const getEcpRouter = () => [
         breadcrumbName: i18n.t('ecp:configuration'),
         routes: [
           {
-            layout: { fullHeight: true },
+            layout: { fullHeight: true, noWrapper: true },
             getComp: (cb: RouterGetComp) => cb(import('./pages/setting')),
           },
           {

--- a/shell/app/styles/antd-extension.scss
+++ b/shell/app/styles/antd-extension.scss
@@ -416,6 +416,22 @@ body {
     display: block;
   }
 
+  // for table operations
+  .ant-dropdown-menu-dark,
+  .ant-dropdown-menu-dark .ant-dropdown-menu {
+    background: $color-default;
+    .disabled {
+      color: #999 !important;
+    }
+  }
+
+  // for table operations
+  .ant-dropdown-menu-dark {
+    .fake-link {
+      color: unset;
+    }
+  }
+
   .ant-dropdown-menu-title-content {
     width: 100%;
   }


### PR DESCRIPTION
## What this PR does / why we need it:
* update table operation dropdown theme
* remove odd space between calendar and content in gantt

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/147822622-67f04f7b-66e2-4014-8693-4318430fd79c.png)
![image](https://user-images.githubusercontent.com/3955437/147822642-ddc2a0a0-c38f-4da7-8798-624c465a23d6.png)
![image](https://user-images.githubusercontent.com/3955437/147822691-772bacc0-1027-4d6e-b9c5-b9de2b1d4a11.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

