### PR TITLE
fix: display edit tip in markdown of project home

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,7 @@ importers:
       react-markdown: ^7.1.0
       react-router-config: ^5.0.0
       react-router-dom: ^5.2.0
+      react-sticky-mouse-tooltip: ^0.0.1
       react-test-renderer: ^16.7.0
       react-use: ^15.3.4
       remark-gfm: ^3.0.1
@@ -518,6 +519,7 @@ importers:
       react-markdown: 7.1.0_2f77d3833b7b833f5364ea085d5a48f2
       react-router-config: 5.1.1_react@16.14.0
       react-router-dom: 5.2.0_react@16.14.0
+      react-sticky-mouse-tooltip: 0.0.1_react-dom@16.14.0+react@16.14.0
       react-use: 15.3.8_react-dom@16.14.0+react@16.14.0
       remark-gfm: 3.0.1
       requestidlecallback-polyfill: 1.0.2
@@ -9901,7 +9903,7 @@ packages:
       '@types/babel__core': 7.1.14
       babel-plugin-istanbul: 6.0.0
       babel-preset-jest: 26.6.2_@babel+core@7.14.3
-      chalk: 4.1.2
+      chalk: 4.1.1
       graceful-fs: 4.2.6
       slash: 3.0.0
     transitivePeerDependencies:
@@ -17397,7 +17399,7 @@ packages:
       '@jest/test-sequencer': 26.6.3_ts-node@10.1.0
       '@jest/types': 26.6.2
       babel-jest: 26.6.3_@babel+core@7.14.3
-      chalk: 4.1.2
+      chalk: 4.1.1
       deepmerge: 4.2.2
       glob: 7.1.7
       graceful-fs: 4.2.6
@@ -17613,7 +17615,7 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
       '@types/node': 15.6.1
-      chalk: 4.1.2
+      chalk: 4.1.1
       co: 4.6.0
       expect: 26.6.2
       is-generator-fn: 2.1.0
@@ -17811,7 +17813,7 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
       '@types/node': 15.6.1
-      chalk: 4.1.2
+      chalk: 4.1.1
       emittery: 0.7.2
       exit: 0.1.2
       graceful-fs: 4.2.6
@@ -17889,7 +17891,7 @@ packages:
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
       '@types/yargs': 15.0.13
-      chalk: 4.1.2
+      chalk: 4.1.1
       cjs-module-lexer: 0.6.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -24072,6 +24074,16 @@ packages:
       - webpack-command
       - webpack-hot-middleware
       - webpack-plugin-serve
+    dev: false
+
+  /react-sticky-mouse-tooltip/0.0.1_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-nuKyvolX3Zsu48uoGXkEvEE8oAwl7jaUvJrA/SxCSmBmbzmECNBQp03Z60L6/1ImLUzLFUHh2Wul3GpkEffrPw==}
+    peerDependencies:
+      react: ^16.1.0
+      react-dom: ^16.1.0
+    dependencies:
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
     dev: false
 
   /react-test-renderer/16.14.0_react@16.14.0:

--- a/shell/app/interface/global.d.ts
+++ b/shell/app/interface/global.d.ts
@@ -17,6 +17,7 @@ declare module 'path';
 declare module 'lodash/_stringToPath';
 declare module 'js-yaml';
 declare module 'react-flame-graph';
+declare module 'react-sticky-mouse-tooltip';
 
 declare let If: React.FunctionComponent<{ condition: boolean }>;
 declare let For: React.FunctionComponent<{ each: string; index: string; of: any[] }>;

--- a/shell/package.json
+++ b/shell/package.json
@@ -93,6 +93,7 @@
     "react-markdown": "^7.1.0",
     "react-router-config": "^5.0.0",
     "react-router-dom": "^5.2.0",
+    "react-sticky-mouse-tooltip": "^0.0.1",
     "react-use": "^15.3.4",
     "remark-gfm": "^3.0.1",
     "requestidlecallback-polyfill": "^1.0.2",


### PR DESCRIPTION
## What this PR does / why we need it:
In the markdown of the read status on the project homepage, the prompt ‘click to edit’ is displayed 

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![2022-01-04 11 05 53](https://user-images.githubusercontent.com/30014895/148004336-d7a19da0-ec36-4342-a3fd-cfc7bed71ea8.gif)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | In the markdown of the read status on the project homepage, the prompt ‘click to edit’ is displayed |
| 🇨🇳 中文    | 在项目首页读取状态的 markdown 中显示 ’点击即可编辑’ 的提示


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【项目首页】点击即可编辑显示位置优化](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?id=271260&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
