### PR TITLE
fix(dop): project pipeline apps list status display bug

### DIFF
--- a/shell/app/modules/project/pages/pipelines/components/form.tsx
+++ b/shell/app/modules/project/pages/pipelines/components/form.tsx
@@ -13,11 +13,10 @@
 
 import React from 'react';
 import { Form, Button } from 'antd';
-import { get } from 'lodash';
 import i18n from 'i18n';
 import { ErdaIcon, RenderFormItem } from 'common';
 import routeInfoStore from 'core/stores/route';
-import { getAppList, getBranchList, getFileDetail, createPipeline, getPipelineList } from 'project/services/pipeline';
+import { getAppList, getBranchList, createPipeline, getPipelineList } from 'project/services/pipeline';
 
 interface IProps {
   onCancel: () => void;

--- a/shell/app/modules/project/pages/pipelines/components/pipeline-protocol.tsx
+++ b/shell/app/modules/project/pages/pipelines/components/pipeline-protocol.tsx
@@ -13,6 +13,7 @@
 
 import React from 'react';
 import { Drawer, Tabs, message } from 'antd';
+import { get } from 'lodash';
 import i18n from 'i18n';
 import DiceConfigPage from 'app/config-page';
 import routeInfoStore from 'core/stores/route';
@@ -26,11 +27,12 @@ import appStore from 'application/stores/application';
 
 interface IProps {
   application: { ID: number; name?: string };
+  getApps: () => void;
 }
 
 const { TabPane } = Tabs;
 
-const PipelineProtocol = ({ application }: IProps) => {
+const PipelineProtocol = ({ application, getApps }: IProps) => {
   const [{ projectId }] = routeInfoStore.useStore((s) => [s.params]);
   const { updateTreeNodeDetail } = fileTreeStore;
   const { updateAppDetail } = appStore.reducers;
@@ -66,6 +68,16 @@ const PipelineProtocol = ({ application }: IProps) => {
         showLoading
         inParams={inParams}
         ref={reloadRef}
+        operationCallBack={(reqConfig) => {
+          const { event } = reqConfig;
+          const { component, operationData } = event || {};
+          if (component === 'pipelineTable') {
+            const id = get(operationData, 'clientData.dataRef.id');
+            if (['run', 'cancelRun'].includes(id)) {
+              getApps();
+            }
+          }
+        }}
         customProps={{
           myPage: {
             props: {

--- a/shell/app/modules/project/pages/pipelines/index.tsx
+++ b/shell/app/modules/project/pages/pipelines/index.tsx
@@ -103,7 +103,7 @@ const Pipeline = () => {
       </div>
 
       <div className="pipeline-right flex-1 pt-2 h-full min-w-0">
-        <PipelineProtocol application={application} />
+        <PipelineProtocol application={application} getApps={getList} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project pipeline apps list status display bug

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  The number of pipelines executing and failing in the list of applications to the left of the pipeline at the project level is not automatically refreshed. |
| 🇨🇳 中文    |  项目级流水线左侧应用列表中正在执行、失败的流水线数量不会自动刷新。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=275706&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMTQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

