### PR TITLE
fix: fix whether isK8S logic

### DIFF
--- a/shell/app/modules/extra/entry.js
+++ b/shell/app/modules/extra/entry.js
@@ -11,13 +11,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import routers from './msp/router';
-
 const entry = (registerModule) => {
-  return registerModule({
-    key: 'msp-extra',
-    routers,
-  });
+  // register some modules here
 };
 
 export default entry;

--- a/shell/app/modules/extra/entry.js
+++ b/shell/app/modules/extra/entry.js
@@ -11,8 +11,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import routers from './msp/router';
+
 const entry = (registerModule) => {
-  // register some modules here
+  return registerModule({
+    key: 'msp-extra',
+    routers,
+  });
 };
 
 export default entry;

--- a/shell/app/modules/msp/stores/micro-service.tsx
+++ b/shell/app/modules/msp/stores/micro-service.tsx
@@ -14,7 +14,7 @@
 import { createStore } from 'core/cube';
 import * as mspService from 'msp/services';
 import { envMap, getMSFrontPathByKey, getMSPSubtitleByName, MSIconMap } from 'msp/config';
-import { filter, get, isEmpty, every } from 'lodash';
+import { every, filter, get, isEmpty } from 'lodash';
 import layoutStore from 'layout/stores/layout';
 import { goTo, qs } from 'common/utils';
 import { getCurrentLocale } from 'i18n';
@@ -138,7 +138,7 @@ export const initMenu = (refresh = false) => {
       const DICE_CLUSTER_NAME = msMenu[0].clusterName;
       const DICE_CLUSTER_TYPE = msMenu[0].clusterType || '';
       const isEdas = DICE_CLUSTER_TYPE.includes('edasv2');
-      const isK8S = DICE_CLUSTER_TYPE === 'kubernetes';
+      const isK8S = msMenu[0].isK8S;
       const clusterType = isEdas ? 'EDAS' : 'TERMINUS';
       setGlobal('service-provider', clusterType);
       mspStore.reducers.updateClusterInfo({

--- a/shell/app/modules/msp/types/index.d.ts
+++ b/shell/app/modules/msp/types/index.d.ts
@@ -81,6 +81,8 @@ declare namespace MS_INDEX {
     cnName: string;
     enName: string;
     exists?: boolean; // false表示没有用到或还未拉起来，先展示引导页
+    isK8S: boolean;
+    isEdas: boolean;
     params: {
       [key: string]: string;
       key: IMenuKey;


### PR DESCRIPTION
## What this PR does / why we need it:
 
fix msp menu [backend:feat: microservice menu api add isk8s field ](https://github.com/erda-project/erda/pull/3791)

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix whether isK8S logic |
| 🇨🇳 中文    |  修复 isK8S 的判断逻辑 |


## Does this PR need be patched to older version?
✅ Yes(version is required)

release/1.6-alpha.2
release/1.5

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

