### PR TITLE
fix(dop): resources table sort bug

### DIFF
--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -156,13 +156,23 @@ function WrappedTable<T extends object = any>({
 
       const onSort = (order?: 'ascend' | 'descend') => {
         setSort({ ...sorter, order });
-        const { sorter: columnSorter } = column as { sorter: { compare: (a: T, b: T) => number } };
+        const { sorter: columnSorter } = column as {
+          sorter: { compare: (a: T, b: T) => number } | ((a: T, b: T) => number);
+        };
         if (order && columnSorter?.compare) {
           sortCompareRef.current = (a: T, b: T) => {
             if (order === 'ascend') {
               return columnSorter?.compare?.(a, b);
             } else {
               return columnSorter?.compare?.(b, a);
+            }
+          };
+        } else if (order && typeof columnSorter === 'function') {
+          sortCompareRef.current = (a: T, b: T) => {
+            if (order === 'ascend') {
+              return columnSorter?.(a, b);
+            } else {
+              return columnSorter?.(b, a);
             }
           };
         } else {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix resources table sort bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix resources table invalid sorting bug.   |
| 🇨🇳 中文    |  修复了资源汇总列表的排序无效问题。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=272844&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

