### PR TITLE
fix: fix project deploy table page no error

### DIFF
--- a/shell/app/modules/project/pages/deploy/add-deploy/add-release.tsx
+++ b/shell/app/modules/project/pages/deploy/add-deploy/add-release.tsx
@@ -129,7 +129,7 @@ const ProjectRelease = (props: IReleaseProps) => {
   const [searchValue, setSearchValue] = React.useState('');
   const [selectedRelease, setSelectedRelease] = React.useState('');
   const getReleaseList = (q?: IReleaseQuery) => {
-    getList({ q: searchValue, pageNo: 1, ...q });
+    getList({ isProjectRelease: true, q: searchValue, pageNo: 1, ...q });
   };
 
   React.useEffect(() => {
@@ -186,7 +186,13 @@ const AppRelease = (props: IReleaseProps) => {
   const [selectedApp, setSelectedApp] = React.useState<IApplication | null>(null);
   const getReleaseList = (q?: IReleaseQuery) => {
     selectedAppRef.current &&
-      getList({ q: searchValue, pageNo: 1, applicationId: `${selectedAppRef.current.id}`, ...q });
+      getList({
+        isProjectRelease: false,
+        q: searchValue,
+        pageNo: 1,
+        applicationId: `${selectedAppRef.current.id}`,
+        ...q,
+      });
   };
 
   const debouncedChange = React.useRef(debounce(getReleaseList, 1000));

--- a/shell/app/modules/project/pages/deploy/add-deploy/index.tsx
+++ b/shell/app/modules/project/pages/deploy/add-deploy/index.tsx
@@ -136,6 +136,7 @@ const AddDeploy = ({ onSelect: propsOnSelect }: { onSelect: (v: string) => void 
             </div>
             <ErdaTable
               hideHeader
+              rowKey="id"
               dataSource={(selectedApp?.params || []).filter((item) =>
                 selectedType === ConfigTabs.text.key
                   ? item.type === ConfigTypeMap.kv.key

--- a/shell/app/modules/project/pages/deploy/deploy-config/index.tsx
+++ b/shell/app/modules/project/pages/deploy/deploy-config/index.tsx
@@ -293,7 +293,7 @@ const OtherConfig = (props: IOtherProps) => {
         />
       </div>
       <div className="relative">
-        <ErdaTable hideHeader columns={columns} dataSource={useData} actions={actions} />
+        <ErdaTable hideHeader rowKey="key" columns={columns} dataSource={useData} actions={actions} />
         <Button className="absolute bottom-3" onClick={() => setAddVisible(true)}>
           {i18n.t('common:add')}
         </Button>

--- a/shell/app/modules/project/pages/deploy/deploy-config/list-edit.tsx
+++ b/shell/app/modules/project/pages/deploy/deploy-config/list-edit.tsx
@@ -212,6 +212,7 @@ const ListEditConfig = (props: IProps) => {
           <ErdaTable
             columns={mergedColumns}
             dataSource={filterValue}
+            rowKey="key"
             hideHeader
             onRow={(record) => ({
               onClick: () => {

--- a/shell/app/modules/project/pages/deploy/deploy-detail/index.tsx
+++ b/shell/app/modules/project/pages/deploy/deploy-detail/index.tsx
@@ -253,7 +253,7 @@ const Params = ({ data }: ISubProps) => {
         : [];
     },
   };
-  return <ErdaTable hideHeader dataSource={data?.params || []} columns={columns} actions={actions} />;
+  return <ErdaTable hideHeader rowKey="key" dataSource={data?.params || []} columns={columns} actions={actions} />;
 };
 
 const Log = ({ data }: ISubProps) => {


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix project deploy table page no error

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: fix project deploy table page no error             |
| 🇨🇳 中文    |   fix: 修复项目部署中心页码错误           |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

