### PR TITLE
Fix: logo wrap height style

### DIFF
--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -121,6 +121,14 @@
   .erda-table-filter {
     min-height: 48px;
 
+    // TODO: remove this after update global input style
+    .ant-input-affix-wrapper,
+    input {
+      background-color: $color-bg-gray;
+      border: none;
+      border-radius: 2px;
+    }
+
     .ant-picker-range {
       input {
         background: none;

--- a/shell/app/layout/pages/page-container/components/navigation/index.scss
+++ b/shell/app/layout/pages/page-container/components/navigation/index.scss
@@ -5,7 +5,6 @@
   z-index: 10;
 
   .logo-wrap {
-    min-height: 32px;
     .erda-global-logo {
       transform: scale(1);
       transition: all 0.1s ease-in;

--- a/shell/app/layout/pages/page-container/components/navigation/index.scss
+++ b/shell/app/layout/pages/page-container/components/navigation/index.scss
@@ -5,6 +5,7 @@
   z-index: 10;
 
   .logo-wrap {
+    min-height: 32px;
     .erda-global-logo {
       transform: scale(1);
       transition: all 0.1s ease-in;

--- a/shell/app/layout/pages/page-container/components/navigation/index.tsx
+++ b/shell/app/layout/pages/page-container/components/navigation/index.tsx
@@ -117,7 +117,7 @@ const Navigation = () => {
 
   return (
     <div className={`erda-global-nav flex flex-col items-center relative`}>
-      <div className="logo-wrap relative w-8 h-8 m-3 cursor-pointer">
+      <div className="logo-wrap relative min-h-[32px] w-8 h-8 m-3 cursor-pointer">
         <ErdaIcon type="gerengongzuotai" size={32} className="absolute erda-global-logo" />
         <ErdaIcon
           type="gerengongzuotaihover"

--- a/shell/app/layout/pages/page-container/components/navigation/index.tsx
+++ b/shell/app/layout/pages/page-container/components/navigation/index.tsx
@@ -117,7 +117,7 @@ const Navigation = () => {
 
   return (
     <div className={`erda-global-nav flex flex-col items-center relative`}>
-      <div className="logo-wrap relative w-8 min-h-8 h-8 m-3 cursor-pointer">
+      <div className="logo-wrap relative w-8 h-8 m-3 cursor-pointer">
         <ErdaIcon type="gerengongzuotai" size={32} className="absolute erda-global-logo" />
         <ErdaIcon
           type="gerengongzuotaihover"


### PR DESCRIPTION
## What this PR does / why we need it:
revert table filter input style before update global input style.
min-h-8 not exist.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

