### PR TITLE
fix(common): pagination btn hover style bug

### DIFF
--- a/shell/app/common/components/pagination/index.scss
+++ b/shell/app/common/components/pagination/index.scss
@@ -1,10 +1,13 @@
 .erda-pagination {
-  padding: 10px 0.5rem;
+  padding: 12px 0.5rem;
   line-height: 24px;
   color: $color-table-color;
 
-  .pagination-center {
-    line-height: 36px;
+  .pagination-center,
+  .pagination-pre,
+  .pagination-next {
+    height: 32px;
+    line-height: 32px;
   }
 
   .bg-hover:not(.disabled) {

--- a/shell/app/common/components/pagination/index.tsx
+++ b/shell/app/common/components/pagination/index.tsx
@@ -53,63 +53,66 @@ const Pagination = (pagination: IPaginationProps) => {
 
   const [goToVisible, setGoToVisible] = React.useState(false);
 
-  const paginationCenterRender = (
-    <Popover
-      content={<PaginationJump pagination={pagination} hidePopover={() => setGoToVisible(false)} />}
-      trigger="click"
-      getPopupContainer={(triggerNode) => triggerNode.parentElement as HTMLElement}
-      placement="top"
-      overlayClassName="pagination-jump"
-      visible={goToVisible}
-      onVisibleChange={setGoToVisible}
-    >
-      <div className="pagination-center bg-hover px-3 rounded cursor-pointer" onClick={() => setGoToVisible(true)}>
-        {total ? pagination.current : 0} / {(total && pageSize && Math.ceil(total / pageSize)) || 0}
-      </div>
-    </Popover>
-  );
-
-  const pageSizeMenu = (
-    <Menu>
-      {PAGINATION.pageSizeOptions.map((item: string | number) => {
-        return (
-          <Menu.Item key={item} onClick={() => onChange?.(1, +item)}>
-            <span className="fake-link mr-1">{i18n.t('{size} items / page', { size: item })}</span>
-          </Menu.Item>
-        );
-      })}
-    </Menu>
-  );
-
   return (
     <div className={`erda-pagination flex justify-end items-center relative theme-${theme}`}>
       <div className="erda-pagination-total mr-2">{i18n.t('total {total} items', { total })}</div>
       <div className="erda-pagination-content inline-flex">
         <div
-          className={`bg-hover p-2 leading-none ${current === 1 ? 'disabled' : 'cursor-pointer'}`}
+          className={`bg-hover p-2 leading-none hover:bg-default-06 pagination-pre ${
+            current === 1 ? 'disabled' : 'cursor-pointer'
+          }`}
           onClick={() => current > 1 && onChange?.(current - 1, pageSize)}
         >
-          <ErdaIcon type="left" size={18} color="currentColor" />
+          <ErdaIcon type="left" size={18} />
         </div>
-        {paginationCenterRender}
+
+        <Popover
+          content={<PaginationJump pagination={pagination} hidePopover={() => setGoToVisible(false)} />}
+          trigger="click"
+          getPopupContainer={(triggerNode) => triggerNode.parentElement as HTMLElement}
+          placement="top"
+          overlayClassName="pagination-jump"
+          visible={goToVisible}
+          onVisibleChange={setGoToVisible}
+        >
+          <div
+            className="pagination-center bg-hover hover:bg-default-06 px-3 rounded cursor-pointer"
+            onClick={() => setGoToVisible(true)}
+          >
+            {total ? pagination.current : 0} / {(total && pageSize && Math.ceil(total / pageSize)) || 0}
+          </div>
+        </Popover>
+
         <div
-          className={`bg-hover p-2 leading-none ${
+          className={`bg-hover p-2 leading-none hover:bg-default-06 pagination-next ${
             current === Math.ceil(total / pageSize) ? 'disabled' : 'cursor-pointer'
           }`}
           onClick={() => total && current < Math.ceil(total / pageSize) && onChange?.(current + 1, pageSize)}
         >
-          <ErdaIcon type="right" size={18} color="currentColor" />
+          <ErdaIcon type="right" size={18} />
         </div>
       </div>
       {!hidePageSizeChange ? (
         <Dropdown
           trigger={['click']}
-          overlay={pageSizeMenu}
+          overlay={
+            <Menu>
+              {PAGINATION.pageSizeOptions.map((item: string | number) => {
+                return (
+                  <Menu.Item key={item} onClick={() => onChange?.(1, +item)}>
+                    <span className="fake-link mr-1">{i18n.t('{size} items / page', { size: item })}</span>
+                  </Menu.Item>
+                );
+              })}
+            </Menu>
+          }
           align={{ offset: [0, 5] }}
           overlayStyle={{ minWidth: 120 }}
           getPopupContainer={(triggerNode) => triggerNode.parentElement as HTMLElement}
         >
-          <span className="bg-hover px-3 py-1 cursor-pointer">{i18n.t('{size} items / page', { size: pageSize })}</span>
+          <span className="bg-hover px-3 py-1 cursor-pointer hover:bg-default-06">
+            {i18n.t('{size} items / page', { size: pageSize })}
+          </span>
         </Dropdown>
       ) : null}
     </div>

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -33,8 +33,6 @@
   }
 
   .bg-hover:hover {
-    background-color: $color-default-06;
-
     &:not(.disabled) {
       cursor: pointer;
     }


### PR DESCRIPTION
## What this PR does / why we need it:
Fix pagination btn hover style bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/149275423-03e71f2e-1b50-4869-ad97-b6f1262ed079.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed a bug where pager hover background would be disabled when used outside of a table.  |
| 🇨🇳 中文    |  修复了在表格之外使用分页器，分页器鼠标悬浮的背景效果会失效的bug。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

