### PR TITLE
fix(dop): project release upload file type change

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -372,10 +372,13 @@ const progressStatusMap = {
 const CustomUpload = ({ form, onChange }: { form: { form: FormInstance }; onChange: (value?: string) => void }) => {
   const [fileList, setFileList] = React.useState<UploadFile[]>([]);
 
+  const fileType = 'application/zip';
+
   const props: UploadProps = {
     fileList,
+    accept: '.zip',
     beforeUpload: (file) => {
-      if (file.type !== 'application/x-tar') {
+      if (file.type !== fileType) {
         onChange('type-error');
         return false;
       }
@@ -383,7 +386,7 @@ const CustomUpload = ({ form, onChange }: { form: { form: FormInstance }; onChan
       return true;
     },
     onChange: async ({ file }) => {
-      if (file.type !== 'application/x-tar') {
+      if (file.type !== fileType) {
         setFileList([{ ...file, status: 'error', percent: 100, name: file.name }]);
       } else {
         setFileList([file]);


### PR DESCRIPTION
## What this PR does / why we need it:
Project release upload file type change.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The type of files uploaded by project level artifacts has changed. |
| 🇨🇳 中文    | 项目级制品上传文件的类型改变。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

