### PR TITLE
style: add edit button in markdown

### DIFF
--- a/shell/app/modules/project/pages/homepage/index.scss
+++ b/shell/app/modules/project/pages/homepage/index.scss
@@ -67,6 +67,13 @@
     }
   }
 
+  .markdown-edit-button {
+    right: 380px;
+    top: 228px;
+    box-shadow: 0 1px 4px 0 rgba(48, 38, 71, 0.16);
+    border-radius: 16px;
+  }
+
   .homepage-body {
     .homepage-info {
       width: 280px;

--- a/shell/app/modules/project/pages/homepage/index.scss
+++ b/shell/app/modules/project/pages/homepage/index.scss
@@ -68,6 +68,10 @@
   }
 
   .read-only-markdown {
+    .markdown-edit-button {
+      display: none;
+    }
+
     &:hover {
       .markdown-edit-button {
         display: flex;

--- a/shell/app/modules/project/pages/homepage/index.scss
+++ b/shell/app/modules/project/pages/homepage/index.scss
@@ -70,17 +70,14 @@
   .read-only-markdown {
     .markdown-edit-button {
       display: none;
+      right: 380px;
+      top: 228px;
+      z-index: 2;
     }
 
     &:hover {
       .markdown-edit-button {
         display: flex;
-        justify-content: center;
-        align-items: center;
-        right: 380px;
-        top: 228px;
-        box-shadow: 0 1px 4px 0 rgba(48, 38, 71, 0.16);
-        border-radius: 16px;
       }
     }
   }

--- a/shell/app/modules/project/pages/homepage/index.scss
+++ b/shell/app/modules/project/pages/homepage/index.scss
@@ -67,11 +67,18 @@
     }
   }
 
-  .markdown-edit-button {
-    right: 380px;
-    top: 228px;
-    box-shadow: 0 1px 4px 0 rgba(48, 38, 71, 0.16);
-    border-radius: 16px;
+  .read-only-markdown {
+    &:hover {
+      .markdown-edit-button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        right: 380px;
+        top: 228px;
+        box-shadow: 0 1px 4px 0 rgba(48, 38, 71, 0.16);
+        border-radius: 16px;
+      }
+    }
   }
 
   .homepage-body {

--- a/shell/app/modules/project/pages/homepage/readme-markdown.tsx
+++ b/shell/app/modules/project/pages/homepage/readme-markdown.tsx
@@ -83,7 +83,12 @@ export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValu
       <div className="overflow-hidden" style={{ maxHeight: 'inherit' }}>
         <div ref={mdContentRef} className="md-content">
           <Tooltip title={i18n.t('dop:click to edit')}>
-            <div className={'markdown-edit-button h-8 w-8 fixed bg-white'} onClick={() => updater.isEditing(true)}>
+            <div
+              className={
+                'markdown-edit-button h-8 w-8 fixed bg-white rounded-2xl shadow-card justify-center items-center'
+              }
+              onClick={() => updater.isEditing(true)}
+            >
               <ErdaIcon type="edit" size={16} className="text-default-4 hover:text-default-8" />
             </div>
           </Tooltip>

--- a/shell/app/modules/project/pages/homepage/readme-markdown.tsx
+++ b/shell/app/modules/project/pages/homepage/readme-markdown.tsx
@@ -32,15 +32,12 @@ interface IMdProps {
 const { ScalableImage } = EditField;
 
 export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValue, maxHeight }: IMdProps) => {
-  const [{ v, expanded, expandBtnVisible, isEditing, isHover }, updater, update] = useUpdate({
+  const [{ v, expanded, expandBtnVisible, isEditing }, updater, update] = useUpdate({
     v: value,
     expanded: false,
     isEditing: false,
     expandBtnVisible: false,
-    isHover: false,
   });
-  const onHover = () => updater.isHover(true);
-  const outHover = () => updater.isHover(false);
   const mdContentRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -80,18 +77,13 @@ export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValu
     />
   ) : (
     <div
-      className="relative cursor-pointer rounded w-full"
+      className="relative cursor-pointer rounded w-full read-only-markdown"
       style={{ maxHeight: expanded ? '' : maxHeight }}
-      onMouseEnter={onHover}
-      onMouseLeave={outHover}
     >
       <div className="overflow-hidden" style={{ maxHeight: 'inherit' }}>
         <div ref={mdContentRef} className="md-content">
           <Tooltip title={i18n.t('dop:click to edit')}>
-            <div
-              className={`markdown-edit-button h-8 w-8 fixed bg-white ${isHover ? 'flex-all-center' : 'hidden'}`}
-              onClick={() => updater.isEditing(true)}
-            >
+            <div className={'markdown-edit-button h-8 w-8 fixed bg-white'} onClick={() => updater.isEditing(true)}>
               <ErdaIcon type="edit" size={16} className="text-default-4 hover:text-default-8" />
             </div>
           </Tooltip>

--- a/shell/app/modules/project/pages/homepage/readme-markdown.tsx
+++ b/shell/app/modules/project/pages/homepage/readme-markdown.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import i18n from 'core/i18n';
 import { Tooltip } from 'antd';
-import { MarkdownEditor, EditField } from 'common';
+import { MarkdownEditor, EditField, ErdaIcon } from 'common';
 import remarkGfm from 'remark-gfm';
 import { useUpdate } from 'common/use-hooks';
 import ReactMarkdown from 'react-markdown';
@@ -32,13 +32,15 @@ interface IMdProps {
 const { ScalableImage } = EditField;
 
 export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValue, maxHeight }: IMdProps) => {
-  const [{ v, expanded, expandBtnVisible, isEditing }, updater, update] = useUpdate({
+  const [{ v, expanded, expandBtnVisible, isEditing, isHover }, updater, update] = useUpdate({
     v: value,
     expanded: false,
     isEditing: false,
     expandBtnVisible: false,
+    isHover: false,
   });
-
+  const onHover = () => updater.isHover(true);
+  const outHover = () => updater.isHover(false);
   const mdContentRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -79,11 +81,20 @@ export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValu
   ) : (
     <div
       className="relative cursor-pointer rounded w-full"
-      onClick={() => updater.isEditing(true)}
       style={{ maxHeight: expanded ? '' : maxHeight }}
+      onMouseEnter={onHover}
+      onMouseLeave={outHover}
     >
       <div className="overflow-hidden" style={{ maxHeight: 'inherit' }}>
         <div ref={mdContentRef} className="md-content">
+          <Tooltip title={i18n.t('dop:click to edit')}>
+            <div
+              className={`markdown-edit-button h-8 w-8 fixed bg-white ${isHover ? 'flex-all-center' : 'hidden'}`}
+              onClick={() => updater.isEditing(true)}
+            >
+              <ErdaIcon type="edit" size={16} className="text-default-4 hover:text-default-8" />
+            </div>
+          </Tooltip>
           <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ img: ScalableImage }}>
             {value || i18n.t('no description yet')}
           </ReactMarkdown>


### PR DESCRIPTION
## What this PR does / why we need it:
add edit button in markdown

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/30014895/148339368-64b537b0-7ea4-4127-8d24-db1598179e2e.png)
![image](https://user-images.githubusercontent.com/30014895/148339821-0f104b7b-228c-411b-bfda-259b43c316a8.png)




## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | add edit button in markdown in project home page|
| 🇨🇳 中文    | 在项目首页中为 markdown 增加编辑按钮 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

