### PR TITLE
fix(dop): project release detail yml file display bug

### DIFF
--- a/shell/app/modules/project/pages/release/components/application-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/application-detail.tsx
@@ -21,7 +21,6 @@ import ErdaTable from 'common/components/table';
 import routeInfoStore from 'core/stores/route';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { debounce } from 'lodash';
 import orgStore from 'app/org-home/stores/org';
 import FileContainer from 'application/common/components/file-container';
 import { getReleaseDetail, formalRelease, updateRelease, checkVersion } from 'project/services/release';
@@ -137,8 +136,8 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
   );
 
   return (
-    <div className="release-releaseDetail release-form h-full overflow-y-auto pb-16 relative">
-      <Form layout="vertical" form={form}>
+    <div className="release-releaseDetail release-form h-full pb-16 relative">
+      <Form layout="vertical" form={form} className="h-full overflow-auto">
         <Tabs defaultActiveKey="1">
           <TabPane tab={i18n.t('dop:basic information')} key="1">
             <div className="mb-4 pl-0.5">
@@ -223,7 +222,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
         </Tabs>
       </Form>
 
-      <div className="absolute bottom-0 left-4 right-0 bg-white z-10 py-4">
+      <div className="absolute bottom-0 left-0 right-0 bg-white z-10 py-4">
         {isEdit ? (
           <Button className="mr-3 bg-default" type="primary" onClick={submit}>
             {i18n.t('submit')}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project release detail yml file display bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [X] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed the display bug of YML files in project level artifact details. |
| 🇨🇳 中文    | 修复了项目级制品详情中yml文件的显示bug。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=275920&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMTQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

