### PR TITLE
feat: only show top 10 at most in personal home

### DIFF
--- a/shell/app/common/components/user-profile/index.tsx
+++ b/shell/app/common/components/user-profile/index.tsx
@@ -17,6 +17,8 @@ import { getAvatarChars } from 'common/utils';
 import i18n from 'i18n';
 import moment from 'moment';
 import React from 'react';
+import userStore from 'user/stores';
+import { erdaEnv, UC_USER_SETTINGS } from 'app/common/constants';
 import './index.scss';
 
 export interface UserProfileProps {
@@ -32,6 +34,7 @@ export interface UserProfileProps {
 }
 
 const UserProfile = ({ data, className = '' }: UserProfileProps) => {
+  const loginUser = userStore.useStore((s) => s.loginUser);
   const { name, avatar, id, email, phone, lastLoginTime } = data;
   const infoList = [
     ['youxiang', i18n.t('email'), email],
@@ -47,7 +50,12 @@ const UserProfile = ({ data, className = '' }: UserProfileProps) => {
           background: `center / cover no-repeat url(${avatar})`,
         }}
       />
-      <div className="name-warp p-4">
+
+      {/* Jump to personal settings of UC */}
+      <div
+        className="name-warp p-4 cursor-pointer hover:bg-default-06"
+        onClick={() => window.open(loginUser.isNewUser ? UC_USER_SETTINGS : erdaEnv.UC_PUBLIC_URL)}
+      >
         <Avatar src={avatar} size={64} alt="user-avatar">
           {name ? getAvatarChars(name) : i18n.t('none')}
         </Avatar>

--- a/shell/app/org-home/pages/active-rank/index.tsx
+++ b/shell/app/org-home/pages/active-rank/index.tsx
@@ -77,8 +77,8 @@ const ActiveRank = (props: { currentUser: ILoginUser }) => {
         </div>
       </div>
       {/* Only show the top 10 at most */}
-      <div className="overflow-y-auto max-h-[560px]">
-        {map(rankList.slice(0, 10), ({ rank, name, avatar, value, id }) => {
+      <div className="overflow-y-auto max-h-[616px]">
+        {map(rankList, ({ rank, name, avatar, value, id }) => {
           return (
             <div key={id} className="grid grid-cols-12 h-11 items-center px-5 py-2">
               <div className="col-span-2 flex justify-center w-6 h-6 leading-6">

--- a/shell/app/org-home/pages/active-rank/index.tsx
+++ b/shell/app/org-home/pages/active-rank/index.tsx
@@ -76,8 +76,9 @@ const ActiveRank = (props: { currentUser: ILoginUser }) => {
           </div>
         </div>
       </div>
-      <div className="overflow-y-auto h-56">
-        {map(rankList, ({ rank, name, avatar, value, id }) => {
+      {/* Only show the top 10 at most */}
+      <div className="overflow-y-auto max-h-[560px]">
+        {map(rankList.slice(0, 10), ({ rank, name, avatar, value, id }) => {
           return (
             <div key={id} className="grid grid-cols-12 h-11 items-center px-5 py-2">
               <div className="col-span-2 flex justify-center w-6 h-6 leading-6">


### PR DESCRIPTION
## What this PR does / why we need it:
1.  only show top 10 at most in the personal home(not display scroll bar)
2. click user info to go to personal setting of UC 

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![2022-01-04 15 58 21](https://user-images.githubusercontent.com/30014895/148027597-65530e03-453a-44a3-99e1-f1a88d777585.gif)
![image](https://user-images.githubusercontent.com/30014895/148028173-8c2aecad-7082-4c92-92b9-6ec59d41154e.png)





## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | only show top 10 at most in contribute rank, and click user info to go to personal setting|
| 🇨🇳 中文    | 贡献排行最多显示前 10 名，点击用户信息区域跳转至个人设置页面 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

