### PR TITLE
fix: with the same route, close message site when click navigation item

### DIFF
--- a/shell/app/layout/pages/page-container/components/navigation/index.tsx
+++ b/shell/app/layout/pages/page-container/components/navigation/index.tsx
@@ -124,7 +124,6 @@ const Navigation = () => {
           className="absolute workbench-icon"
           size={32}
           onClick={() => {
-            // with same the route, close message site
             layoutStore.reducers.switchMessageCenter(false);
             const isIncludeOrg = !!orgs.find((x) => x.name === curOrgName);
             if (isAdminRoute) {
@@ -152,7 +151,6 @@ const Navigation = () => {
             label={item.name}
             link={item.href}
             onClick={() => {
-              // with same the route, close message site
               layoutStore.reducers.switchMessageCenter(false);
               layoutStore.reducers.switchToApp(item.key);
             }}

--- a/shell/app/layout/pages/page-container/components/navigation/index.tsx
+++ b/shell/app/layout/pages/page-container/components/navigation/index.tsx
@@ -124,8 +124,8 @@ const Navigation = () => {
           className="absolute workbench-icon"
           size={32}
           onClick={() => {
-            // close message site
-            layoutStore.reducers.switchMessageCenter(null);
+            // with same the route, close message site
+            layoutStore.reducers.switchMessageCenter(false);
             const isIncludeOrg = !!orgs.find((x) => x.name === curOrgName);
             if (isAdminRoute) {
               const lastOrg = window.localStorage.getItem('lastOrg');
@@ -151,7 +151,11 @@ const Navigation = () => {
             key={item.key}
             label={item.name}
             link={item.href}
-            onClick={() => layoutStore.reducers.switchToApp(item.key)}
+            onClick={() => {
+              // with same the route, close message site
+              layoutStore.reducers.switchMessageCenter(false);
+              layoutStore.reducers.switchToApp(item.key);
+            }}
             icon={
               currentApp.key === item.key ? (
                 <ErdaIcon className="absolute icon active-icon opacity-100" size={24} type={item.icon} />


### PR DESCRIPTION
## What this PR does / why we need it:
with the same route, close message site when clicking navigation item

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【个人工作台】点击后会出现个人工作台和站内信的页面切换](https://erda.cloud/erda/dop/projects/387/issues/all?id=272273&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
