### PR TITLE
fix: add no space check rule for certificate alias fields

### DIFF
--- a/shell/app/modules/org/pages/certificate/index.tsx
+++ b/shell/app/modules/org/pages/certificate/index.tsx
@@ -391,6 +391,7 @@ const Certificate = () => {
         {
           label: `Debug-key ${i18n.t('cmp:alias')}`,
           name: keyPrefix.adrManualDebug.concat(['alias']),
+          rules: [noSpaceRule],
         },
         {
           label: `Debug-key ${i18n.t('password')}`,
@@ -442,6 +443,7 @@ const Certificate = () => {
         {
           label: `Release-key ${i18n.t('cmp:alias')}`,
           name: keyPrefix.adrManualRelease.concat(['alias']),
+          rules: [noSpaceRule],
         },
         {
           label: `Release-key ${i18n.t('password')}`,
@@ -474,6 +476,7 @@ const Certificate = () => {
         {
           label: `Debug-key ${i18n.t('cmp:alias')}`,
           name: keyPrefix.adrAuto.concat(['debugKeyStore', 'alias']),
+          rules: [noSpaceRule],
         },
         {
           label: `Debug-key ${i18n.t('password')}`,
@@ -496,6 +499,7 @@ const Certificate = () => {
         {
           label: `Release-key ${i18n.t('cmp:alias')}`,
           name: keyPrefix.adrAuto.concat(['releaseKeyStore', 'alias']),
+          rules: [noSpaceRule],
         },
         {
           label: `Release-key ${i18n.t('password')}`,

--- a/shell/app/modules/project/pages/issue/gantt/index.tsx
+++ b/shell/app/modules/project/pages/issue/gantt/index.tsx
@@ -216,7 +216,7 @@ const IssuePlan = () => {
       if ((chosenParentId === 0 && (isDelete || isCreate)) || chosenParentId !== 0) {
         reInParams = [chosenParentId];
       } else {
-        reInParams = [chosenParentId, chosenIssueId];
+        reInParams = [chosenParentId, +chosenIssueId];
       }
       reloadData({ parentId: reInParams });
     }


### PR DESCRIPTION
## What this PR does / why we need it:
add check rule

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add no space check rule for certificate alias fields  |
| 🇨🇳 中文    | 证书表单中的别名字段添加禁止空格的校验 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
cherry-pick release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

