### PR TITLE
fix(common): load more selector style bug

### DIFF
--- a/shell/app/common/components/load-more-selector/index.scss
+++ b/shell/app/common/components/load-more-selector/index.scss
@@ -178,6 +178,10 @@
         padding: 9px 10px;
         color: $color-white-6;
 
+        .ant-checkbox {
+          top: 0;
+        }
+
         &:hover,
         &.checked {
           color: $white;

--- a/shell/app/common/components/load-more-selector/index.tsx
+++ b/shell/app/common/components/load-more-selector/index.tsx
@@ -353,11 +353,9 @@ const PureLoadMoreSelector = (props: IProps) => {
           ? [
               <MenuItem className="chosen-info" key="_chosen-info-item">
                 <div className="w-full flex justify-between my-1">
-                  <div className={''}>
+                  <div>
                     {i18n.t('common:selected')}
-                    &nbsp;
-                    <span>{chosenItem.length}</span>
-                    &nbsp;
+                    <span className="mx-0.5">{chosenItem.length}</span>
                     {i18n.t('common:item')}
                   </div>
                   <span className="fake-link ml-2 text-purple-deep" onClick={clearValue}>

--- a/shell/app/common/components/load-more-selector/index.tsx
+++ b/shell/app/common/components/load-more-selector/index.tsx
@@ -352,16 +352,18 @@ const PureLoadMoreSelector = (props: IProps) => {
         {isMultiple
           ? [
               <MenuItem className="chosen-info" key="_chosen-info-item">
-                <div className={''}>
-                  {i18n.t('common:selected')}
-                  &nbsp;
-                  <span>{chosenItem.length}</span>
-                  &nbsp;
-                  {i18n.t('common:item')}
+                <div className="w-full flex justify-between my-1">
+                  <div className={''}>
+                    {i18n.t('common:selected')}
+                    &nbsp;
+                    <span>{chosenItem.length}</span>
+                    &nbsp;
+                    {i18n.t('common:item')}
+                  </div>
+                  <span className="fake-link ml-2 text-purple-deep" onClick={clearValue}>
+                    {i18n.t('common:clear selected')}
+                  </span>
                 </div>
-                <span className="fake-link ml-2 text-purple-deep" onClick={clearValue}>
-                  {i18n.t('common:clear selected')}
-                </span>
               </MenuItem>,
               <Menu.Divider key="_chosen-info-divider" />,
             ]


### PR DESCRIPTION
## What this PR does / why we need it:
Fix load more selector style bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/150107603-a8fc9ea9-f83e-41d3-bbcc-0338fbf2f332.png)
->
![image](https://user-images.githubusercontent.com/82502479/150107402-15581fe9-1375-4b81-add6-36fcb60d7e1b.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed style issues with selectors.  |
| 🇨🇳 中文    | 修复了选择器的样式问题。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

