### PR TITLE
fix(dop): obsoleted pipelines page scroll bug

### DIFF
--- a/shell/app/layout/pages/page-container/page-container.tsx
+++ b/shell/app/layout/pages/page-container/page-container.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { renderRoutes } from 'react-router-config';
+import { renderRoutes, RouteConfig } from 'react-router-config';
 import { ErrorBoundary } from 'common';
 import { useUpdate } from 'common/use-hooks';
 import classnames from 'classnames';
@@ -133,23 +133,7 @@ const PageContainer = ({ route }: IProps) => {
   } else if (notFound) {
     MainContent = <NotFound />;
   } else if (state.startInit) {
-    MainContent = (
-      <ErrorBoundary>
-        <DndProvider backend={HTML5Backend}>
-          {noWrapper ? (
-            <>
-              {typeof customMain === 'function' ? customMain() : customMain}
-              {renderRoutes(route.routes)}
-            </>
-          ) : (
-            <Card className={layout && layout.fullHeight ? 'h-full overflow-auto' : ''}>
-              {typeof customMain === 'function' ? customMain() : customMain}
-              {renderRoutes(route.routes)}
-            </Card>
-          )}
-        </DndProvider>
-      </ErrorBoundary>
-    );
+    MainContent = <RenderMainContent noWrapper={noWrapper} customMain={customMain} route={route} layout={layout} />;
   }
 
   return (
@@ -174,5 +158,39 @@ const PageContainer = ({ route }: IProps) => {
     </Shell>
   );
 };
+
+const RenderMainContent = React.memo(
+  ({
+    noWrapper,
+    customMain,
+    route,
+    layout,
+  }: {
+    noWrapper: boolean;
+    customMain: Function | JSX.Element | null;
+    route: RouteConfig;
+    layout: {
+      [k: string]: any;
+    };
+  }) => {
+    return (
+      <ErrorBoundary>
+        <DndProvider backend={HTML5Backend}>
+          {noWrapper ? (
+            <>
+              {typeof customMain === 'function' ? customMain() : customMain}
+              {renderRoutes(route.routes)}
+            </>
+          ) : (
+            <Card className={layout && layout.fullHeight ? 'h-full overflow-auto' : ''}>
+              {typeof customMain === 'function' ? customMain() : customMain}
+              {renderRoutes(route.routes)}
+            </Card>
+          )}
+        </DndProvider>
+      </ErrorBoundary>
+    );
+  },
+);
 
 export default PageContainer;

--- a/shell/app/modules/project/common/components/pipeline-manage/config-detail/index.tsx
+++ b/shell/app/modules/project/common/components/pipeline-manage/config-detail/index.tsx
@@ -68,6 +68,8 @@ const PipelineConfigDetail = (props: IProps) => {
     updater.useCaseDetail(c || caseDetail);
   };
 
+  const _addDrawerProps = React.useMemo(() => ({ ...addDrawerProps, curCaseId: caseId }), [addDrawerProps, caseId]);
+
   return (
     <div>
       <div className="flex justify-between items-center mb-2">
@@ -82,7 +84,7 @@ const PipelineConfigDetail = (props: IProps) => {
       <CaseInfo caseDetail={useCaseDetail} />
       <CasePipelineEditor
         scope={scope}
-        addDrawerProps={{ ...addDrawerProps, curCaseId: caseId }}
+        addDrawerProps={_addDrawerProps}
         caseDetail={useCaseDetail}
         editable={isLastRecord}
         onUpdateYml={onUpdateYml}

--- a/shell/app/modules/project/common/components/pipeline-manage/config-detail/pipeline-editor/index.tsx
+++ b/shell/app/modules/project/common/components/pipeline-manage/config-detail/pipeline-editor/index.tsx
@@ -33,14 +33,20 @@ stages: []
 const CasePipelineEditor = (props: IProps) => {
   const { caseDetail, onUpdateYml, addDrawerProps, scope, editable } = props;
   const curPipelineYml = get(caseDetail, 'meta.pipelineYml') || defaultPipelineYml;
-  const ymlStr = isEmpty(caseDetail) ? '' : curPipelineYml; //
+  const ymlStr = isEmpty(caseDetail) ? '' : curPipelineYml;
+
+  const ymlEditorRender = React.useCallback(
+    (p: any) => <CaseYmlGraphicEditor scope={scope} addDrawerProps={addDrawerProps} {...p} />,
+    [scope, addDrawerProps],
+  );
+
   return (
     <div>
       <PipelineEditor
         ymlStr={ymlStr}
         editable={editable}
         title={i18n.t('pipeline')}
-        YmlGraphicEditor={(p: any) => <CaseYmlGraphicEditor scope={scope} addDrawerProps={addDrawerProps} {...p} />}
+        YmlGraphicEditor={ymlEditorRender}
         onSubmit={onUpdateYml}
         addDrawerProps={{ ...addDrawerProps, scope, showInParams: true, showOutParams: true }}
         chartProps={{

--- a/shell/app/modules/project/common/components/pipeline-manage/pipeline-detail.tsx
+++ b/shell/app/modules/project/common/components/pipeline-manage/pipeline-detail.tsx
@@ -26,8 +26,10 @@ interface IProps {
   scope: string;
 }
 
+const emptyObj = {};
+
 const PipelineDetail = (props: IProps) => {
-  const { caseId: propsCaseId, addDrawerProps = {}, scope } = props || {};
+  const { caseId: propsCaseId, addDrawerProps = emptyObj, scope } = props || {};
   const caseId = propsCaseId || routeInfoStore.useStore((s) => s.query.caseId);
   const [{ activeKey, runKey, canRunTest }, updater] = useUpdate({
     activeKey: 'configDetail',


### PR DESCRIPTION
## What this PR does / why we need it:
Obsoleted pipelines page scroll bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed the old project pipeline page scintillation bug. |
| 🇨🇳 中文    | 修复了旧版项目流水线页面滚动闪烁的bug。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.2


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

