### PR TITLE
fix(common): config table header background color optimization

### DIFF
--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -73,7 +73,6 @@
 
   .erda-table-footer {
     padding: 0 1rem;
-    background-color: $color-table-head-bg;
   }
 
   .ant-table {
@@ -123,7 +122,6 @@
     // TODO: remove this after update global input style
     .ant-input-affix-wrapper,
     input {
-      background-color: $color-bg-gray;
       border: none;
       border-radius: 2px;
     }
@@ -207,7 +205,6 @@
 .erda-table-filter {
   padding: 7px 1rem;
   line-height: 50px;
-  background-color: $color-table-head-bg;
 
   &-content {
     line-height: 1.2;

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -305,7 +305,10 @@ function WrappedTable<T extends object = any>({
   }
 
   return (
-    <div className={`flex flex-col erda-table ${hideHeader ? 'hide-header' : ''} theme-${theme}`} ref={containerRef}>
+    <div
+      className={`flex flex-col erda-table bg-white ${hideHeader ? 'hide-header' : ''} theme-${theme}`}
+      ref={containerRef}
+    >
       {!hideHeader && (
         <TableConfig
           slot={slot}

--- a/shell/app/common/components/table/table-config.tsx
+++ b/shell/app/common/components/table/table-config.tsx
@@ -49,7 +49,7 @@ function TableConfig<T extends object = any>({
     ));
 
   return (
-    <div className="erda-table-filter flex justify-between">
+    <div className="erda-table-filter flex justify-between bg-default-02">
       <div className="erda-table-filter-content flex-1 flex items-center">
         <div className="flex-1">{slot}</div>
       </div>

--- a/shell/app/common/components/table/table-footer.tsx
+++ b/shell/app/common/components/table/table-footer.tsx
@@ -41,7 +41,7 @@ const TableFooter = ({ rowSelection, pagination, hidePagination, onTableChange }
   };
 
   return (
-    <div className="erda-table-footer flex justify-between">
+    <div className="erda-table-footer flex justify-between bg-default-02">
       {rowSelection?.actions ? (
         <div className="erda-table-batch-ops flex items-center">
           <Dropdown

--- a/shell/app/modules/project/router.tsx
+++ b/shell/app/modules/project/router.tsx
@@ -201,7 +201,7 @@ function getProjectRouter(): RouteConfigItem[] {
         },
         {
           path: 'ticket',
-          breadcrumbName: i18n.t('dop:tickets'),
+          breadcrumbName: i18n.t('Tickets'),
           getComp: (cb) => cb(import('project/pages/ticket')),
           layout: {
             noWrapper: true,


### PR DESCRIPTION
## What this PR does / why we need it:
Config table header background color optimization 

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/149703987-29b159a9-877a-478c-89cc-05eddd62a78d.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Unified background color for componentized table headers. |
| 🇨🇳 中文    | 组件化表格头部背景色统一。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

