### PR TITLE
fix(common): project edit save button disabled by default

### DIFF
--- a/shell/app/common/components/render-pure-form/index.tsx
+++ b/shell/app/common/components/render-pure-form/index.tsx
@@ -27,6 +27,7 @@ interface IProps {
   onlyItems?: boolean;
   style?: object;
   readOnly?: boolean;
+  formProps?: Obj;
 }
 
 class RenderPureForm extends React.Component<IProps> {
@@ -40,6 +41,7 @@ class RenderPureForm extends React.Component<IProps> {
       onlyItems = false,
       style,
       readOnly = false,
+      ...formProps
     } = this.props;
     const itemLayout = layout === 'horizontal' ? formItemLayout : null;
     const items = list.map((info, i) => {
@@ -100,7 +102,7 @@ class RenderPureForm extends React.Component<IProps> {
     return onlyItems ? (
       items
     ) : (
-      <Form form={form} className={formClass} layout={layout} style={style}>
+      <Form form={form} className={formClass} layout={layout} style={style} {...formProps}>
         {items}
       </Form>
     );

--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -28,6 +28,7 @@ import { HeadProjectSelector } from 'project/common/components/project-selector'
 import userStore from 'app/user/stores';
 import Card from 'org/common/card';
 import { WORKSPACE_LIST } from 'common/constants';
+import { useUpdate } from 'common/use-hooks';
 import './index.scss';
 
 // 修改项目信息后，更新左侧菜单上方的信息
@@ -63,14 +64,27 @@ const Info = () => {
   const loginUser = userStore.useStore((s) => s.loginUser);
   const orgName = routeInfoStore.useStore((s) => s.params.orgName);
   const info = projectStore.useStore((s) => s.info);
-  const [confirmProjectName, setConfirmProjectName] = React.useState('');
 
-  const [projectInfoEditVisible, setProjectInfoEditVisible] = React.useState(false);
-  const [projectInfoSaveDisabled, setProjectInfoSaveDisabled] = React.useState(true);
-  const [projectQuotaEditVisible, setProjectQuotaEditVisible] = React.useState(false);
-  const [projectQuotaSaveDisabled, setProjectQuotaSaveDisabled] = React.useState(true);
-  const [projectRollbackEditVisible, setProjectRollbackEditVisible] = React.useState(false);
-  const [projectRollbackSaveDisabled, setProjectRollbackSaveDisabled] = React.useState(true);
+  const [
+    {
+      confirmProjectName,
+      projectInfoEditVisible,
+      projectInfoSaveDisabled,
+      projectQuotaEditVisible,
+      projectQuotaSaveDisabled,
+      projectRollbackEditVisible,
+      projectRollbackSaveDisabled,
+    },
+    updater,
+  ] = useUpdate({
+    confirmProjectName: '',
+    projectInfoEditVisible: false,
+    projectInfoSaveDisabled: true,
+    projectQuotaEditVisible: false,
+    projectQuotaSaveDisabled: true,
+    projectRollbackEditVisible: false,
+    projectRollbackSaveDisabled: true,
+  });
 
   const { rollbackConfig } = info;
 
@@ -150,7 +164,7 @@ const Info = () => {
 
   const inOrgCenter = location.pathname.startsWith(`/${orgName}/orgCenter`);
   const onDelete = async () => {
-    setConfirmProjectName('');
+    updater.confirmProjectName('');
     await deleteProject();
     await deleteTenantProject({ projectId: info.id });
     if (inOrgCenter) {
@@ -209,7 +223,7 @@ const Info = () => {
           </div>
         }
         actions={
-          <span className="hover-active" onClick={() => setProjectInfoEditVisible(true)}>
+          <span className="hover-active" onClick={() => updater.projectInfoEditVisible(true)}>
             <ErdaIcon type="edit" size={16} className="mr-2 align-middle" />
           </span>
         }
@@ -247,7 +261,7 @@ const Info = () => {
           <Card
             header={i18n.t('dop:project quota')}
             actions={
-              <span className="hover-active" onClick={() => setProjectQuotaEditVisible(true)}>
+              <span className="hover-active" onClick={() => updater.projectQuotaEditVisible(true)}>
                 <ErdaIcon type="edit" size={16} className="mr-2 align-middle" />
               </span>
             }
@@ -326,13 +340,13 @@ const Info = () => {
           <FormModal
             onOk={(result) =>
               updatePrj(result).then(() => {
-                setProjectQuotaEditVisible(false);
-                setProjectQuotaSaveDisabled(true);
+                updater.projectQuotaEditVisible(false);
+                updater.projectQuotaSaveDisabled(true);
               })
             }
             onCancel={() => {
-              setProjectQuotaEditVisible(false);
-              setProjectQuotaSaveDisabled(true);
+              updater.projectQuotaEditVisible(false);
+              updater.projectQuotaSaveDisabled(true);
             }}
             name={i18n.t('dop:project quota')}
             visible={projectQuotaEditVisible}
@@ -340,7 +354,7 @@ const Info = () => {
             formData={{ ...info, isPublic: `${info.isPublic || 'false'}` }}
             okButtonState={projectQuotaSaveDisabled}
             onValuesChange={() => {
-              setProjectQuotaSaveDisabled(false);
+              updater.projectQuotaSaveDisabled(false);
             }}
           />
         </>
@@ -350,7 +364,7 @@ const Info = () => {
         header={i18n.t('advanced settings')}
         actions={
           notMSP ? (
-            <span className="hover-active" onClick={() => setProjectRollbackEditVisible(true)}>
+            <span className="hover-active" onClick={() => updater.projectRollbackEditVisible(true)}>
               <ErdaIcon type="edit" size={16} className="mr-2 align-middle" />
             </span>
           ) : null
@@ -411,7 +425,7 @@ const Info = () => {
               <ConfirmDelete
                 onConfirm={onDelete}
                 deleteItem={`${i18n.t('project')}?`}
-                onCancel={() => setConfirmProjectName('')}
+                onCancel={() => updater.confirmProjectName('')}
                 disabledConfirm={confirmProjectName !== info.displayName}
                 confirmTip={false}
                 secondTitle={i18n.t(
@@ -424,7 +438,7 @@ const Info = () => {
                   <Input
                     value={confirmProjectName}
                     placeholder={i18n.t('please enter {name}', { name: i18n.t('project name') })}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setConfirmProjectName(e.target.value)}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => updater.confirmProjectName(e.target.value)}
                   />
                 }
               >
@@ -438,13 +452,13 @@ const Info = () => {
       <FormModal
         onOk={(result) =>
           updatePrj(result).then(() => {
-            setProjectInfoEditVisible(false);
-            setProjectInfoSaveDisabled(true);
+            updater.projectInfoEditVisible(false);
+            updater.projectInfoSaveDisabled(true);
           })
         }
         onCancel={() => {
-          setProjectInfoEditVisible(false);
-          setProjectInfoSaveDisabled(true);
+          updater.projectInfoEditVisible(false);
+          updater.projectInfoSaveDisabled(true);
         }}
         name={i18n.t('dop:project info')}
         visible={projectInfoEditVisible}
@@ -452,19 +466,19 @@ const Info = () => {
         formData={{ ...info, isPublic: `${info.isPublic || 'false'}` }}
         okButtonState={projectInfoSaveDisabled}
         onValuesChange={() => {
-          setProjectInfoSaveDisabled(false);
+          updater.projectInfoSaveDisabled(false);
         }}
       />
       <FormModal
         onOk={(result) =>
           updateProject({ ...result, isPublic: info.isPublic }).then(() => {
-            setProjectRollbackEditVisible(false);
-            setProjectRollbackSaveDisabled(true);
+            updater.projectRollbackEditVisible(false);
+            updater.projectRollbackSaveDisabled(true);
           })
         }
         onCancel={() => {
-          setProjectRollbackEditVisible(false);
-          setProjectRollbackSaveDisabled(true);
+          updater.projectRollbackEditVisible(false);
+          updater.projectRollbackSaveDisabled(true);
         }}
         name={i18n.t('dop:rollback point')}
         visible={projectRollbackEditVisible}
@@ -472,7 +486,7 @@ const Info = () => {
         formData={{ rollbackConfig: configData }}
         okButtonState={projectRollbackSaveDisabled}
         onValuesChange={() => {
-          setProjectRollbackSaveDisabled(false);
+          updater.projectRollbackSaveDisabled(false);
         }}
       />
     </div>

--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -66,8 +66,11 @@ const Info = () => {
   const [confirmProjectName, setConfirmProjectName] = React.useState('');
 
   const [projectInfoEditVisible, setProjectInfoEditVisible] = React.useState(false);
+  const [projectInfoSaveDisabled, setProjectInfoSaveDisabled] = React.useState(true);
   const [projectQuotaEditVisible, setProjectQuotaEditVisible] = React.useState(false);
+  const [projectQuotaSaveDisabled, setProjectQuotaSaveDisabled] = React.useState(true);
   const [projectRollbackEditVisible, setProjectRollbackEditVisible] = React.useState(false);
+  const [projectRollbackSaveDisabled, setProjectRollbackSaveDisabled] = React.useState(true);
 
   const { rollbackConfig } = info;
 
@@ -321,12 +324,24 @@ const Info = () => {
               : i18n.t('no quota')}
           </Card>
           <FormModal
-            onOk={(result) => updatePrj(result).then(() => setProjectQuotaEditVisible(false))}
-            onCancel={() => setProjectQuotaEditVisible(false)}
+            onOk={(result) =>
+              updatePrj(result).then(() => {
+                setProjectQuotaEditVisible(false);
+                setProjectQuotaSaveDisabled(true);
+              })
+            }
+            onCancel={() => {
+              setProjectQuotaEditVisible(false);
+              setProjectQuotaSaveDisabled(true);
+            }}
             name={i18n.t('dop:project quota')}
             visible={projectQuotaEditVisible}
             fieldsList={fieldsListQuota}
             formData={{ ...info, isPublic: `${info.isPublic || 'false'}` }}
+            okButtonState={projectQuotaSaveDisabled}
+            onValuesChange={() => {
+              setProjectQuotaSaveDisabled(false);
+            }}
           />
         </>
       )}
@@ -421,22 +436,44 @@ const Info = () => {
       </Card>
 
       <FormModal
-        onOk={(result) => updatePrj(result).then(() => setProjectInfoEditVisible(false))}
-        onCancel={() => setProjectInfoEditVisible(false)}
+        onOk={(result) =>
+          updatePrj(result).then(() => {
+            setProjectInfoEditVisible(false);
+            setProjectInfoSaveDisabled(true);
+          })
+        }
+        onCancel={() => {
+          setProjectInfoEditVisible(false);
+          setProjectInfoSaveDisabled(true);
+        }}
         name={i18n.t('dop:project info')}
         visible={projectInfoEditVisible}
         fieldsList={fieldsListInfo}
         formData={{ ...info, isPublic: `${info.isPublic || 'false'}` }}
+        okButtonState={projectInfoSaveDisabled}
+        onValuesChange={() => {
+          setProjectInfoSaveDisabled(false);
+        }}
       />
       <FormModal
         onOk={(result) =>
-          updateProject({ ...result, isPublic: info.isPublic }).then(() => setProjectRollbackEditVisible(false))
+          updateProject({ ...result, isPublic: info.isPublic }).then(() => {
+            setProjectRollbackEditVisible(false);
+            setProjectRollbackSaveDisabled(true);
+          })
         }
-        onCancel={() => setProjectRollbackEditVisible(false)}
+        onCancel={() => {
+          setProjectRollbackEditVisible(false);
+          setProjectRollbackSaveDisabled(true);
+        }}
         name={i18n.t('dop:rollback point')}
         visible={projectRollbackEditVisible}
         fieldsList={fieldsListRollback}
         formData={{ rollbackConfig: configData }}
+        okButtonState={projectRollbackSaveDisabled}
+        onValuesChange={() => {
+          setProjectRollbackSaveDisabled(false);
+        }}
       />
     </div>
   );

--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -50,10 +50,10 @@ interface IItemProps {
 }
 const FormItem = Form.Item;
 class SectionInfoEdit extends React.Component<IProps, IState> {
-  state = { modalVisible: false };
+  state = { modalVisible: false, saveDisabled: true };
 
   toggleModal = () => {
-    this.setState({ modalVisible: !this.state.modalVisible });
+    this.setState({ modalVisible: !this.state.modalVisible, saveDisabled: true });
     this.props.setCanGetClusterListAndResources?.(!this.state.modalVisible);
   };
 
@@ -131,7 +131,7 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
   };
 
   render() {
-    const { modalVisible } = this.state;
+    const { modalVisible, saveDisabled } = this.state;
     const { data, fieldsList, hasAuth, readonlyForm, name, desc, formName, extraSections } = this.props;
     let sectionList = [
       {
@@ -160,6 +160,10 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
           onOk={this.handleSubmit}
           onCancel={this.toggleModal}
           modalProps={{ destroyOnClose: true }}
+          okButtonState={saveDisabled}
+          onValuesChange={() => {
+            this.setState({ saveDisabled: false });
+          }}
         />
       </React.Fragment>
     );


### PR DESCRIPTION
## What this PR does / why we need it:
Project edit save button disabled by default.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The save button for project editing is disabled by default, only enabled when the form value changes. |
| 🇨🇳 中文    | 项目编辑的保存按钮默认禁用，表单值变化后才启用。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=275782&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

