### PR TITLE
fix(common): config table batch operations disabled style bug

### DIFF
--- a/shell/app/config-page/components/table/table.scss
+++ b/shell/app/config-page/components/table/table.scss
@@ -107,7 +107,7 @@
     }
 
     .disabled {
-      color: $color-white-9 !important;
+      color: $color-white-9;
     }
   }
 


### PR DESCRIPTION
## What this PR does / why we need it:
Fix config table batch operations disabled style bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/150733098-e37263a1-2130-4b71-adb9-068f6521109c.png)
->
![image](https://user-images.githubusercontent.com/82502479/150733057-a05c8233-c762-4f78-86de-5ab3053b1580.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Color of the text when the batch button in the config table is disabled. |
| 🇨🇳 中文    |  组件化协议表格批量按钮不可点击时的文字颜色。   |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

