### PR TITLE
fix(dop): config table column add tip in gallery

### DIFF
--- a/shell/app/config-page/components/table/table.mock.ts
+++ b/shell/app/config-page/components/table/table.mock.ts
@@ -28,7 +28,7 @@ const mockData: CP_TABLE.Spec = {
   props: {
     rowKey: 'id',
     columns: [
-      { title: '标题', dataIndex: 'title' },
+      { title: '标题', dataIndex: 'title', titleTip: '表头提示，v2版本的table是用的tip' },
       { title: '进度', dataIndex: 'progress', width: 100 },
       { title: '严重程度', dataIndex: 'severity', width: 100 },
       { title: '优先级', dataIndex: 'priority', width: 120 },


### PR DESCRIPTION
## What this PR does / why we need it:
Config table column add tip in gallery.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/150902922-934d5fbc-2a2b-46fd-9d22-f2edc6aef352.png)
->
![image](https://user-images.githubusercontent.com/82502479/150902733-f6790156-c8ea-4000-87cf-7e73cca366cb.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | On the componentized protocol component library page, add a hint to the table column header.  |
| 🇨🇳 中文    |  在组件化协议的组件库页面中，给表格列头增加提示。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

