### PR TITLE
feat: set list kv-info margin top to 8px

### DIFF
--- a/shell/app/common/components/base-list/list-item.tsx
+++ b/shell/app/common/components/base-list/list-item.tsx
@@ -138,7 +138,7 @@ const ListItem = (props: ERDA_LIST.ItemProps) => {
                 <Ellipsis className={`body-description ${kvInfos?.length ? '' : 'mt-1'}`} title={description || '-'} />
               </If>
               <If condition={!!kvInfos?.length}>
-                <div className={`body-meta-info flex ${description ? '' : 'mt-2'}`}>
+                <div className="body-meta-info flex mt-2">
                   {map(kvInfos, (info) => {
                     const { compWapper, status = 'default' } = info;
 


### PR DESCRIPTION
## What this PR does / why we need it:
update list syle

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/150094997-81bed9d5-56a0-4292-85a6-ef84d6ca63c2.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     feat: set list kv-info margin top to 8px         |
| 🇨🇳 中文    |  设置列表 kv 信息行上边距为 8 像素 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
 release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

