### PR TITLE
fix: remove input border under contractive filter

### DIFF
--- a/shell/app/common/components/contractive-filter/index.scss
+++ b/shell/app/common/components/contractive-filter/index.scss
@@ -72,6 +72,12 @@
     }
   }
 
+  // TODO: remove after overwrite global input style
+  .ant-input-affix-wrapper {
+    border: none;
+    margin-left: 2px;
+  }
+
   .contractive-filter-item-close {
     position: absolute;
     top: -6px;


### PR DESCRIPTION
## What this PR does / why we need it:
fix input border

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  remove input border under contractive filter |
| 🇨🇳 中文    | 移除筛选器下的输入框边框 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

