### PR TITLE
refactor: revert app deploy page for now

### DIFF
--- a/shell/app/menus/application.tsx
+++ b/shell/app/menus/application.tsx
@@ -55,6 +55,14 @@ export const getAppMenu = ({ appDetail }: { appDetail: IApplication }) => {
     subtitle: 'API',
   };
 
+  const deploy = {
+    show: perm.runtime.read.pass,
+    key: 'deploy',
+    href: goTo.resolve.deploy(), // `/dop/projects/${projectId}/apps/${appId}/deploy`,
+    icon: <ErdaIcon type="bushuzhongxin" />,
+    text: i18n.t('dop:Environments'),
+    subtitle: i18n.t('Deploy'),
+  };
   const dataTask = {
     show: perm.dataTask.read.pass,
     key: 'dataTask',
@@ -97,14 +105,14 @@ export const getAppMenu = ({ appDetail }: { appDetail: IApplication }) => {
     subtitle: i18n.t('Setting'),
   };
 
-  // const full = [repo, pipeline, dataTask, dataModel, dataMarket, test, analysis, setting];
+  // const full = [repo, pipeline, deploy, dataTask, dataModel, dataMarket, test, analysis, setting];
   const modeMap = {
-    [appMode.SERVICE]: [repo, pipeline, apiDesign, test, setting],
+    [appMode.SERVICE]: [repo, pipeline, apiDesign, deploy, test, setting],
     [appMode.PROJECT_SERVICE]: [repo, pipeline, test, setting],
-    [appMode.MOBILE]: [repo, pipeline, apiDesign, test, setting],
-    [appMode.LIBRARY]: [repo, pipeline, apiDesign, test, setting],
+    [appMode.MOBILE]: [repo, pipeline, apiDesign, deploy, test, setting],
+    [appMode.LIBRARY]: [repo, pipeline, apiDesign, deploy, test, setting],
     [appMode.BIGDATA]: [repo, dataTask, dataModel, dataMarket, setting],
-    [appMode.ABILITY]: [test, setting],
+    [appMode.ABILITY]: [deploy, test, setting],
   };
 
   return filter(modeMap[mode], (item: IMenuItem) => item.show !== false);


### PR DESCRIPTION
## What this PR does / why we need it:
 revert app deploy page for now

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   revert app deploy page for now  |
| 🇨🇳 中文    | 临时恢复应用部署入口   |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

