### PR TITLE
feat: update project home and breadcrumb style

### DIFF
--- a/shell/app/layout/pages/page-container/components/header.scss
+++ b/shell/app/layout/pages/page-container/components/header.scss
@@ -9,17 +9,9 @@
     font-family: PingFangSC-Medium;
     padding-right: 16px;
     overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
 
     .erda-header-title {
-      display: flex;
-      align-items: center;
-      width: 100%;
       font-size: 20px;
-      color: rgba(9, 24, 33, 0.84);
     }
   }
 

--- a/shell/app/layout/pages/page-container/components/header.tsx
+++ b/shell/app/layout/pages/page-container/components/header.tsx
@@ -14,64 +14,12 @@
 import React from 'react';
 import { Tab } from 'layout/pages/tab/tab';
 import layoutStore from 'layout/stores/layout';
-import { goTo } from 'common/utils';
 import routeInfoStore from 'core/stores/route';
 import breadcrumbStore from 'layout/stores/breadcrumb';
 import { isEmpty, isFunction } from 'lodash';
 import { matchPath } from 'react-router-dom';
-import { ErdaIcon } from 'common';
-import { Route } from 'core/common/interface';
-import { Breadcrumb, Tooltip } from 'antd';
+import { Ellipsis } from 'common';
 import './header.scss';
-
-const getPath = (path: string, params: Obj<string>) => {
-  path = (path || '').replace(/^\//, '');
-  Object.keys(params).forEach((key) => {
-    path = path.replace(`:${key}`, params[key]);
-  });
-  return path;
-};
-
-const BreadcrumbItem = ({
-  route,
-  paths,
-  params,
-  title,
-}: {
-  route: IRoute;
-  params: Obj<string>;
-  paths: string[];
-  title?: string;
-}) => {
-  const { path, eternal, changePath, pageName } = route;
-  const [link, setLink] = React.useState('');
-  React.useEffect(() => {
-    const currentPath = paths[paths.length - 1];
-    const lastPath = paths.length > 1 ? paths[paths.length - 2] : '';
-
-    let finalPath = route.encode
-      ? `${lastPath}/${encodeURIComponent(params[route.relativePath.slice(1)])}`
-      : currentPath;
-    if (changePath) {
-      finalPath = changePath(finalPath);
-    }
-
-    setLink(`/${finalPath}`);
-  }, [changePath, params, paths, route.encode, route.relativePath]);
-
-  const displayTitle = title || pageName;
-
-  return displayTitle ? (
-    <span
-      className={`breadcrumb-name ${route.disabled ? 'breadcrumb-disabled' : ''}`}
-      title={displayTitle}
-      key={eternal || path}
-      onClick={() => !route.disabled && goTo(link)}
-    >
-      {displayTitle}
-    </span>
-  ) : null;
-};
 
 const Header = () => {
   const [currentApp] = layoutStore.useStore((s) => [s.currentApp]);
@@ -80,7 +28,7 @@ const Header = () => {
   const infoMap = breadcrumbStore.useStore((s) => s.infoMap);
   const [query] = routeInfoStore.useStore((s) => [s.query]);
 
-  const [allRoutes, setAllRoutes] = React.useState<Route[]>([]);
+  const [allRoutes, setAllRoutes] = React.useState<IRoute[]>([]);
   const [params, setParams] = React.useState<Obj<string>>({});
   const [pageNameInfo, setPageNameInfo] = React.useState<Function>();
   const checkHasTemplate = React.useCallback(
@@ -112,7 +60,7 @@ const Header = () => {
   );
 
   const getBreadcrumbTitle = React.useCallback(
-    (route: Route, isBreadcrumb = false) => {
+    (route: IRoute, isBreadcrumb = false) => {
       const { breadcrumbName, pageName } = route;
       let _title = '';
       if (!isBreadcrumb && pageName) {
@@ -176,11 +124,7 @@ const Header = () => {
       const Comp = pageNameInfo;
       return <Comp />;
     }
-    return (
-      <div className="erda-header-title truncate">
-        <Tooltip title={pageName}>{pageName}</Tooltip>
-      </div>
-    );
+    return <div className="text-xl truncate">{pageName}</div>;
   };
   return (
     <div className="erda-header">

--- a/shell/app/layout/pages/page-container/components/shell/index.tsx
+++ b/shell/app/layout/pages/page-container/components/shell/index.tsx
@@ -30,7 +30,11 @@ const Shell = ({ children, breadcrumb, announcement, navigation, sidebar, classN
       <div className="erda-nav h-full">{navigation}</div>
       {sidebar}
       {(breadcrumb || announcement) && (
-        <div className="absolute flex items-center justify-between z-10 top-0 left-28 right-4">
+        <div
+          className={`absolute flex items-center justify-between z-10 top-0 ${
+            sidebar ? 'left-28' : 'left-[72px]'
+          } right-4`}
+        >
           {breadcrumb}
           {announcement}
         </div>

--- a/shell/app/layout/pages/page-container/components/sidebar/index.scss
+++ b/shell/app/layout/pages/page-container/components/sidebar/index.scss
@@ -103,6 +103,7 @@
   user-select: none;
 
   .ant-menu {
+    border: none;
     background-color: transparent;
     .ant-menu-item-icon {
       color: $color-default-6;

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -1079,7 +1079,7 @@
     "circulation setting": "流转设置",
     "class catalog": "类目录",
     "click this area to browse and upload": "点击此区域进行浏览上传",
-    "click to add URL path": "单击添加 URL 路径",
+    "click to add URL path": "点击添加 URL",
     "click to edit": "点击即可编辑",
     "click to expand": "点击展开",
     "clone application": "克隆应用",

--- a/shell/app/modules/project/pages/deploy/index.tsx
+++ b/shell/app/modules/project/pages/deploy/index.tsx
@@ -370,7 +370,7 @@ const DeployContent = ({ projectId, env: propsEnv }: { projectId: string; env: s
                           {moment(card.time).format('YYYY-MM-DD HH:mm:ss')}
                         </span>
                         <CardItem
-                          className={selectedOrder === card.id ? 'bg-default-06' : ''}
+                          className={`animate-border ${selectedOrder === card.id ? 'bg-default-06' : ''}`}
                           card={card}
                           onClick={() => {
                             getDeployDetailFunc(card.id);

--- a/shell/app/modules/project/pages/homepage/index.scss
+++ b/shell/app/modules/project/pages/homepage/index.scss
@@ -36,76 +36,32 @@
 
   .homepage-header {
     height: 120px;
-    position: relative;
-    margin-bottom: 56px;
     border-radius: 2px 2px 0 0;
-
-    .project-icon {
-      position: absolute;
-      width: 76px;
-      height: 76px;
-      bottom: -38px;
-      left: 16px;
-      border: 6px $white solid;
-      box-shadow: 0 2px 7px 0 rgba($color-default, 0.16);
-      border-radius: 2px;
-
-      .big-icon {
-        border-radius: 2px;
-        box-shadow: 0 0 0 4px $white;
-      }
-    }
-
-    .project-name {
-      position: absolute;
-      bottom: -38px;
-      left: 108px;
-      font-size: 30px;
-      color: $color-default;
-      letter-spacing: 0;
-      line-height: 38px;
-    }
   }
 
   .read-only-markdown {
     .markdown-edit-button {
-      display: none;
-      right: 380px;
-      top: 228px;
+      opacity: 0;
+      right: 396px;
+      top: 272px;
       z-index: 2;
     }
 
     &:hover {
       .markdown-edit-button {
-        display: flex;
+        opacity: 1;
       }
     }
   }
 
-  .homepage-body {
-    .homepage-info {
-      width: 280px;
+  .homepage-info {
+    border-left: 1px solid $color-default-04;
 
-      .info-title {
-        font-family: 'PingFangSC-Medium';
-        font-size: 14px;
-        color: $color-default;
-        letter-spacing: 0;
-        line-height: 22px;
-        margin-bottom: 12px;
-      }
-
-      .info-brief {
-        line-height: 22px;
-      }
-
-      .homepage-link {
-        span {
-          color: #424CA6,
-        }
-      }
+    .info-brief {
+      line-height: 22px;
     }
   }
+
   .markdown-editor .markdown-editor-content .rc-md-editor .editor-container {
     padding: 0;
   }

--- a/shell/app/modules/project/pages/homepage/index.tsx
+++ b/shell/app/modules/project/pages/homepage/index.tsx
@@ -59,26 +59,28 @@ const LinkRow = (props: LinkRowProps) => {
   const isHovering = useHoverDirty(linkRef);
 
   return (
-    <div key={item.id} ref={linkRef} className="cursor-pointer flex items-center homepage-link mb-1">
+    <div
+      key={item.id}
+      ref={linkRef}
+      className="h-8 cursor-pointer flex items-center homepage-link pl-2 hover:bg-default-04"
+    >
       <ErdaIcon type="lianjie" {...iconStyle} />
-      <div className="cursor-pointer ml-2 w-64 px-2 py-1 flex justify-between items-center hover:bg-default-04">
-        <div className="w-52 truncate">
-          <Tooltip title={item.name || item.url} placement="left" overlayClassName="homepage-tooltip">
-            <span
-              className="hover:underline"
-              onClick={() => {
-                if (item.url.startsWith('www')) {
-                  window.open(`https://${item.url}`);
-                }
-                window.open(item.url);
-              }}
+      <div className="cursor-pointer ml-2 w-64 px-2 py-1 flex justify-between items-center">
+        <div className="truncate">
+          <Tooltip title={item.name || item.url} placement="left">
+            <a
+              className="underline"
+              style={{ color: 'rgba(66,76,166,0.90)' }}
+              href={item.url.startsWith('http') ? item.url : `https://${item.url}`}
+              target="_blank"
+              rel="noopener noreferrer"
             >
               {item.url}
-            </span>
+            </a>
           </Tooltip>
         </div>
         <div className={`${isHovering ? 'homepage-link-operation' : 'hidden'} flex justify-between items-center`}>
-          <Tooltip title={i18n.t('edit')} overlayClassName="homepage-tooltip">
+          <Tooltip title={i18n.t('edit')}>
             <ErdaIcon
               type="correction"
               className={'w-4 mx-2 self-center text-default-4 hover:text-default-8'}
@@ -94,7 +96,7 @@ const LinkRow = (props: LinkRowProps) => {
             icon={null}
             onConfirm={() => handleDelete(item.id)}
           >
-            <Tooltip title={i18n.t('delete')} overlayClassName="homepage-tooltip">
+            <Tooltip title={i18n.t('delete')}>
               <ErdaIcon type="remove" size={16} className="text-default-4 hover:text-default-8" />
             </Tooltip>
           </Popconfirm>
@@ -183,89 +185,92 @@ export const ProjectHomepage = () => {
   return (
     <div className="full-spin-height">
       <Spin spinning={loading}>
-        <div className="project-homepage bg-white">
+        <div className="project-homepage relative bg-white">
           <div
-            className="homepage-header relative bg-cover bg-center"
+            className="homepage-header bg-cover bg-center"
             style={{ backgroundImage: `url(${defaultProjectMainBg})` }}
           >
             <div style={{ transform: 'scale(0.8)' }} className="absolute top-2 -right-1 text-xs text-white-4">
               {i18n.t('dop:project-img-copyright-tip')}
             </div>
-            <div className="project-icon bg-white">
+          </div>
+          <div className="relative pb-4 top-[-30px] px-[60px]">
+            <div className="project-icon">
               {logo ? (
-                <img className="big-icon" src={logo} width={64} height={64} />
+                <img className="rounded-sm" src={logo} width={60} height={60} alt="project logo" />
               ) : (
-                <ErdaIcon type="morenxiangmu" size={64} />
+                <ErdaIcon type="morenxiangmu" size={60} />
               )}
             </div>
-            <div className="project-name">{displayName || name}</div>
-          </div>
-          <div className="homepage-body pb-4 flex justify-between px-4">
-            <div className="homepage-markdown w-full mr-4">
-              <ReadMeMarkdown
-                value={markdownContent || emptyMarkdownContent}
-                onSave={(v: string) => handleSave({ ...data, readme: v })}
-                onChange={(v: string) => {
-                  if (v.length > 65535) {
-                    setDisabledMarkdownBtn(true);
-                    message.warning(i18n.t('dop:Markdown content length cannot exceed 65535 characters!'));
-                  } else {
-                    setDisabledMarkdownBtn(false);
-                  }
-                }}
-                disabled={disabledMarkdownBtn}
-                originalValue={projectHomepageInfo?.readme || emptyMarkdownContent}
-              />
-            </div>
-            <div className="homepage-info py-3 text-default">
-              <div className="info-title">{i18n.t('dop:About')}</div>
-              <div className="info-brief mb-4">
-                {desc || (
-                  <span>
-                    {i18n.t(
-                      'dop:Tell about your project in one sentence, so that more people can quickly understand your project, go to',
+            <div className="text-3xl font-bold text-default mt-4 mb-5">{displayName || name}</div>
+            <div className="flex justify-between">
+              <div className="homepage-markdown w-full mr-4">
+                <ReadMeMarkdown
+                  value={markdownContent || emptyMarkdownContent}
+                  onSave={(v: string) => handleSave({ ...data, readme: v })}
+                  onChange={(v: string) => {
+                    if (v.length > 65535) {
+                      setDisabledMarkdownBtn(true);
+                      message.warning(i18n.t('dop:Markdown content length cannot exceed 65535 characters!'));
+                    } else {
+                      setDisabledMarkdownBtn(false);
+                    }
+                  }}
+                  disabled={disabledMarkdownBtn}
+                  originalValue={projectHomepageInfo?.readme || emptyMarkdownContent}
+                />
+              </div>
+              <div className="py-3 text-default">
+                <div className="homepage-info pl-4 pb-4">
+                  <div className="mb-2 font-bold">{i18n.t('dop:About')}</div>
+                  <div className="info-brief mb-4">
+                    {desc || (
+                      <span>
+                        {i18n.t(
+                          'dop:Tell about your project in one sentence, so that more people can quickly understand your project, go to',
+                        )}
+                        <span
+                          onClick={() => goTo(goTo.pages.projectSetting, { projectId })}
+                          className="text-purple-deep mx-1 cursor-pointer"
+                        >
+                          {i18n.t('project setting')}
+                        </span>
+                        {i18n.t('dop:to configure')}
+                      </span>
                     )}
-                    <span
-                      onClick={() => goTo(goTo.pages.projectSetting, { projectId })}
-                      className="text-purple-deep mx-1 cursor-pointer"
-                    >
-                      {i18n.t('project setting')}
-                    </span>
-                    {i18n.t('dop:to configure')}
-                  </span>
-                )}
-              </div>
-              <div className="info-links">
-                {map(data?.links, (item) => (
-                  <LinkRow item={item} handleEditLink={handleEditLink} handleDelete={handleDelete} key={item.id} />
-                ))}
-                {data?.links.length < MAX_LINKS_LENGTH && (
-                  <div className="flex items-center mb-4 cursor-pointer" onClick={handleAdd}>
-                    <ErdaIcon type="lianjie" {...iconStyle} />
-                    <div
-                      className={
-                        'ml-2 w-64 px-2 py-1 flex justify-between items-center text-default-3 hover:bg-default-04'
-                      }
-                    >
-                      {i18n.t('dop:click to add URL path')}
-                    </div>
                   </div>
-                )}
-              </div>
-              <div className="flex items-center mb-2">
-                <ErdaIcon type="zerenren" {...iconStyle} />
-                <span className="ml-4">
-                  <Avatar size={24} src={projectOwner?.avatar || undefined}>
-                    {projectOwner?.nick ? getAvatarChars(projectOwner?.nick) : i18n.t('none')}
-                  </Avatar>
-                  {projectOwner?.name && (
-                    <span className="text-default-8 ml-1">{projectOwner?.nick || projectOwner?.name || '-'}</span>
-                  )}
-                </span>
-              </div>
-              <div className="flex items-center mb-2">
-                <ErdaIcon type="chuangjianshijian" {...iconStyle} />
-                <span className="ml-4 text-default-8">{moment(createdAt).format('YYYY/MM/DD')}</span>
+                  <div className="info-links mb-4 ml-[-8px]">
+                    {map(data?.links, (item) => (
+                      <LinkRow item={item} handleEditLink={handleEditLink} handleDelete={handleDelete} key={item.id} />
+                    ))}
+                    {data?.links.length < MAX_LINKS_LENGTH && (
+                      <div
+                        className="flex items-center h-8 pl-2 mb-4 cursor-pointer hover:bg-default-04"
+                        onClick={handleAdd}
+                      >
+                        <ErdaIcon type="lianjie" {...iconStyle} />
+                        <div className={'ml-2 w-64 px-2 py-1 flex justify-between items-center text-default-3'}>
+                          {i18n.t('dop:click to add URL path')}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex items-center h-8 mb-2">
+                    <ErdaIcon type="zerenren" {...iconStyle} />
+                    <span className="ml-4">
+                      <Avatar size={24} src={projectOwner?.avatar || undefined}>
+                        {projectOwner?.nick ? getAvatarChars(projectOwner?.nick) : i18n.t('none')}
+                      </Avatar>
+                      {projectOwner?.name && (
+                        <span className="text-default-8 ml-1">{projectOwner?.nick || projectOwner?.name || '-'}</span>
+                      )}
+                    </span>
+                  </div>
+                  <div className="flex items-center h-8 mb-2">
+                    <ErdaIcon type="chuangjianshijian" {...iconStyle} />
+                    <span className="ml-4 text-default-8">{moment(createdAt).format('YYYY/MM/DD')}</span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/shell/app/modules/project/pages/homepage/readme-markdown.tsx
+++ b/shell/app/modules/project/pages/homepage/readme-markdown.tsx
@@ -24,7 +24,7 @@ interface IMdProps {
   value?: string;
   originalValue?: string;
   disabled?: boolean;
-  maxHeight: number;
+  maxHeight?: number;
   onChange: (v: string) => void;
   onSave: (v: string) => void;
 }
@@ -80,22 +80,20 @@ export const ReadMeMarkdown = ({ value, onChange, onSave, disabled, originalValu
       style={{ maxHeight: expanded ? '' : maxHeight }}
     >
       <div className="overflow-hidden" style={{ maxHeight: 'inherit' }}>
-        <div className="md-content">
+        <div className="md-content p-0">
           <Tooltip title={i18n.t('dop:click to edit')}>
             <div
-              className={
-                'markdown-edit-button h-8 w-8 fixed bg-white rounded-2xl shadow-card justify-center items-center'
-              }
+              className={'markdown-edit-button flex-all-center h-8 w-8 fixed bg-white rounded-2xl shadow-card'}
               onClick={() => updater.isEditing(true)}
             >
               <ErdaIcon type="edit" size={16} className="text-default-4 hover:text-default-8" />
             </div>
           </Tooltip>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ img: ScalableImage }} linkTarget='_blank'>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ img: ScalableImage }} linkTarget="_blank">
             {value || i18n.t('no description yet')}
           </ReactMarkdown>
           <div
-            className={`absolute left-0 bottom-0 w-full h-16 bg-gradient-to-b from-transparent to-white flex justify-center items-center ${
+            className={`absolute left-0 bottom-0 w-full h-16 bg-gradient-to-b from-transparent to-white flex-all-center ${
               !expandBtnVisible || expanded ? 'hidden' : ''
             }`}
           />


### PR DESCRIPTION
## What this PR does / why we need it:
* update project home style
* update breadcrumb position when sidebar not exist
* remove sidebar border
* add animate border to deploy record card

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/149306483-8ba69ba7-1f5e-4373-829b-8bfeedc3007a.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | update breadcrumb position when sidebar not exist  |
| 🇨🇳 中文    |  调整无权限页面的面包屑位置  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

