### PR TITLE
fix: add line break plugin for markdown render

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,7 @@ importers:
       react-syntax-highlighter: ^15.4.5
       react-test-renderer: ^16.7.0
       react-use: ^15.3.4
+      remark-breaks: ^3.0.2
       remark-gfm: ^3.0.1
       requestidlecallback-polyfill: ^1.0.2
       sass: ^1.32.4
@@ -482,7 +483,6 @@ importers:
     dependencies:
       '@erda-ui/dashboard-configurator': 2.0.7_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
-      '@types/react-syntax-highlighter': 13.5.2
       ace-builds: 1.4.12
       ansi_up: 5.0.1
       antd: 4.16.13_react-dom@16.14.0+react@16.14.0
@@ -529,6 +529,7 @@ importers:
       react-router-dom: 5.2.0_react@16.14.0
       react-syntax-highlighter: 15.4.5_react@16.14.0
       react-use: 15.3.8_react-dom@16.14.0+react@16.14.0
+      remark-breaks: 3.0.2
       remark-gfm: 3.0.1
       requestidlecallback-polyfill: 1.0.2
       sass-loader: 10.2.0_sass@1.34.0+webpack@5.63.0
@@ -589,6 +590,7 @@ importers:
       '@types/react-router': 4.4.5
       '@types/react-router-config': 1.1.3
       '@types/react-router-dom': 5.1.7
+      '@types/react-syntax-highlighter': 13.5.2
       '@types/superagent': 4.1.11
       '@types/webpack': 4.41.29
       '@types/webpack-env': 1.16.0
@@ -8010,6 +8012,12 @@ packages:
     resolution: {integrity: sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==}
     dev: true
 
+  /@types/mdast/3.0.10:
+    resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
   /@types/mdast/3.0.3:
     resolution: {integrity: sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==}
     dependencies:
@@ -8068,7 +8076,7 @@ packages:
 
   /@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
-    dev: false
+    dev: true
 
   /@types/q/1.5.4:
     resolution: {integrity: sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==}
@@ -8137,7 +8145,7 @@ packages:
     resolution: {integrity: sha512-sRZoKZBGKaE7CzMvTTgz+0x/aVR58ZYUTfB7HN76vC+yQnvo1FWtzNARBt0fGqcLGEVakEzMu/CtPzssmanu8Q==}
     dependencies:
       '@types/react': 16.14.21
-    dev: false
+    dev: true
 
   /@types/react-test-renderer/16.9.5:
     resolution: {integrity: sha512-C4cN7C2uSSGOYelp2XfdtJb5TsCP+QiZ+0Bm4U3ZfUswN8oN9O/l86XO/OvBSFCmWY7w75fzsQvZ50eGkFN34A==}
@@ -8153,7 +8161,7 @@ packages:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2
       csstype: 3.0.10
-    dev: false
+    dev: true
 
   /@types/react/16.14.7:
     resolution: {integrity: sha512-JhbikeQ1i18ut9Sro3j/xvhN073zJA9sqGqbwJByhOfLPXxEJdqjal9piZd9tmVEC+LP6RN2dLvWx9Hbr0reTw==}
@@ -8195,7 +8203,7 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: false
+    dev: true
 
   /@types/serve-static/1.13.10:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
@@ -8239,6 +8247,10 @@ packages:
 
   /@types/unist/2.0.3:
     resolution: {integrity: sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==}
+
+  /@types/unist/2.0.6:
+    resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+    dev: false
 
   /@types/vinyl-fs/2.4.11:
     resolution: {integrity: sha512-2OzQSfIr9CqqWMGqmcERE6Hnd2KY3eBVtFaulVo3sJghplUcaeMdL9ZjEiljcQQeHjheWY9RlNmumjIAvsBNaA==}
@@ -12509,7 +12521,7 @@ packages:
 
   /csstype/3.0.10:
     resolution: {integrity: sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==}
-    dev: false
+    dev: true
 
   /csstype/3.0.8:
     resolution: {integrity: sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==}
@@ -24824,6 +24836,14 @@ packages:
   /relateurl/0.2.7:
     resolution: {integrity: sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=}
     engines: {node: '>= 0.10'}
+
+  /remark-breaks/3.0.2:
+    resolution: {integrity: sha512-x96YDJ9X+Ry0/JNZFKfr1hpcAKvGYWfUTszxY9RbxKEqq6uzPPoLCuHdZsLPZZUdAv3nCROyc7FPrQLWr2rxyw==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      unified: 10.1.1
+      unist-util-visit: 4.1.0
+    dev: false
 
   /remark-gfm/3.0.1:
     resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}

--- a/shell/app/common/components/markdown-render/index.tsx
+++ b/shell/app/common/components/markdown-render/index.tsx
@@ -19,6 +19,7 @@ import ReactMarkdown from 'react-markdown';
 import { useEvent, useUnmount } from 'react-use';
 import { gfm, gfmHtml } from 'micromark-extension-gfm';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { CodeComponent } from 'react-markdown/lib/ast-to-react';
 import './index.scss';
@@ -131,7 +132,10 @@ interface IMdProps {
 }
 export const MarkdownRender = ({ value, className, style, noWrapper, components }: IMdProps) => {
   const content = (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ img: ScalableImage, a: Link, pre, code, ...components }}>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      components={{ img: ScalableImage, a: Link, pre, code, ...components }}
+    >
       {value}
     </ReactMarkdown>
   );

--- a/shell/app/modules/dop/pages/projects/project-list-protocol.tsx
+++ b/shell/app/modules/dop/pages/projects/project-list-protocol.tsx
@@ -49,8 +49,8 @@ const ProjectList = () => {
   return (
     <>
       <DiceConfigPage
-        scenarioType="project-list-all"
-        scenarioKey="project-list-all"
+        scenarioType="project-list-my"
+        scenarioKey="project-list-my"
         ref={reloadRef}
         customProps={{
           list: {

--- a/shell/app/modules/dop/pages/projects/project-list-protocol.tsx
+++ b/shell/app/modules/dop/pages/projects/project-list-protocol.tsx
@@ -49,8 +49,8 @@ const ProjectList = () => {
   return (
     <>
       <DiceConfigPage
-        scenarioType="project-list-my"
-        scenarioKey="project-list-my"
+        scenarioType="project-list-all"
+        scenarioKey="project-list-all"
         ref={reloadRef}
         customProps={{
           list: {

--- a/shell/package.json
+++ b/shell/package.json
@@ -95,6 +95,7 @@
     "react-router-dom": "^5.2.0",
     "react-syntax-highlighter": "^15.4.5",
     "react-use": "^15.3.4",
+    "remark-breaks": "^3.0.2",
     "remark-gfm": "^3.0.1",
     "requestidlecallback-polyfill": "^1.0.2",
     "sass-loader": "^10.1.1",


### PR DESCRIPTION
## What this PR does / why we need it:
* add break line plugin to auto add <br>

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/151646173-4a600138-cdec-4e00-abd6-fda3c3c6d2d3.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  auto add line break for markdown render  |
| 🇨🇳 中文    | markdown 渲染器中自动添加换行符   |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

