### PR TITLE
feat: line-graph and bubble-graph dynamic unit

### DIFF
--- a/shell/app/charts/utils/formatter.js
+++ b/shell/app/charts/utils/formatter.js
@@ -12,6 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import { findIndex } from 'lodash';
+import moment from 'moment';
 
 class Formatter {
   toFixed(value, fixed = 2, unitType = 'NUMBER') {
@@ -156,4 +157,23 @@ const MonitorChartFormatterMap = (unitType, unit) => {
 
 export const getFormatter = (unitType, unit) => {
   return MonitorChartFormatterMap(unitType, unit) || new NumberFormatter(unit);
+};
+
+/**
+ * @description format the chart axes
+ * @param type {'string' | 'number' | 'capacity' | 'trafficRate' | 'storage' | 'timestamp' | 'time'}
+ * @param precision {string}
+ * @param value {number}
+ * @returns {string}
+ */
+export const formatValue = (type, precision, value) => {
+  const valueType = type === 'trafficRate' ? 'TRAFFIC' : type.toUpperCase();
+  if (['NUMBER', 'PERCENT', 'CAPACITY', 'TIME', 'STORAGE', 'TRAFFIC'].includes(valueType)) {
+    const format = getFormatter(valueType, precision);
+    return format.format(value);
+  } else if (valueType === 'TIMESTAMP') {
+    return moment(value).format(precision);
+  } else {
+    return `${value} ${precision}`;
+  }
 };

--- a/shell/app/charts/utils/index.tsx
+++ b/shell/app/charts/utils/index.tsx
@@ -13,4 +13,4 @@
 
 import './regist';
 
-export { getFormatter } from './formatter';
+export { getFormatter, formatValue } from './formatter';

--- a/shell/app/config-page/components/bubble-graph/bubble-graph.spec.d.ts
+++ b/shell/app/config-page/components/bubble-graph/bubble-graph.spec.d.ts
@@ -19,12 +19,29 @@ declare namespace CP_BUBBLE_GRAPH {
     style: import('react').CSSProperties;
   }
 
+  type ValueType = 'string' | 'number' | 'capacity' | 'trafficRate' | 'storage' | 'timestamp' | 'time';
+
+  interface AxisOptions {
+    inverse: boolean;
+    structure: {
+      enable: boolean;
+      precision: string;
+      type: ValueType;
+    };
+  }
+
   interface Spec {
     type: 'BubbleGraph';
     props: IProps;
     data: {
       title: string;
       subTitle?: string;
+      xOptions: AxisOptions | null;
+      yOptions: Array<
+        AxisOptions & {
+          dimension: string[];
+        }
+      >;
       list: {
         dimension: string;
         group: string;

--- a/shell/app/config-page/components/line-graph/index.tsx
+++ b/shell/app/config-page/components/line-graph/index.tsx
@@ -105,7 +105,6 @@ const LineGraph: React.FC<CP_LINE_GRAPH.Props> = (props) => {
         const { enable, type, precision } = structure;
         return {
           type: 'value',
-          xx: structure,
           axisLabel: {
             color: colorToRgb(color, 0.3),
             formatter: enable ? (v: number) => formatValue(type, precision, v) : undefined,

--- a/shell/app/config-page/components/line-graph/line-graph.spec.d.ts
+++ b/shell/app/config-page/components/line-graph/line-graph.spec.d.ts
@@ -18,24 +18,37 @@ declare namespace CP_LINE_GRAPH {
     style: import('react').CSSProperties;
   }
 
+  type ValueType = 'string' | 'number' | 'capacity' | 'trafficRate' | 'storage' | 'timestamp' | 'time';
+
+  interface AxisOptions {
+    inverse: boolean;
+    structure: {
+      enable: boolean;
+      precision: string;
+      type: ValueType;
+    };
+  }
+
   interface Spec {
     type: 'LineGraph';
     props: IProps;
     data: {
       dimensions: string[];
       title: string;
-      subTitle?: string;
       inverse: boolean;
       xAxis: {
-        inverse: boolean;
         values: Array<string | number>;
-        formatter?: string;
       };
+      xOptions: AxisOptions | null;
       yAxis: {
         dimension: string;
-        inverse: boolean;
         values: Array<string | number>;
       }[];
+      yOptions: Array<
+        AxisOptions & {
+          dimension: string[];
+        }
+      >;
     };
   }
 


### PR DESCRIPTION
## What this PR does / why we need it:

line-graph and bubble-graph auto unit 

Related PR [feat: linegraph and bubblegraph auto unit #3802](https://github.com/erda-project/erda/pull/3802)

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | line-graph and bubble-graph dynamic unit|
| 🇨🇳 中文    | 折线图气泡图坐标轴动态单位 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

