### PR TITLE
fix(common): fdp display on menu according to environment

### DIFF
--- a/shell/app/menus/appCenter.tsx
+++ b/shell/app/menus/appCenter.tsx
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import { goTo } from 'common/utils';
+import { goTo, insertWhen } from 'common/utils';
 import i18n from 'i18n';
 import { filterMenu, MENU_SCOPE } from './util';
 
@@ -57,13 +57,15 @@ export const appList: () => LAYOUT.IApp[] = () =>
         breadcrumbName: i18n.t('Cloud management'),
         href: goTo.resolve.cmpRoot(),
       },
-      {
-        key: 'fdp',
-        icon: 'FDP-entry',
-        name: i18n.t('Fast data'),
-        breadcrumbName: i18n.t('Fast data'),
-        href: goTo.resolve.dataAppEntry(),
-      },
+      ...insertWhen(!process.env.FOR_COMMUNITY, [
+        {
+          key: 'fdp',
+          icon: 'FDP-entry',
+          name: i18n.t('Fast data'),
+          breadcrumbName: i18n.t('Fast data'),
+          href: goTo.resolve.dataAppEntry(),
+        },
+      ]),
       {
         key: 'ecp',
         icon: 'ECP-entry',

--- a/shell/app/org-home/pages/personal-home.tsx
+++ b/shell/app/org-home/pages/personal-home.tsx
@@ -59,7 +59,7 @@ const PurePersonalHome = ({ orgName }: { orgName: string }) => {
       orgCenter: permMap.entryOrgCenter.pass,
       cmp: permMap.cmp.showApp.pass,
       dop: permMap.dop.read.pass,
-      fdp: permMap.entryFastData.pass && currentOrg.openFdp,
+      fdp: permMap.entryFastData.pass && currentOrg.openFdp && !process.env.FOR_COMMUNITY,
       msp: permMap.entryMsp.pass,
       ecp: erdaEnv.ENABLE_EDGE === 'true' && permMap.ecp.view.pass && currentOrg.type === 'ENTERPRISE',
     }),


### PR DESCRIPTION
## What this PR does / why we need it:
Fdp display on menu according to environment

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  ...  |
| 🇨🇳 中文    |   。。。   |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

