### PR TITLE
feat: update personal contribute item background color

### DIFF
--- a/shell/app/config-page/components/card/card.scss
+++ b/shell/app/config-page/components/card/card.scss
@@ -29,7 +29,7 @@
   .cp-card-item {
     position: relative;
     overflow: hidden;
-    border: 1px solid $color-border;
+    outline: 1px solid $color-border;
     &::after {
       content: '';
       position: absolute;
@@ -40,6 +40,7 @@
       background-color: $color-cyan-600;
     }
     &:hover {
+      outline: none;
       box-shadow: 0 2px 8px 0 rgba($color-default, 0.16);
       &::after {
         animation: border 0.1s ease-in-out forwards;

--- a/shell/app/modules/application/common/app-selector.tsx
+++ b/shell/app/modules/application/common/app-selector.tsx
@@ -32,11 +32,7 @@ interface IProps {
 }
 
 const AppItem = (app: IApplication) => {
-  return (
-    <Tooltip key={app.id} title={app.name}>
-      {app.displayName || app.name}
-    </Tooltip>
-  );
+  return app.displayName || app.name;
 };
 
 interface IChosenItem {

--- a/shell/app/modules/project/common/components/project-selector.tsx
+++ b/shell/app/modules/project/common/components/project-selector.tsx
@@ -29,13 +29,8 @@ interface IProps {
 }
 
 const ProjectItem = (project: PROJECT.Detail) => {
-  return (
-    <Tooltip key={project.id} title={project.name}>
-      {project.displayName || project.name}
-    </Tooltip>
-  );
+  return project.displayName || project.name;
 };
-const noop = () => {};
 
 export const ProjectSelector = (props: IProps) => {
   const getData = (_q: any = {}) => {

--- a/shell/app/org-home/pages/personal-contribute/index.tsx
+++ b/shell/app/org-home/pages/personal-contribute/index.tsx
@@ -102,7 +102,7 @@ const PersonalContribute = ({ currentUser }: { currentUser: ILoginUser }) => {
               <div
                 key={key}
                 className="w-52 px-4 py-3 relative"
-                style={{ backgroundColor: colorToRgb(themeColor[color], 0.04) }}
+                style={{ backgroundColor: colorToRgb(themeColor[color], 0.1) }}
               >
                 <div
                   className="absolute top-0 right-0 bg-icon-wrapper flex justify-center items-center"


### PR DESCRIPTION
## What this PR does / why we need it:
* update personal contribute item bg color
* remove project and app selector tooltip

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/148354631-d02d066c-d300-489b-8a12-73baa7c797a2.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | update personal contribute card background color |
| 🇨🇳 中文    |  调整个人贡献卡片背景色   |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

