### PR TITLE
fix: remove file style in importing project

### DIFF
--- a/shell/app/modules/org/pages/projects/import-project-template.scss
+++ b/shell/app/modules/org/pages/projects/import-project-template.scss
@@ -2,6 +2,12 @@
   font-family: 'PingFangSC-Regular';
   line-height: 22px;
 
+  .init-upload {
+    .ant-upload-list-item-info {
+      display: none;
+    }
+  }
+
   .ant-upload-list-text-container {
     margin-top: -8px;
 

--- a/shell/app/modules/org/pages/projects/import-project-template.tsx
+++ b/shell/app/modules/org/pages/projects/import-project-template.tsx
@@ -76,7 +76,7 @@ export const ImportProjectTemplate = ({ form }: { form: FormInstance }) => {
     action: `/api/${getOrgFromPath()}/projects/template/actions/parse`,
     onChange: handleChange,
     iconRender: () => <ErdaIcon type="shenjirizhi" />,
-    className: `w-full ${fileStatus === 'init' ? 'flex-all-center' : ''}`,
+    className: `w-full ${fileStatus === 'init' ? 'flex-all-center init-upload' : ''}`,
     onRemove: () =>
       form.setFieldsValue({
         projectTemplate: undefined,

--- a/shell/app/modules/org/pages/projects/settings/info/index.scss
+++ b/shell/app/modules/org/pages/projects/settings/info/index.scss
@@ -5,4 +5,8 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
   }
+
+  .org-with-logo {
+    width: calc(100% - 64px - 16px);
+  }
 }

--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -212,9 +212,9 @@ const Info = () => {
         }
       >
         <Row>
-          <Col span={12} className="flex items-center pr-4 flex-1">
+          <Col span={12} className="flex items-center pr-4">
             {info.logo && <img src={info.logo} className="w-16 h-16 mr-4" />}
-            <div>
+            <div className={`${info.logo ? 'org-with-logo' : 'w-full'}`}>
               <Ellipsis title={info.displayName} className="text-xl label" />
               <Tooltip title={info.desc}>
                 <div className="desc">{info.desc}</div>


### PR DESCRIPTION
## What this PR does / why we need it:
1. remove file style in importing project

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | project import file delete file optimize style |
| 🇨🇳 中文    | 项目导入文件删除文件优化样式 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[项目导入文件删除优化](https://erda.cloud/erda/dop/projects/387/issues/all?id=275832&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
