### PR TITLE
feat: update filter to tab in iteration

### DIFF
--- a/shell/app/modules/project/pages/homepage/index.tsx
+++ b/shell/app/modules/project/pages/homepage/index.tsx
@@ -259,7 +259,7 @@ export const ProjectHomepage = () => {
                     {projectOwner?.nick ? getAvatarChars(projectOwner?.nick) : i18n.t('none')}
                   </Avatar>
                   {projectOwner?.name && (
-                    <span className="text-default-8 ml-1">{projectOwner?.name || projectOwner?.nick || '-'}</span>
+                    <span className="text-default-8 ml-1">{projectOwner?.nick || projectOwner?.name || '-'}</span>
                   )}
                 </span>
               </div>

--- a/shell/app/modules/project/pages/iteration/table.tsx
+++ b/shell/app/modules/project/pages/iteration/table.tsx
@@ -13,12 +13,12 @@
 
 import { goTo } from 'common/utils';
 import iterationStore from 'app/modules/project/stores/iteration';
-import { DeleteConfirm, Ellipsis } from 'common';
+import { Ellipsis, RadioTabs } from 'common';
 import { useUpdate } from 'common/use-hooks';
 import { useLoading } from 'core/stores/loading';
 import i18n from 'i18n';
 import moment from 'moment';
-import { Button, Progress, Select, Modal } from 'antd';
+import { Button, Progress, Modal } from 'antd';
 import Table from 'common/components/table';
 import React from 'react';
 import { map, sumBy } from 'lodash';
@@ -26,16 +26,10 @@ import IterationModal from './iteration-modal';
 import { WithAuth, usePerm } from 'user/common';
 import routeInfoStore from 'core/stores/route';
 
-const { Option } = Select;
-
-const iterationOptions = [
-  { cnName: i18n.t('processing'), enName: 'unarchive' },
-  { cnName: i18n.t('archived'), enName: 'archived' },
-].map(({ cnName, enName }) => (
-  <Option key={enName} value={enName}>
-    {cnName}
-  </Option>
-));
+const options = [
+  { value: 'unarchive', label: i18n.t('processing') },
+  { value: 'archived', label: i18n.t('archived') },
+];
 
 export const Iteration = () => {
   const [status, setStatus] = React.useState('unarchive');
@@ -212,6 +206,14 @@ export const Iteration = () => {
           </Button>
         </WithAuth>
       </div>
+      <RadioTabs
+        options={options}
+        value={status}
+        onChange={(v: string) => {
+          setStatus(v);
+        }}
+        className="mb-2"
+      />
       <Table
         rowKey="id"
         dataSource={list}
@@ -238,11 +240,6 @@ export const Iteration = () => {
             },
           };
         }}
-        slot={
-          <Select className="mb-4 w-52" value={status} onChange={(value: any) => setStatus(value)}>
-            {iterationOptions}
-          </Select>
-        }
       />
       <IterationModal visible={state.modalVisible} data={state.curDetail as ITERATION.Detail} onClose={handleClose} />
     </div>


### PR DESCRIPTION
## What this PR does / why we need it:
1. update filter to tab in iteration
2. display nickname by default on project home page

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
**before:**
![image](https://user-images.githubusercontent.com/30014895/148036103-c2766a0f-c752-406f-a08b-7acf1c6fa91c.png)

**current：**
![image](https://user-images.githubusercontent.com/30014895/148035983-9ae31351-ff6b-4cf9-8799-6d20ac984a15.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | update filter to tab in iteration |
| 🇨🇳 中文    | 迭代管理从 filter 改为 tab |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

