### PR TITLE
fix: revert config page partial update

### DIFF
--- a/shell/app/config-page/index.tsx
+++ b/shell/app/config-page/index.tsx
@@ -118,7 +118,7 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
   const { getRenderPageLayout } = commonStore.effects;
 
   useMount(() => {
-    queryPageConfig(undefined, undefined, (config: CONFIG_PAGE.RenderConfig) => {
+    queryPageConfig(undefined, false, undefined, (config: CONFIG_PAGE.RenderConfig) => {
       // if there is any component marked as asyncAtInit, fetch again to load async component
       const comps = config?.protocol?.components || {};
       const asyncComponents: string[] = [];
@@ -195,7 +195,12 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
     }
   }, [inParamsStr]);
 
-  const queryPageConfig = (p?: CONFIG_PAGE.RenderConfig, op?: CP_COMMON.Operation, callBack?: Function) => {
+  const queryPageConfig = (
+    p?: CONFIG_PAGE.RenderConfig,
+    partial?: boolean,
+    op?: CP_COMMON.Operation,
+    callBack?: Function,
+  ) => {
     if (fetchingRef.current || forbiddenRequest) return; // forbidden request when fetching
     // 此处用state，为了兼容useMock的情况
     if (!op?.async) {
@@ -206,24 +211,26 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
     const reqConfig = { ...curConfig, inParams: { ...inParamsRef.current, ...curConfig?.inParams } };
     ((useMockMark && _useMock) || getRenderPageLayout)(reqConfig)
       .then((res: CONFIG_PAGE.RenderConfig) => {
-        const _curConfig = pageConfigRef.current;
-        const newConfig = produce(_curConfig, (draft) => {
-          draft.inParams = reqConfig.inParams;
-          draft.protocol = {
-            ...draft.protocol,
-            ...res.protocol,
-            components: {
-              ...draft.protocol?.components,
-              ...res.protocol?.components,
-            },
-          };
-        });
-        // if (op?.index === undefined || (op.index && opIndexRef.current === op.index))  {
-        //   // }
-        updateConfig ? updateConfig(newConfig) : updater.pageConfig(newConfig);
-        pageConfigRef.current = newConfig;
-        operationCallBack?.(reqConfig, newConfig, op);
-        callBack?.(newConfig);
+        if (partial) {
+          const _curConfig = pageConfigRef.current;
+          const newConfig = produce(_curConfig, (draft) => {
+            if (draft.protocol?.components) {
+              draft.protocol.components = { ...draft.protocol.components };
+            }
+          });
+          updateConfig ? updateConfig(newConfig) : updater.pageConfig(newConfig);
+          pageConfigRef.current = newConfig;
+          operationCallBack?.(reqConfig, newConfig, op);
+          callBack?.(newConfig);
+        } else {
+          // if (op?.index === undefined || (op.index && opIndexRef.current === op.index))  {
+          // }
+          // Retain the response data that matches the latest operation
+          updateConfig ? updateConfig(res) : updater.pageConfig(res);
+          pageConfigRef.current = res;
+          operationCallBack?.(reqConfig, res, op);
+          callBack?.(res);
+        }
         if (op?.successMsg) notify('success', op.successMsg);
       })
       .catch(() => {
@@ -253,7 +260,7 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
     updateInfo?: { dataKey: string; dataVal: Obj },
     extraUpdateInfo?: Obj,
   ) => {
-    const { key, reload, skipRender, ..._rest } = op;
+    const { key, reload, skipRender, partial, ..._rest } = op;
     const loadCallBack = (_pageData: CONFIG_PAGE.RenderConfig) => {
       op?.callBack?.();
       onExecOp && onExecOp({ cId, op, reload, updateInfo, pageData: _pageData });
@@ -289,7 +296,7 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
       });
 
       const formatConfig = clearLoadMoreData(newConfig);
-      queryPageConfig(formatConfig, { ...op, index: opIndexRef.current }, loadCallBack);
+      queryPageConfig(formatConfig, partial, { ...op, index: opIndexRef.current }, loadCallBack);
     } else if (updateInfo) {
       updateState(updateInfo.dataKey, updateInfo.dataVal, loadCallBack);
     }


### PR DESCRIPTION
## What this PR does / why we need it:
fix: revert config page partial update

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix: revert config page partial update          |
| 🇨🇳 中文    |   fix: 回退组件化协议部分更新          |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

