### PR TITLE
fix(common): configurable filter display bug when receiving null

### DIFF
--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -399,7 +399,7 @@ const SelectComp = ({ value, onChange, options, size, optionRender, ...restItemP
   return (
     <Select
       {...restItemProps}
-      value={value}
+      value={value || undefined}
       onChange={onChange}
       size={size}
       filterOption={(input, option) =>


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter display bug when receiving null.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/149716059-137dbd90-bdbe-417e-b578-da993b83630d.png)
->
![image](https://user-images.githubusercontent.com/82502479/149716077-96d615bd-e81f-4de9-9b29-1eb0d3376a38.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed display issues when configurable filters receive NULL values.  |
| 🇨🇳 中文    | 修复了可配置筛选器接收null值时的显示问题。  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=275907&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMTQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

