### PR TITLE
fix: revert old project pipeline

### DIFF
--- a/shell/app/modules/project/pages/pipelines/old-pipeline.tsx
+++ b/shell/app/modules/project/pages/pipelines/old-pipeline.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import React from 'react';
+import PipelineManage from 'project/common/components/pipeline-manage';
+
+const DataConfig = () => {
+  return <PipelineManage scope="projectPipeline" />;
+};
+
+export default DataConfig;

--- a/shell/app/modules/project/router.tsx
+++ b/shell/app/modules/project/router.tsx
@@ -228,6 +228,11 @@ function getProjectRouter(): RouteConfigItem[] {
           ],
         },
         {
+          path: 'old-pipelines',
+          breadcrumbName: i18n.t('pipeline'),
+          getComp: (cb) => cb(import('project/pages/pipelines/old-pipeline')),
+        },
+        {
           path: 'manual',
           pageName: i18n.t('dop:manual test'),
           routes: [


### PR DESCRIPTION
## What this PR does / why we need it:
revert old project pipeline

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        -     |
| 🇨🇳 中文    |         -    |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

