### PR TITLE
feat: api version list use new table

### DIFF
--- a/shell/app/modules/apiManagePlatform/pages/api-market/detail/components/api-body/index.tsx
+++ b/shell/app/modules/apiManagePlatform/pages/api-market/detail/components/api-body/index.tsx
@@ -12,8 +12,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Radio, Select, Input, Button, message } from 'antd';
-import { map, isString } from 'lodash';
+import { Button, Input, message, Radio, Select } from 'antd';
+import { isString, map } from 'lodash';
 import KeyValueEdit from 'apiManagePlatform/pages/api-market/detail/components/key-val-edit';
 import { FileEditor } from 'common';
 import i18n from 'i18n';
@@ -102,7 +102,7 @@ const TestJsonEditor = (props: any) => {
           setContent(formatJSON(content));
         }}
       >
-        格式化
+        {i18n.t('format')}
       </Button>
       <FileEditor
         fileExtension="json"

--- a/shell/app/modules/apiManagePlatform/pages/api-market/detail/index.tsx
+++ b/shell/app/modules/apiManagePlatform/pages/api-market/detail/index.tsx
@@ -178,7 +178,6 @@ const ApiAssetDetail = () => {
           rowKey={({ version: { major, minor, patch } }) => `${major}-${minor}-${patch}`}
           columns={columns}
           dataSource={assetVersionList}
-          pagination={false}
           onChange={() => {
             getListOfVersions({ major: version.major, minor: version.minor, spec: false, assetID });
           }}


### PR DESCRIPTION
## What this PR does / why we need it:

api version list uses a new table

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | - |
| 🇨🇳 中文    | - |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

