### PR TITLE
fix: cmp top head button style in 1.5  

### DIFF
--- a/shell/app/config-page/page-render.tsx
+++ b/shell/app/config-page/page-render.tsx
@@ -46,7 +46,7 @@ const ConfigPageRender = (props: IProps) => {
     if (components) {
       const curCompKeys = Object.keys(components);
       if (!isEqual(curCompKeys, componentsKey)) {
-        containerMapRef.current = getContainerMap(components);
+        containerMapRef.current = getContainerMap(components, customProps);
         setComponentsKey(curCompKeys);
       }
     }
@@ -178,11 +178,15 @@ const ConfigPageRender = (props: IProps) => {
 export default ConfigPageRender;
 
 // 根据配置中的container，获取到当前的所有的组件map
-const getContainerMap = (container: Obj<CONFIG_PAGE.BaseSpec>) => {
+const getContainerMap = (container: Obj<CONFIG_PAGE.BaseSpec>, customProps?: Obj) => {
   const conMap = {};
   map(container, (config, cId) => {
-    const Comp = fullContainerMap[config.type];
-    conMap[cId] = Comp || fullContainerMap.NotFound;
+    if (config.type === 'Custom') {
+      conMap[cId] = customProps?.[cId] || fullContainerMap.NotFound;
+    } else {
+      const Comp = fullContainerMap[config.type];
+      conMap[cId] = Comp || fullContainerMap.NotFound;
+    }
   });
   return conMap;
 };

--- a/shell/app/modules/cmp/pages/cluster-container/cluster-pods.tsx
+++ b/shell/app/modules/cmp/pages/cluster-container/cluster-pods.tsx
@@ -97,9 +97,6 @@ const ClusterPods = () => {
 
   return (
     <ClusterContainer>
-      <div className="top-button-group" style={{ right: 135 }}>
-        <K8sClusterTerminalButton clusterName={clusterName} />
-      </div>
       <DiceConfigPage
         scenarioType={'cmp-dashboard-pods'}
         scenarioKey={'cmp-dashboard-pods'}
@@ -107,6 +104,7 @@ const ClusterPods = () => {
         ref={reloadRef}
         customProps={{
           ...customProps,
+          consoleButton: () => <K8sClusterTerminalButton clusterName={clusterName} />,
           filter: {
             op: {
               onFilterChange: urlQueryChange,

--- a/shell/app/modules/cmp/pages/cluster-container/cluster-workload.tsx
+++ b/shell/app/modules/cmp/pages/cluster-container/cluster-workload.tsx
@@ -93,9 +93,6 @@ const ClusterWorkload = () => {
 
   return (
     <ClusterContainer>
-      <div className="top-button-group" style={{ right: 162 }}>
-        <K8sClusterTerminalButton clusterName={clusterName} />
-      </div>
       <DiceConfigPage
         scenarioType={'cmp-dashboard-workloads-list'}
         scenarioKey={'cmp-dashboard-workloads-list'}
@@ -103,6 +100,7 @@ const ClusterWorkload = () => {
         ref={reloadRef}
         customProps={{
           ...customProps,
+          consoleButton: () => <K8sClusterTerminalButton clusterName={clusterName} />,
           filter: {
             op: {
               onFilterChange: urlQueryChange,


### PR DESCRIPTION
## What this PR does / why we need it:
fix: cmp top head button style in 1.5  
## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/15364706/151300194-757346bb-e2cc-4fb6-97f3-141ebf96438c.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: cmp top head button style in 1.5         |
| 🇨🇳 中文    |  fix: 1.5版本修复cmp页头按钮样式问题            |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

