### PR TITLE
fix(dop): project pipeline apps list pipeline num

### DIFF
--- a/shell/app/modules/project/pages/pipelines/index.tsx
+++ b/shell/app/modules/project/pages/pipelines/index.tsx
@@ -79,34 +79,30 @@ const Pipeline = () => {
                       <div className="flex-1 min-w-0">
                         <Ellipsis title={item.displayName} />
                       </div>
-                      {item.runningNum || item.failedNum || item.totalNum ? (
-                        <div className="bg-default-04 text-default-9 rounded-2xl px-3 py-0.5 text-xs flex-h-center">
-                          {item.runningNum ? (
-                            <Tooltip title={i18n.t('running')}>
-                              <div className="flex-h-center mr-0.5">
-                                <Badge onlyDot breathing status={'success'} className="mr-0.5" />
-                                <div>{item.runningNum}</div>
-                              </div>
-                            </Tooltip>
-                          ) : null}
-                          {item.failedNum ? (
-                            <Tooltip title={i18n.t('dop:number of failures in a day')}>
-                              <div className="flex-h-center">
-                                <Badge onlyDot breathing status={'error'} className="mr-0.5" />
-                                <div>{item.failedNum}</div>
-                              </div>
-                            </Tooltip>
-                          ) : null}
-                          {(item.runningNum || item.failedNum) && item.totalNum ? (
-                            <Divider type="vertical" className="top-0" />
-                          ) : null}
-                          {item.totalNum ? (
-                            <Tooltip title={i18n.t('dop:total number of pipelines')}>
-                              <div>{item.totalNum}</div>
-                            </Tooltip>
-                          ) : null}
-                        </div>
-                      ) : null}
+                      <div className="bg-default-04 text-default-9 rounded-2xl px-3 py-0.5 text-xs flex-h-center">
+                        {item.runningNum ? (
+                          <Tooltip title={i18n.t('running')}>
+                            <div className="flex-h-center mr-0.5">
+                              <Badge onlyDot breathing status={'success'} className="mr-0.5" />
+                              <div>{item.runningNum}</div>
+                            </div>
+                          </Tooltip>
+                        ) : null}
+                        {item.failedNum ? (
+                          <Tooltip title={i18n.t('dop:number of failures in a day')}>
+                            <div className="flex-h-center">
+                              <Badge onlyDot breathing status={'error'} className="mr-0.5" />
+                              <div>{item.failedNum}</div>
+                            </div>
+                          </Tooltip>
+                        ) : null}
+                        {(item.runningNum || item.failedNum) && item.totalNum ? (
+                          <Divider type="vertical" className="top-0" />
+                        ) : null}
+                        <Tooltip title={i18n.t('dop:total number of pipelines')}>
+                          <div>{item.totalNum || 0}</div>
+                        </Tooltip>
+                      </div>
                     </div>
                   ))}
               </div>


### PR DESCRIPTION
## What this PR does / why we need it:
Project pipeline apps list pipeline num.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/150741992-b7d8fbef-1e56-49b1-9055-25812648c305.png)
->
![image](https://user-images.githubusercontent.com/82502479/150741457-8215f96a-c31e-42da-b408-0e9ce5418e10.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | In the app list of project-level pipelines, it is also displayed when the total number of pipelines is 0. |
| 🇨🇳 中文    | 项目级流水线的app列表中，当流水线总数为0时也显示。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

