### PR TITLE
fix(common): org home display optimization when org name too long

### DIFF
--- a/shell/app/common/components/dropdown-select-new/index.tsx
+++ b/shell/app/common/components/dropdown-select-new/index.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import { Dropdown, Menu, Input } from 'antd';
-import { ErdaIcon } from 'common';
+import { ErdaIcon, Ellipsis } from 'common';
 import React from 'react';
 import { map } from 'lodash';
 import i18n from 'i18n';
@@ -178,7 +178,7 @@ const DropdownSelect = (props: DropdownSelectNewProps) => {
                 className={`p-0 seleted-item ${className}`}
                 switcher={
                   <span
-                    className="rounded-sm bg-default-06 text-default-8 px-2 py-0.5 ml-1 hover:bg-purple-deep hover:text-white"
+                    className="whitespace-nowrap rounded-sm bg-default-06 text-default-8 px-2 py-0.5 ml-1 hover:bg-purple-deep hover:text-white"
                     onClick={() => !disabled && setActive(!active)}
                   >
                     {i18n.t('common:switch')}
@@ -228,7 +228,7 @@ const Item = (props: ItemProps) => {
         {onlyIcon ? null : (
           <div className="flex-1 overflow-hidden">
             <div className="flex items-center">
-              <div className="truncate option-label">{label}</div>
+              <Ellipsis className="option-label" title={label} />
               {switcher}
             </div>
             {desc ? <div className="option-desc truncate ">{desc}</div> : null}


### PR DESCRIPTION
## What this PR does / why we need it:
Org home display optimization when org name too long.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/149763050-2a3d6767-8615-4f28-9ae8-673015df6e11.png)
->
![image](https://user-images.githubusercontent.com/82502479/149762914-b795159a-2ae1-4b6e-bba2-69d0d74f645e.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Optimize the display of personal workbench switch when the enterprise name is long.   |
| 🇨🇳 中文    | 企业名称比较长的情况下个人工作台切换显示优化。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=275900&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMTQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

