### PR TITLE
fix: update full screen markdown style in project home

### DIFF
--- a/shell/app/common/components/markdown-editor/editor.scss
+++ b/shell/app/common/components/markdown-editor/editor.scss
@@ -1,16 +1,18 @@
 .md-content {
+  font-family: 'Avenir-Book';
   padding: 8px;
   font-size: 14px;
-  line-height: 1.6;
+  color: $color-default;
   word-break: break-word;
 
   a {
-    color: #424CA6;
+    color: #424ca6;
     text-decoration: underline;
   }
 
   p {
     white-space: normal !important;
+    line-height: 22px;
   }
 
   > *:first-child {
@@ -58,7 +60,7 @@
   h5 .mini-icon-link,
   h6 .mini-icon-link {
     display: none;
-    color: #000000;
+    color: $color-default;
   }
 
   h1:hover a.anchor,
@@ -122,7 +124,7 @@
   }
 
   h6 {
-    color: #777777;
+    color: $color-default-8;
     font-size: 14px;
   }
 
@@ -139,7 +141,7 @@
   hr {
     height: 4px;
     padding: 0;
-    color: #cccccc;
+    color: $color-default;
     border: 0 none;
   }
 

--- a/shell/app/common/components/markdown-editor/editor.scss
+++ b/shell/app/common/components/markdown-editor/editor.scss
@@ -5,7 +5,8 @@
   word-break: break-word;
 
   a {
-    color: $color-purple-highlight;
+    color: #424CA6;
+    text-decoration: underline;
   }
 
   p {
@@ -41,7 +42,9 @@
   h4,
   h5,
   h6 {
+    font-family: 'Avenir-Heavy';
     position: relative;
+    color: $color-default;
     margin: 20px 0 10px;
     padding: 0;
     font-weight: bold;
@@ -96,17 +99,18 @@
   }
 
   h1 {
-    color: #000000;
-    font-size: 28px;
+    font-size: 24px;
+    line-height: 32px;
   }
 
   h2 {
-    color: #000000;
-    font-size: 24px;
+    font-size: 20px;
+    line-height: 28px;
   }
 
   h3 {
-    font-size: 18px;
+    font-size: 16px;
+    line-height: 24px;
   }
 
   h4 {

--- a/shell/app/common/components/markdown-editor/index.scss
+++ b/shell/app/common/components/markdown-editor/index.scss
@@ -1,4 +1,6 @@
 .markdown-editor {
+  outline: none;
+
   .markdown-editor-content {
     display: block;
     .rc-md-editor {
@@ -40,6 +42,10 @@
     &.show-btn {
       .rc-md-editor {
         padding-bottom: 42px;
+      }
+
+      .full-screen-btn {
+        z-index: 9999;
       }
     }
 

--- a/shell/app/common/components/markdown-editor/index.tsx
+++ b/shell/app/common/components/markdown-editor/index.tsx
@@ -90,7 +90,7 @@ const MarkdownEditor: React.ForwardRefRenderFunction<EC_MarkdownEditor, IProps> 
   });
 
   React.useEffect(() => {
-    mdEditorRef?.current?.on('fullscreen', (isFullScreen: boolean) => {
+    mdEditorRef.current?.on('fullscreen', (isFullScreen: boolean) => {
       updater.fullscreen(isFullScreen);
     });
   }, []);

--- a/shell/app/common/components/markdown-editor/index.tsx
+++ b/shell/app/common/components/markdown-editor/index.tsx
@@ -50,6 +50,7 @@ interface IState {
     html: boolean;
     menu: boolean;
   };
+  fullscreen: boolean;
 }
 
 export interface EC_MarkdownEditor {
@@ -77,7 +78,7 @@ const MarkdownEditor: React.ForwardRefRenderFunction<EC_MarkdownEditor, IProps> 
 ) => {
   const mdEditorRef = React.useRef<any>(null); // TODO ts type should export from @erda-ui/react-markdown-editor-lite
 
-  const [{ content, view, tempContent }, updater] = useUpdate<IState>({
+  const [{ content, view, tempContent, fullscreen }, updater] = useUpdate<IState>({
     content: value || '',
     tempContent: value || '',
     view: {
@@ -85,7 +86,14 @@ const MarkdownEditor: React.ForwardRefRenderFunction<EC_MarkdownEditor, IProps> 
       html: defaultMode === 'html',
       menu: showMenu,
     },
+    fullscreen: false,
   });
+
+  React.useEffect(() => {
+    mdEditorRef?.current?.on('fullscreen', (isFullScreen: boolean) => {
+      updater.fullscreen(isFullScreen);
+    });
+  }, []);
 
   useMount(() => {
     setTimeout(() => {
@@ -135,8 +143,18 @@ const MarkdownEditor: React.ForwardRefRenderFunction<EC_MarkdownEditor, IProps> 
   // const height: string | number = style.height ? parseInt(style.height, 10) : 400;
   // height = view.menu ? (view.md && curShowButton ? height + 50 : height) : 'auto';
 
+  const btnCls = fullscreen ? 'fixed full-screen-btn' : 'absolute';
+
   return (
-    <div className="markdown-editor relative">
+    <div
+      className="markdown-editor relative"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          mdEditorRef.current?.fullScreen(false);
+        }
+      }}
+    >
       <div
         className={`markdown-editor-content flex flex-col ${disableEdit ? 'disable-edit' : ''} ${
           readOnly ? 'read-only' : ''
@@ -159,7 +177,7 @@ const MarkdownEditor: React.ForwardRefRenderFunction<EC_MarkdownEditor, IProps> 
           onChange={onChangeContent}
           onBlur={() => onBlur?.(content)}
         />
-        <div className="absolute left-2 flex bottom-2 space-x-2">
+        <div className={`${btnCls} left-2 flex bottom-2 space-x-2`}>
           {map(operationBtns, (operationBtn, i) => {
             const { text, type, className = '', onClick } = operationBtn;
             return (

--- a/shell/app/modules/project/pages/homepage/index.scss
+++ b/shell/app/modules/project/pages/homepage/index.scss
@@ -98,6 +98,12 @@
       .info-brief {
         line-height: 22px;
       }
+
+      .homepage-link {
+        span {
+          color: #424CA6,
+        }
+      }
     }
   }
   .markdown-editor .markdown-editor-content .rc-md-editor .editor-container {

--- a/shell/app/modules/project/pages/homepage/index.scss
+++ b/shell/app/modules/project/pages/homepage/index.scss
@@ -106,13 +106,14 @@
 
   .rc-md-editor {
     border: 0;
-    background: rgba($color-default, 0.04);
+    background: $white;
   }
 
   .rc-md-navigation {
     background: transparent;
     border-bottom: rgba($color-default, 0.08);
     box-shadow: 0 2px 1px 0 rgba($color-default, 0.08);
+    z-index: 9999;
   }
 
   .markdown-editor .markdown-editor-content .rc-md-editor .editor-container .sec-md .input {
@@ -138,7 +139,6 @@
   .markdown-editor-content {
     &.show-btn {
       .rc-md-editor {
-        background: $color-default-04;
         padding-bottom: 48px;
       }
     }

--- a/shell/app/modules/project/pages/homepage/index.tsx
+++ b/shell/app/modules/project/pages/homepage/index.tsx
@@ -62,10 +62,10 @@ const LinkRow = (props: LinkRowProps) => {
     <div key={item.id} ref={linkRef} className="cursor-pointer flex items-center homepage-link mb-1">
       <ErdaIcon type="lianjie" {...iconStyle} />
       <div className="cursor-pointer ml-2 w-64 px-2 py-1 flex justify-between items-center hover:bg-default-04">
-        <div className="w-52 truncate text-purple-deep">
+        <div className="w-52 truncate">
           <Tooltip title={item.name || item.url} placement="left" overlayClassName="homepage-tooltip">
             <span
-              className="text-link hover:underline"
+              className="hover:underline"
               onClick={() => {
                 if (item.url.startsWith('www')) {
                   window.open(`https://${item.url}`);

--- a/shell/app/modules/project/pages/homepage/index.tsx
+++ b/shell/app/modules/project/pages/homepage/index.tsx
@@ -65,7 +65,7 @@ const LinkRow = (props: LinkRowProps) => {
         <div className="w-52 truncate text-purple-deep">
           <Tooltip title={item.name || item.url} placement="left" overlayClassName="homepage-tooltip">
             <span
-              className="text-purple-deep hover:underline"
+              className="text-link hover:underline"
               onClick={() => {
                 if (item.url.startsWith('www')) {
                   window.open(`https://${item.url}`);

--- a/shell/app/modules/project/pages/homepage/readme-markdown.tsx
+++ b/shell/app/modules/project/pages/homepage/readme-markdown.tsx
@@ -38,7 +38,6 @@ export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValu
     isEditing: false,
     expandBtnVisible: false,
   });
-  const mdContentRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     updater.v(value);
@@ -81,7 +80,7 @@ export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValu
       style={{ maxHeight: expanded ? '' : maxHeight }}
     >
       <div className="overflow-hidden" style={{ maxHeight: 'inherit' }}>
-        <div ref={mdContentRef} className="md-content">
+        <div className="md-content">
           <Tooltip title={i18n.t('dop:click to edit')}>
             <div
               className={
@@ -92,7 +91,7 @@ export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValu
               <ErdaIcon type="edit" size={16} className="text-default-4 hover:text-default-8" />
             </div>
           </Tooltip>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ img: ScalableImage }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ img: ScalableImage }} linkTarget='_blank'>
             {value || i18n.t('no description yet')}
           </ReactMarkdown>
           <div

--- a/shell/theme-color.js
+++ b/shell/theme-color.js
@@ -144,6 +144,4 @@ module.exports = {
   'yellow-green-deep': '#C9C400',
   'yellow-green-mid': '#ECE97D',
   'yellow-green-light': '#FAF9DC',
-
-  link: '#424CA6',
 };

--- a/shell/theme-color.js
+++ b/shell/theme-color.js
@@ -144,4 +144,6 @@ module.exports = {
   'yellow-green-deep': '#C9C400',
   'yellow-green-mid': '#ECE97D',
   'yellow-green-light': '#FAF9DC',
+
+  link: '#424CA6',
 };


### PR DESCRIPTION
## What this PR does / why we need it:
1. fix full-screen markdown style in project home
2. update link style in markdown

![image](https://user-images.githubusercontent.com/30014895/148521001-cf6b47af-c4ce-4679-8681-aabfad10161f.png)
![image](https://user-images.githubusercontent.com/30014895/148521226-d6cc2106-2f4d-41fc-bb49-0327b7354d52.png)


## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | update style of markdown in project home page |
| 🇨🇳 中文    | 更改项目首页 markdown 样式  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[项目主页编辑点击全屏异常](https://dice.app.terminus.io/erda/dop/projects/387/issues/all?id=272953&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
