### PR TITLE
fix(common): in config page, radio tabs value change by state

### DIFF
--- a/shell/app/common/components/radio-tabs/index.tsx
+++ b/shell/app/common/components/radio-tabs/index.tsx
@@ -47,6 +47,13 @@ const RadioTabs = (props: RadioTabsProps) => {
     subValues: {},
   });
 
+  React.useEffect(() => {
+    if (value !== propsValue) {
+      updater.value(propsValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [propsValue]);
+
   const convertValue = (val: Value) => {
     if (options.find((o) => o.value === val)) {
       return val;

--- a/shell/app/common/components/radio-tabs/index.tsx
+++ b/shell/app/common/components/radio-tabs/index.tsx
@@ -48,11 +48,8 @@ const RadioTabs = (props: RadioTabsProps) => {
   });
 
   React.useEffect(() => {
-    if (value !== propsValue) {
-      updater.value(propsValue);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [propsValue]);
+    updater.value((prev: string) => (prev !== propsValue ? propsValue : prev));
+  }, [propsValue, updater]);
 
   const convertValue = (val: Value) => {
     if (options.find((o) => o.value === val)) {


### PR DESCRIPTION
## What this PR does / why we need it:
 In config page, radio tabs value change by state.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Makes the value of the tag radio button in the componentization change with the state of the componentized species. |
| 🇨🇳 中文    | 让组件化中的标签单选按钮的值随着组件化种的状态改变。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=275905&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMTQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

