### PR TITLE
fix: select display in table

### DIFF
--- a/shell/app/modules/cmp/common/custom-alarm/index.tsx
+++ b/shell/app/modules/cmp/common/custom-alarm/index.tsx
@@ -277,6 +277,7 @@ const CustomAlarm = ({ scopeType }: { scopeType: string }) => {
               { key: 'value', value: undefined },
             ]);
           }}
+          getPopupContainer={() => document.body}
         >
           {map(tags, ({ key, name }) => (
             <Select.Option key={key} value={key}>
@@ -297,6 +298,7 @@ const CustomAlarm = ({ scopeType }: { scopeType: string }) => {
           onSelect={(operator) => {
             handleEditEditingFilters(uniKey, [{ key: 'operator', value: operator }]);
           }}
+          getPopupContainer={() => document.body}
         >
           {map(filters, ({ operation, name }) => (
             <Select.Option key={operation}>{name}</Select.Option>
@@ -328,6 +330,7 @@ const CustomAlarm = ({ scopeType }: { scopeType: string }) => {
               onSelect={(v: any) => {
                 handleEditEditingFilters(uniKey, [{ key: 'value', value: v }]);
               }}
+              getPopupContainer={() => document.body}
             >
               {map(_values, ({ value: v, name }) => (
                 <Select.Option key={v} value={v}>
@@ -368,6 +371,7 @@ const CustomAlarm = ({ scopeType }: { scopeType: string }) => {
               { key: 'aggregations', value: get(types[get(fieldsMap[field], 'type')], 'aggregations') },
             ]);
           }}
+          getPopupContainer={() => document.body}
         >
           {map(fields, ({ key, name }) => (
             <Select.Option key={key} value={key}>
@@ -403,6 +407,7 @@ const CustomAlarm = ({ scopeType }: { scopeType: string }) => {
               { key: 'aggregatorType', value: get(find(aggregations, { aggregation: aggregator }), 'result_type') },
             ]);
           }}
+          getPopupContainer={() => document.body}
         >
           {map(aggregations, ({ aggregation, name }) => (
             <Select.Option key={aggregation}>{name}</Select.Option>
@@ -421,6 +426,7 @@ const CustomAlarm = ({ scopeType }: { scopeType: string }) => {
           onSelect={(operator) => {
             handleEditEditingFields(uniKey, [{ key: 'operator', value: operator }]);
           }}
+          getPopupContainer={() => document.body}
         >
           {map(get(types[aggregatorType], 'operations'), ({ operation, name }) => (
             <Select.Option key={operation}>{name}</Select.Option>

--- a/shell/app/modules/org/pages/projects/settings/info/index.scss
+++ b/shell/app/modules/org/pages/projects/settings/info/index.scss
@@ -5,8 +5,4 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
   }
-
-  .org-with-logo {
-    width: calc(100% - 64px - 16px);
-  }
 }

--- a/shell/app/modules/org/pages/projects/settings/info/index.scss
+++ b/shell/app/modules/org/pages/projects/settings/info/index.scss
@@ -1,0 +1,12 @@
+.project-setting-info {
+  .desc {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .org-with-logo {
+    width: calc(100% - 64px - 16px);
+  }
+}

--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -216,7 +216,9 @@ const Info = () => {
             {info.logo && <img src={info.logo} className="w-16 h-16 mr-4" />}
             <div className={`${info.logo ? 'org-with-logo' : ''}`}>
               <Ellipsis title={info.displayName} className="text-xl label" />
-              <div className="desc">{info.desc}</div>
+              <Tooltip title={info.desc}>
+                <div className="desc">{info.desc}</div>
+              </Tooltip>
             </div>
           </Col>
           <Col span={12} className="py-1">

--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -212,9 +212,9 @@ const Info = () => {
         }
       >
         <Row>
-          <Col span={12} className="flex items-center pr-4">
+          <Col span={12} className="flex items-center pr-4 flex-1">
             {info.logo && <img src={info.logo} className="w-16 h-16 mr-4" />}
-            <div className={`${info.logo ? 'org-with-logo' : ''}`}>
+            <div>
               <Ellipsis title={info.displayName} className="text-xl label" />
               <Tooltip title={info.desc}>
                 <div className="desc">{info.desc}</div>

--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -28,6 +28,7 @@ import { HeadProjectSelector } from 'project/common/components/project-selector'
 import userStore from 'app/user/stores';
 import Card from 'org/common/card';
 import { WORKSPACE_LIST } from 'common/constants';
+import './index.scss';
 
 // 修改项目信息后，更新左侧菜单上方的信息
 let selectorKey = 1;
@@ -206,19 +207,19 @@ const Info = () => {
         }
         actions={
           <span className="hover-active" onClick={() => setProjectInfoEditVisible(true)}>
-            <ErdaIcon type="edit" size={16} className="mr-2 align-middle " />
+            <ErdaIcon type="edit" size={16} className="mr-2 align-middle" />
           </span>
         }
       >
         <Row>
-          <Col span={12} className="flex items-center h-20">
+          <Col span={12} className="flex items-center pr-4">
             {info.logo && <img src={info.logo} className="w-16 h-16 mr-4" />}
-            <div>
-              <div className="text-xl label">{info.displayName}</div>
+            <div className={`${info.logo ? 'org-with-logo' : ''}`}>
+              <Ellipsis title={info.displayName} className="text-xl label" />
               <div className="desc">{info.desc}</div>
             </div>
           </Col>
-          <Col span={12} className="py-5">
+          <Col span={12} className="py-1">
             <Panel
               columnNum={2}
               fields={[

--- a/shell/app/modules/project/pages/homepage/index.tsx
+++ b/shell/app/modules/project/pages/homepage/index.tsx
@@ -221,7 +221,7 @@ export const ProjectHomepage = () => {
                 />
               </div>
               <div className="py-3 text-default">
-                <div className="homepage-info pl-4 pb-4">
+                <div className="homepage-info pl-4 pb-4 w-[296px]">
                   <div className="mb-2 font-bold">{i18n.t('dop:About')}</div>
                   <div className="info-brief mb-4">
                     {desc || (


### PR DESCRIPTION
## What this PR does / why we need it:
1. select display incomplete in table

2. modify the style of basic project info

**before:** 
![image](https://user-images.githubusercontent.com/30014895/149733557-8185b37f-d1ca-4ee6-a472-1e26baf76a64.png)


**now:**
![image](https://user-images.githubusercontent.com/30014895/149733373-dc33489e-bb4c-4e57-a34c-e82d856e1791.png)

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      -     |
| 🇨🇳 中文    |      -    |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【告警】微服务告警规则，新增/编辑，添加过滤规则/字段规则，页面显示不全](https://erda.cloud/erda/dop/projects/387/issues/all?id=276193&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA3MjMiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
[项目标识比较长、项目描述比较长的情况下项目信息显示乱了](https://erda.cloud/erda/dop/projects/387/issues/all?id=275319&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)