### PR TITLE
fix(cmp): clusters list reload after add or delete

### DIFF
--- a/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
@@ -79,7 +79,7 @@ const ClusterList: React.ForwardRefRenderFunction<{ reload: () => void }, IProps
   React.useImperativeHandle(
     ref,
     () => ({
-      reload: () => reloadRef?.current?.reload?.(),
+      reload: () => reloadRef.current?.reload(),
     }),
     [],
   );

--- a/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/cluster-list.tsx
@@ -12,22 +12,20 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Modal, Table, Button, Drawer, Input, Spin } from 'antd';
-import { goTo, insertWhen, notify, setSearch } from 'common/utils';
-import { map, get, find } from 'lodash';
+import { Modal, Button, Drawer, Input, Spin } from 'antd';
+import { goTo, notify, setSearch } from 'common/utils';
+import { get } from 'lodash';
 import AddMachineModal from 'app/modules/cmp/common/components/machine-form-modal';
 import AddCloudMachineModal from './cloud-machine-form-modal';
 import TokenManageModal from './token-manage-modal';
-import { Icon as CustomIcon, Copy, ConfirmDelete } from 'common';
+import { Copy, ConfirmDelete } from 'common';
 import { useUpdate } from 'common/use-hooks';
 import machineStore from 'app/modules/cmp/stores/machine';
 import clusterStore from 'app/modules/cmp/stores/cluster';
 import i18n from 'i18n';
 import { ClusterLog } from './cluster-log';
 import { getClusterOperationHistory } from 'app/modules/cmp/services/machine';
-import { ColumnProps, IActions } from 'core/common/interface';
 import orgStore from 'app/org-home/stores/org';
-import { bgColorClsMap } from 'common/utils/style-constants';
 import { useLoading } from 'core/stores/loading';
 import DiceConfigPage from 'config-page/index';
 
@@ -37,10 +35,6 @@ import './cluster-list.scss';
 
 interface IProps {
   onEdit: (record: any) => void;
-}
-
-interface ICluster {
-  title: string;
 }
 
 export const statusMap = {
@@ -58,7 +52,7 @@ export const manageTypeMap = {
   import: i18n.t('import'),
 };
 
-const ClusterList = ({ onEdit }: IProps) => {
+const ClusterList: React.ForwardRefRenderFunction<{ reload: () => void }, IProps> = ({ onEdit }: IProps, ref) => {
   const { addCloudMachine } = machineStore.effects;
   const { upgradeCluster, deleteCluster, getRegisterCommand, clusterInitRetry } = clusterStore.effects;
   const [curCluster, setCurCluster] = React.useState<ORG_CLUSTER.ICluster | null>(null);
@@ -79,6 +73,16 @@ const ClusterList = ({ onEdit }: IProps) => {
     deleteClusterName: '',
     registerCommandVisible: false,
   });
+
+  const reloadRef = React.useRef<Obj | null>(null);
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      reload: () => reloadRef?.current?.reload?.(),
+    }),
+    [],
+  );
 
   const toggleAddCloudMachine = (cluster?: ORG_CLUSTER.ICluster) => {
     if (cluster) {
@@ -154,6 +158,9 @@ const ClusterList = ({ onEdit }: IProps) => {
             notify('error', curRecord.detail);
           }
         });
+      if (reloadRef.current && reloadRef.current.reload) {
+        reloadRef.current.reload();
+      }
     });
     toggleDeleteModal();
   };
@@ -245,6 +252,7 @@ const ClusterList = ({ onEdit }: IProps) => {
         <DiceConfigPage
           scenarioKey="cmp-cluster-list"
           scenarioType="cmp-cluster-list"
+          ref={reloadRef}
           customProps={{
             list: {
               props: {
@@ -303,4 +311,4 @@ const ClusterList = ({ onEdit }: IProps) => {
   );
 };
 
-export default ClusterList;
+export default React.forwardRef<{ reload: () => void }, IProps>(ClusterList);

--- a/shell/app/modules/cmp/pages/cluster-manage/index.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/index.tsx
@@ -31,6 +31,7 @@ const ClusterManage = () => {
   const list = clusterStore.useStore((s) => s.list);
   const { addCluster, updateCluster, getClusterList } = clusterStore.effects;
   const [loading] = useLoading(clusterStore, ['getClusterList']);
+  const listRef = React.useRef<Obj | null>(null);
 
   const [
     {
@@ -102,7 +103,7 @@ const ClusterManage = () => {
     toggleAddModalVis();
   };
 
-  const handleAddCluster = (values: any) => {
+  const handleAddCluster = async (values: any) => {
     const { id, credential: credentialData, ...restData } = values;
     const credential =
       credentialData?.content === '********'
@@ -114,7 +115,8 @@ const ClusterManage = () => {
       // urls 中仍有其他配置，后面可能会加入
       updateCluster({ ...values, credential });
     } else {
-      addCluster({ ...restData, credential });
+      await addCluster({ ...restData, credential });
+      listRef.current?.reload();
       if (restData.credentialType === 'proxy') {
         setSearch({ autoOpenCmd: true, clusterName: restData.name }, [], true);
       }
@@ -134,7 +136,7 @@ const ClusterManage = () => {
   return (
     <div className="cluster-manage-ct">
       <Spin spinning={loading}>
-        <ClusterList onEdit={handleShowAddClusterModal} />
+        <ClusterList ref={listRef} onEdit={handleShowAddClusterModal} />
       </Spin>
       <div className="top-button-group">
         <Button onClick={() => goTo('./history')}>{i18n.t('cmp:operation history')}</Button>


### PR DESCRIPTION
## What this PR does / why we need it:
Clusters list reload after add or delete

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=270014&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

