### PR TITLE
fix(dop): project release create release by upload file remove changelog

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -17,7 +17,7 @@ import moment from 'moment';
 import { RenderForm, ListSelect, MarkdownEditor, ErdaIcon } from 'common';
 import i18n from 'i18n';
 import { PAGINATION } from 'app/constants';
-import { goTo } from 'common/utils';
+import { goTo, insertWhen } from 'common/utils';
 import { getUploadProps } from 'common/utils/upload-props';
 import releaseStore from 'project/stores/release';
 import routeInfoStore from 'core/stores/route';
@@ -290,15 +290,17 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
             },
           ],
         },
-    {
-      label: i18n.t('content'),
-      name: 'changelog',
-      type: 'custom',
-      getComp: () => <EditMd />,
-      readOnlyRender: (value: string) => {
-        return <MarkdownReadOnlyRender value={value} />;
+    ...insertWhen(type === 'app', [
+      {
+        label: i18n.t('content'),
+        name: 'changelog',
+        type: 'custom',
+        getComp: () => <EditMd />,
+        readOnlyRender: (value: string) => {
+          return <MarkdownReadOnlyRender value={value} />;
+        },
       },
-    },
+    ]),
   ];
 
   const submit = () => {
@@ -338,10 +340,12 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
   };
 
   return (
-    <div className="release-form">
-      <Spin spinning={loading}>
-        <RenderForm ref={formRef} layout="vertical" list={list} readOnly={readyOnly} />
-      </Spin>
+    <div className="release-form h-full flex flex-col">
+      <div className="flex-1">
+        <Spin spinning={loading}>
+          <RenderForm ref={formRef} layout="vertical" list={list} readOnly={readyOnly} />
+        </Spin>
+      </div>
 
       {!readyOnly ? (
         <div className="mb-2">

--- a/shell/app/modules/project/router.tsx
+++ b/shell/app/modules/project/router.tsx
@@ -421,11 +421,13 @@ function getProjectRouter(): RouteConfigItem[] {
               path: 'createRelease/:type',
               pageName: i18n.t('create {name}', { name: i18n.t('Artifact') }),
               getComp: (cb) => cb(import('project/pages/release/components/form')),
+              layout: { fullHeight: true },
             },
             {
               path: 'updateRelease/:releaseID',
               pageName: i18n.t('edit {name}', { name: i18n.t('Artifact') }),
               getComp: (cb) => cb(import('project/pages/release/components/update')),
+              layout: { fullHeight: true },
             },
           ],
         },


### PR DESCRIPTION
## What this PR does / why we need it:
project release create release by upload file remove changelog.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/148894972-a45f7294-dc73-45ad-a5b3-03ae9560340a.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  In file creation artifacts, the form item is removed from the description.   |
| 🇨🇳 中文    | 通过文件创建制品中，表单项去掉描述。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

