### PR TITLE
fix(common): radio tabs default value bug

### DIFF
--- a/shell/app/common/components/radio-tabs/index.tsx
+++ b/shell/app/common/components/radio-tabs/index.tsx
@@ -48,7 +48,7 @@ const RadioTabs = (props: RadioTabsProps) => {
   });
 
   React.useEffect(() => {
-    updater.value((prev: string) => (prev !== propsValue ? propsValue : prev));
+    propsValue && updater.value((prev: string) => (prev !== propsValue ? propsValue : prev));
   }, [propsValue, updater]);
 
   const convertValue = (val: Value) => {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix radio tabs default value bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/150122007-8ac9d3ea-2e00-4ac9-b417-4da17deff3bd.png)
->
![image](https://user-images.githubusercontent.com/82502479/150121785-a95dca50-9631-479c-8d0c-7a0feee96e0e.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a bug where radio button TAB initial values were invalid. |
| 🇨🇳 中文    | 修复了单选按钮标签页初始值失效的bug。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

