### PR TITLE
fix(dop): project release applications list pageSize bug

### DIFF
--- a/shell/app/modules/project/stores/release.ts
+++ b/shell/app/modules/project/stores/release.ts
@@ -27,7 +27,7 @@ const releaseStore = createStore({
   state: initState,
   effects: {
     async getAppList({ call, update }, payload: { projectId: string; q?: string }) {
-      const res = await call(getAppList, payload);
+      const res = await call(getAppList, { ...payload, pageSize: 1000 });
       const { list } = res;
       update({ appList: list.map((item) => ({ ...item, title: item.displayName })) });
     },


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project release applications list pageSize bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a bug where the app list for artifact management would only display 20 entries by default. |
| 🇨🇳 中文    |  修复了制品管理的应用列表默认只显示20条数据的bug。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.1

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

