### PR TITLE
fix(common): config page list operations bug

### DIFF
--- a/shell/app/config-page/components/list-new/list-new.tsx
+++ b/shell/app/config-page/components/list-new/list-new.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { isNumber, filter, map, sortBy, cloneDeep } from 'lodash';
+import { isNumber, filter, map, sortBy } from 'lodash';
 import { useUpdate } from 'common/use-hooks';
 import { OperationAction } from 'config-page/utils';
 import { containerMap } from '../../components';
@@ -170,7 +170,7 @@ const List = (props: CP_LIST_NEW.Props) => {
           onClick={() => {
             execOperation(action);
             if (customOp && customOp[action.key]) {
-              customOp[action.key](cloneDeep(action), data);
+              customOp[action.key](action, data);
             }
           }}
         >

--- a/shell/app/config-page/components/list-new/list-new.tsx
+++ b/shell/app/config-page/components/list-new/list-new.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { isNumber, filter, map, sortBy } from 'lodash';
+import { isNumber, filter, map, sortBy, cloneDeep } from 'lodash';
 import { useUpdate } from 'common/use-hooks';
 import { OperationAction } from 'config-page/utils';
 import { containerMap } from '../../components';
@@ -170,7 +170,7 @@ const List = (props: CP_LIST_NEW.Props) => {
           onClick={() => {
             execOperation(action);
             if (customOp && customOp[action.key]) {
-              customOp[action.key](action, data);
+              customOp[action.key](cloneDeep(action), data);
             }
           }}
         >

--- a/shell/app/modules/cmp/pages/cluster-manage/add-cluster-forms/cluster-form.tsx
+++ b/shell/app/modules/cmp/pages/cluster-manage/add-cluster-forms/cluster-form.tsx
@@ -306,6 +306,11 @@ interface IProps {
   clusterType: string;
 }
 
+interface FormData {
+  credentialType: string;
+  credential: { address: string };
+}
+
 export const AddClusterModal = (props: IProps) => {
   const { initData, toggleModal, visible, onSubmit, clusterList, clusterType } = props;
   const handleSubmit = (values: any) => {
@@ -324,11 +329,14 @@ export const AddClusterModal = (props: IProps) => {
     toggleModal();
   };
 
+  const formData: FormData = (initData && { ...initData }) || ({} as FormData);
+
   if (TYPE_K8S_AND_EDAS.includes(clusterType) && initData) {
     const { manageConfig } = initData as Obj;
     const { credentialSource, address } = manageConfig || {};
-    set(initData, 'credentialType', credentialSource);
-    set(initData, 'credential.address', address);
+
+    formData.credentialType = credentialSource;
+    formData.credential = { ...formData.credential, address };
   }
 
   return (
@@ -339,7 +347,7 @@ export const AddClusterModal = (props: IProps) => {
       })}
       title={
         clusterType === 'k8s'
-          ? initData
+          ? formData
             ? i18n.t('dop:edit cluster configuration')
             : i18n.t('cmp:import an existing Erda {type} cluster', { type: 'Kubernetes' })
           : undefined
@@ -348,7 +356,7 @@ export const AddClusterModal = (props: IProps) => {
       onOk={handleSubmit}
       onCancel={() => toggleModal(true)}
       PureForm={ClusterAddForm}
-      formData={initData}
+      formData={formData}
       clusterList={clusterList}
       clusterType={clusterType}
       modalProps={{


### PR DESCRIPTION
## What this PR does / why we need it:
Fix config page list operations bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed an issue where the Record object in the list operation event of a componentized protocol was a read-only object. |
| 🇨🇳 中文    |  修复了组件化协议的列表操作事件中，接受参数中的record对象是只读对象的问题。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

