### PR TITLE
fix: markdown editor locale change after rerender

### DIFF
--- a/shell/app/common/components/markdown-editor/editor.tsx
+++ b/shell/app/common/components/markdown-editor/editor.tsx
@@ -24,8 +24,6 @@ import { getFormatter } from 'charts/utils';
 import '@erda-ui/react-markdown-editor-lite/lib/index.css';
 import './editor.scss';
 
-// eslint-disable-next-line react-hooks/rules-of-hooks
-MdEditor.useLocale(getLang() === 'zh-CN' ? 'zhCN' : 'enUS');
 MdEditor.use(UploadPlugin);
 
 interface IProps extends Omit<EditorProps, 'renderHTML'> {
@@ -55,6 +53,10 @@ const Editor = React.forwardRef((props: IProps, ref) => {
         });
     }) as Promise<string>;
   }
+
+  // have to call this every time rerender
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  MdEditor.useLocale(getLang() === 'zh-CN' ? 'zhCN' : 'enUS');
 
   return (
     <MdEditor


### PR DESCRIPTION
## What this PR does / why we need it:
markdown editor always use navigator.language as a prior flag, so always set locale every time in render.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  markdown editor locale change after rerender  |
| 🇨🇳 中文    |  修复 markdown 编辑器重新打开后国际化错误问题  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2
release/1.5


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

