### PR TITLE
fix(dop): project release create disabled button style bug

### DIFF
--- a/shell/app/modules/project/pages/release/release-protocol.tsx
+++ b/shell/app/modules/project/pages/release/release-protocol.tsx
@@ -74,7 +74,7 @@ const ReleaseProtocol = ({ isProjectRelease, applicationID }: IProps) => {
         <div className="top-button-group">
           <WithAuth pass={canCreateRelease}>
             <Dropdown overlay={addDropdownMenu} placement="bottomRight" trigger={['click']}>
-              <Button type={'primary'} className="bg-default flex-h-center">
+              <Button type={'primary'} className="flex-h-center">
                 {i18n.t('new {name}', { name: i18n.t('Artifact') })}
                 <ErdaIcon type="caret-down" size="18" color="currentColor" className="ml-1 text-white-4" />
               </Button>


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project release create disabled button style bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/149914401-cc4d294a-233f-42c5-ab96-b3750e8a2cd5.png)
->
![image](https://user-images.githubusercontent.com/82502479/149914159-32994a97-2912-485c-bf60-f86cf1451921.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a style issue where new buttons in project level artifacts had no power limit. |
| 🇨🇳 中文    | 修复了项目级制品新增按钮无权限时的样式问题。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

