### PR TITLE
fix(common): table sorter dropdown menu display bug

### DIFF
--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -18,6 +18,7 @@
 
   .erda-table-sorter-overlay {
     width: 160px;
+    min-width: 160px !important;
 
     .ant-dropdown-menu-title-content > span {
       color: $color-table-color;

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -89,6 +89,8 @@ function WrappedTable<T extends object = any>({
     : (paginationProps as TablePaginationConfig);
   const { current = 1, pageSize = PAGINATION.pageSize } = pagination;
 
+  const containerRef = React.useRef(document.body);
+
   React.useEffect(() => {
     if (isFrontendPaging) {
       const newRowKeys =
@@ -204,7 +206,7 @@ function WrappedTable<T extends object = any>({
               overlay={sorterMenu({ ...args, title, sorter })}
               align={{ offset: [0, 5] }}
               overlayClassName="erda-table-sorter-overlay"
-              getPopupContainer={(triggerNode) => triggerNode.parentElement?.parentElement as HTMLElement}
+              getPopupContainer={() => containerRef.current as HTMLElement}
             >
               <span
                 className={`cursor-pointer erda-table-sorter flex items-center ${(align && alignMap[align]) || ''}`}
@@ -287,7 +289,7 @@ function WrappedTable<T extends object = any>({
   }
 
   return (
-    <div className={`flex flex-col erda-table ${hideHeader ? 'hide-header' : ''}`}>
+    <div className={`flex flex-col erda-table ${hideHeader ? 'hide-header' : ''}`} ref={containerRef}>
       {!hideHeader && (
         <TableConfig
           slot={slot}

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -89,7 +89,7 @@ function WrappedTable<T extends object = any>({
     : (paginationProps as TablePaginationConfig);
   const { current = 1, pageSize = PAGINATION.pageSize } = pagination;
 
-  const containerRef = React.useRef(document.body);
+  const containerRef = React.useRef<HTMLElement>(document.body);
 
   React.useEffect(() => {
     if (isFrontendPaging) {
@@ -206,7 +206,7 @@ function WrappedTable<T extends object = any>({
               overlay={sorterMenu({ ...args, title, sorter })}
               align={{ offset: [0, 5] }}
               overlayClassName="erda-table-sorter-overlay"
-              getPopupContainer={() => containerRef.current as HTMLElement}
+              getPopupContainer={() => containerRef.current}
             >
               <span
                 className={`cursor-pointer erda-table-sorter flex items-center ${(align && alignMap[align]) || ''}`}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix table sorter dropdown menu display bug

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/148063278-e8ed914b-ad49-48c6-9a06-8caadd3f7180.png)
->
![image](https://user-images.githubusercontent.com/82502479/148063156-d184f4ee-f42f-4009-9e86-a98619a5fb3b.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

