### PR TITLE
fix(dashboard): i18n validating about required fields in dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,7 +334,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.6
+      '@erda-ui/dashboard-configurator': 2.0.7
       '@erda-ui/react-markdown-editor-lite': ^1.4.7
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -478,7 +478,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.6_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.7_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -5733,8 +5733,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.6_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-AX7igyo2BUYYAR825mWcz7ztMvR2ovmJOJCcPTnLQbQjDu1AZ65KuixVjxjIo5WEM8fWzO3inIELLle0qikLbw==}
+  /@erda-ui/dashboard-configurator/2.0.7_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-Kwj5fnOCIACjs+Uzsmt1Qqk7ueKHCKWSWyzgZWN9Jbln8vkB05JPdNCnF/OHeRllEHpdyFEQ6bYEdj21qy5M/Q==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -13838,18 +13838,18 @@ packages:
       eslint-plugin-testing-library:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.25.0_6fb86b31e39dbd15f93824c03ca6ca0c
-      '@typescript-eslint/parser': 4.25.0_eslint@7.27.0+typescript@4.2.4
+      '@typescript-eslint/eslint-plugin': 4.25.0_15a8c6a214b1547f8382842b92f9dbe9
+      '@typescript-eslint/parser': 4.25.0_eslint@7.27.0+typescript@4.4.2
       babel-eslint: 10.1.0_eslint@7.27.0
       confusing-browser-globals: 1.0.10
       eslint: 7.27.0
       eslint-plugin-flowtype: 5.7.2_eslint@7.27.0
       eslint-plugin-import: 2.23.3_eslint@7.27.0
-      eslint-plugin-jest: 24.3.6_37bf39ebe0f22c2c661de72fa9962677
+      eslint-plugin-jest: 24.3.6_c82f5996322cd9ede56a955914b627f7
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.27.0
       eslint-plugin-react: 7.23.2_eslint@7.27.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.27.0
-      eslint-plugin-testing-library: 3.10.2_eslint@7.27.0+typescript@4.2.4
+      eslint-plugin-testing-library: 3.10.2_eslint@7.27.0+typescript@4.4.2
     dev: false
 
   /eslint-import-resolver-node/0.3.4:

--- a/shell/package.json
+++ b/shell/package.json
@@ -47,7 +47,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.6",
+    "@erda-ui/dashboard-configurator": "2.0.7",
     "@erda-ui/react-markdown-editor-lite": "^1.4.7",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:
fix that i18n validating about required fields in the dashboard

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix that i18n validating about required fields in dashboard |
| 🇨🇳 中文    | 修复大盘中必填字段校验国际化问题 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
/cherry-pick release/1.6-alpha.2

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
[【集成环境】【国际化】自定义大盘，新增/编辑页面，字段为空时，提示语没有翻译](https://erda.cloud/erda/dop/projects/387/issues/all?id=277529&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA3MjMiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)
