### PR TITLE
Hotfix/unify filter input border style when focus

### DIFF
--- a/shell/app/common/components/contractive-filter/index.scss
+++ b/shell/app/common/components/contractive-filter/index.scss
@@ -82,10 +82,6 @@
     cursor: pointer;
   }
 
-  .ant-input {
-    background: none;
-  }
-
   .anticon-calendar {
     display: none;
   }

--- a/shell/app/common/components/contractive-filter/index.tsx
+++ b/shell/app/common/components/contractive-filter/index.tsx
@@ -186,7 +186,6 @@ const FilterItem = ({ itemData, value, active, onVisibleChange, onChange, onQuic
         style={{ width: 180 }}
         allowClear
         className="bg-hover-gray-bg"
-        bordered={false}
         // ref={inputRef}
         prefix={<ErdaIcon fill="default-3" size="16" type="search" />}
         placeholder={placeholder || i18n.t('press enter to search')}

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -88,7 +88,7 @@
   }
 
   .ant-table-tbody td {
-    line-height: 30px !important;
+    line-height: 41px !important;
   }
 
   .ant-table-tbody tr:not(.ant-table-measure-row) {

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -121,13 +121,6 @@
   .erda-table-filter {
     min-height: 48px;
 
-    .ant-input-affix-wrapper,
-    input {
-      background-color: $color-input-bg;
-      border: none;
-      border-radius: 2px;
-    }
-
     .ant-picker-range {
       input {
         background: none;

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -88,7 +88,7 @@
   }
 
   .ant-table-tbody td {
-    line-height: 41px !important;
+    line-height: 30px !important;
   }
 
   .ant-table-tbody tr:not(.ant-table-measure-row) {

--- a/shell/app/styles/_color.scss
+++ b/shell/app/styles/_color.scss
@@ -115,9 +115,6 @@ $color-table-bg-hover: #f7f7f8;
 $color-table-head-bg: #fbfbfb;
 $color-bg-gray: #efeef0;
 
-// Color Filter
-$color-input-bg: #efeef0;
-
 // color new list
 $color-box-shadow: rgba($color-text-sub, 0.1);
 

--- a/shell/app/styles/antd-extension.scss
+++ b/shell/app/styles/antd-extension.scss
@@ -345,6 +345,14 @@ body {
     min-height: auto;
   }
 
+  .ant-input-affix-wrapper {
+    border: none; // remove border in normal mode but show in focus mode
+
+    input {
+      background-color: transparent;
+    }
+  }
+
   .ant-input-group span.ant-input-affix-wrapper {
     display: inline-flex;
   }


### PR DESCRIPTION
## What this PR does / why we need it:
unify filter input style, always show border when focus


## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/148022081-89ecd9ec-f71c-4f08-b001-78b3dd7b75c1.png)

->

![image](https://user-images.githubusercontent.com/3955437/148022063-cd635ab5-5c90-4635-ac54-194f57772a3e.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

