### PR TITLE
fix(dop): project release put application in front of project

### DIFF
--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -169,7 +169,7 @@ export enum pages {
   projectTestReportCreate = '/{orgName}/dop/projects/{projectId}/test-report/create',
   projectMemberManagement = '/{orgName}/dop/projects/{projectId}/setting?tabKey=projectMember',
   projectRelease = '/{orgName}/dop/projects/{projectId}/release',
-  projectReleaseList = '/{orgName}/dop/projects/{projectId}/release/project',
+  projectReleaseList = '/{orgName}/dop/projects/{projectId}/release/application',
   projectDeploy = '/{orgName}/dop/projects/{projectId}/deploy',
   projectDeployEnv = '/{orgName}/dop/projects/{projectId}/deploy/list/{env}',
   projectDeployConfigEnv = '/{orgName}/dop/projects/{projectId}/deploy/config/{env}',

--- a/shell/app/modules/project/tabs.tsx
+++ b/shell/app/modules/project/tabs.tsx
@@ -219,12 +219,12 @@ export const AUTO_TEST_TABS = [
 
 export const RELEASE_TABS = [
   {
-    key: 'project',
-    name: i18n.t('dop:project release'),
-  },
-  {
     key: 'application',
     name: i18n.t('dop:app release'),
+  },
+  {
+    key: 'project',
+    name: i18n.t('dop:project release'),
   },
 ];
 


### PR DESCRIPTION
## What this PR does / why we need it:
Project release put application in front of project.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/149882151-2884cc93-28da-40f2-a031-057302f41b9d.png)
->
![image](https://user-images.githubusercontent.com/82502479/149882266-f24ba9c7-a776-49aa-8768-897a43b1a4e8.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  In a project-level pipeline, applications come before projects. |
| 🇨🇳 中文    | 在项目级流水线中，应用放在项目前面。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

