### PR TITLE
fix: revert table header bg color

### DIFF
--- a/shell/app/common/components/base-list/index.tsx
+++ b/shell/app/common/components/base-list/index.tsx
@@ -53,7 +53,7 @@ const List = (props: ERDA_LIST.Props) => {
           </div>
           {pagination &&
             (!isLoadMore ? (
-              <div className="flex items-center justify-between px-4 bg-default-02">
+              <div className="pagination-wrap flex items-center justify-between px-4 bg-default-02">
                 <div>{batchOperation}</div>
                 <Pagination {...pagination} current={pagination.pageNo} />
               </div>

--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -73,7 +73,7 @@
 
   .erda-table-footer {
     padding: 0 1rem;
-    background-color: $color-default-02;
+    background-color: $color-table-head-bg;
   }
 
   .ant-table {
@@ -207,7 +207,7 @@
 .erda-table-filter {
   padding: 7px 1rem;
   line-height: 50px;
-  background-color: $color-default-02;
+  background-color: $color-table-head-bg;
 
   &-content {
     line-height: 1.2;

--- a/shell/app/modules/msp/env-overview/service-list/pages/service-list.scss
+++ b/shell/app/modules/msp/env-overview/service-list/pages/service-list.scss
@@ -1,5 +1,5 @@
 .bg-header {
-  background-color: $color-default-02;
+  background-color: $color-table-head-bg;
 }
 
 .language-wrapper {

--- a/shell/app/modules/org/common/card/index.scss
+++ b/shell/app/modules/org/common/card/index.scss
@@ -2,7 +2,7 @@
   .erda-card-header {
     line-height: 1;
     font-weight: bold;
-    background-color: $color-default-02;
+    background-color: $color-table-head-bg;
   }
 
   .erda-card-body {

--- a/shell/app/org-home/pages/personal-home.scss
+++ b/shell/app/org-home/pages/personal-home.scss
@@ -18,4 +18,8 @@
       background-attachment: local, local, scroll, scroll;
     }
   }
+
+  .pagination-wrap {
+    background-color: $white !important;
+  }
 }

--- a/shell/app/styles/_color.scss
+++ b/shell/app/styles/_color.scss
@@ -157,6 +157,7 @@ $terminal-bgcolor: #48515f;
 $color-table-color: #837d90;
 $color-table-text-highlight: #7c53db;
 $color-table-bg-hover: #f7f7f8;
+$color-table-head-bg: #fbfbfb;
 $color-bg-gray: #efeef0;
 
 // color new list


### PR DESCRIPTION
## What this PR does / why we need it:
fix: revert table header bg color

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     -        |
| 🇨🇳 中文    |       -      |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

