### PR TITLE
fix(dop): project pipeline name rules change

### DIFF
--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -854,6 +854,7 @@
     "Mobile application is a mobile client developed on Android and iOS platforms, including the overall process of development, release and submit to the app store.": "The mobile application is a mobile APP client applied to the development of two major platforms, Android and iOS, and includes the overall process of development, release, and launch to the market.",
     "Modified or added features affect the original function.": "Modified or added features affect the original function.",
     "Modifying service parameters will restart all associated applications.": "modify service parameters, you need to restart all associated applications",
+    "Must be composed of Chinese, letters, numbers, underscores, hyphens and dots.": "Must be composed of Chinese, letters, numbers, underscores, hyphens and dots.",
     "Must be composed of letters, numbers, underscores, hyphens and dots.": "must be composed of English, numbers, underscores, underscores, dots",
     "Name already existed. Please rename it.": "Name already existed. Please rename it.",
     "New version available. Upgrade now?": "New version available. Upgrade now?",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -854,6 +854,7 @@
     "Mobile application is a mobile client developed on Android and iOS platforms, including the overall process of development, release and submit to the app store.": "移动应用是应用于 Android 和 iOS 两大平台开发的移动 APP 客户端，包含了开发、发布、上架到市场的整体流程。",
     "Modified or added features affect the original function.": "修改或新增的功能影响原来的功能",
     "Modifying service parameters will restart all associated applications.": "修改服务参数，需重启所有关联应用",
+    "Must be composed of Chinese, letters, numbers, underscores, hyphens and dots.": "必须由中文、英文、数字、下划线、中划线、点组成",
     "Must be composed of letters, numbers, underscores, hyphens and dots.": "必须由英文、数字、下划线、中划线、点组成",
     "Name already existed. Please rename it.": "名称已存在，请重新命名",
     "New version available. Upgrade now?": "版本可升级，是否升级",

--- a/shell/app/modules/project/pages/pipelines/components/form.tsx
+++ b/shell/app/modules/project/pages/pipelines/components/form.tsx
@@ -139,8 +139,8 @@ const PipelineForm = ({ onCancel, application, onOk }: IProps) => {
               { required: true, message: i18n.t('please enter {name}', { name: i18n.t('pipeline') }) },
               { max: 30, message: i18n.t('dop:no more than 30 characters') },
               {
-                pattern: /^[A-Za-z0-9._-]+$/,
-                message: i18n.t('dop:Must be composed of letters, numbers, underscores, hyphens and dots.'),
+                pattern: /^[\u4e00-\u9fa5A-Za-z0-9._-]+$/,
+                message: i18n.t('dop:Must be composed of Chinese, letters, numbers, underscores, hyphens and dots.'),
               },
             ]}
             itemProps={{


### PR DESCRIPTION
## What this PR does / why we need it:
Project pipeline name rules change

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The name of the project level assembly line is allowed in Chinese. |
| 🇨🇳 中文    | 项目级流水线取名允许中文。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=276316&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMTQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

