### PR TITLE
fix: set markdown editor lang by current locale

### DIFF
--- a/shell/app/common/components/markdown-editor/editor.tsx
+++ b/shell/app/common/components/markdown-editor/editor.tsx
@@ -19,10 +19,13 @@ import { EditorProps } from '@erda-ui/react-markdown-editor-lite/editor';
 import UploadPlugin from './upload-plugin';
 import { uploadFile } from '../../services';
 import { convertToFormData } from 'common/utils';
+import { getLang } from 'i18n';
 import { getFormatter } from 'charts/utils';
 import '@erda-ui/react-markdown-editor-lite/lib/index.css';
 import './editor.scss';
 
+// eslint-disable-next-line react-hooks/rules-of-hooks
+MdEditor.useLocale(getLang() === 'zh-CN' ? 'zhCN' : 'enUS');
 MdEditor.use(UploadPlugin);
 
 interface IProps extends Omit<EditorProps, 'renderHTML'> {


### PR DESCRIPTION
## What this PR does / why we need it:
fix: set markdown editor lang by current locale

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: set markdown editor lang by current locale   |
| 🇨🇳 中文    |  根据国际化设置 markdown 编辑器的语言   |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

