### PR TITLE
fix(dop): get options when opening issue detail

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -54,7 +54,6 @@ import { IssueTestCaseRelation } from './issue-testCase-relation';
 import { FIELD_WITH_OPTION, FIELD_TYPE_ICON_MAP } from 'org/common/config';
 import { produce } from 'immer';
 import issueFieldStore from 'org/stores/issue-field';
-import projectLabelStore from 'project/stores/label';
 import orgStore from 'app/org-home/stores/org';
 import { templateMap } from 'project/common/issue-config';
 
@@ -96,6 +95,7 @@ const { getLabels } = labelStore.effects;
 const IssueMetaFields = React.forwardRef(
   ({ labels, isEditMode, isBacklog, editAuth, issueType, formData, setFieldCb, projectId, ticketType }: any, ref) => {
     const userMap = getUserMap();
+    const { id: orgID } = orgStore.useStore((s) => s.currentOrg);
     const projectMembers = projectMemberStore.useStore((s) => s.list);
     const urlParams = routeInfoStore.useStore((s) => s.params);
     // const isRequirement = issueType === ISSUE_TYPE.REQUIREMENT;
@@ -147,6 +147,8 @@ const IssueMetaFields = React.forwardRef(
 
     useMount(() => {
       getLabels({ type: 'issue', projectID: Number(projectId) });
+      issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'BUG' });
+      issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'TASK' });
       if (!iterationList.length && !isBacklog) {
         iterationStore.effects.getIterations({
           pageNo: 1,
@@ -719,9 +721,6 @@ export const EditIssueDrawer = (props: IProps) => {
         getIssueStreams({ type: issueType, id, pageNo: 1, pageSize: 50 });
         getCustomFields();
       }
-      projectLabelStore.effects.getLabels({ type: 'issue' });
-      issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'BUG' });
-      issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'TASK' });
       getCustomFieldsByProject({
         propertyIssueType: issueType,
         orgID,
@@ -733,8 +732,6 @@ export const EditIssueDrawer = (props: IProps) => {
           issueID: undefined,
         });
       });
-    } else {
-      projectLabelStore.reducers.clearList();
     }
   }, [
     addRelatedMattersProjectId,

--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer.tsx
@@ -54,6 +54,7 @@ import { IssueTestCaseRelation } from './issue-testCase-relation';
 import { FIELD_WITH_OPTION, FIELD_TYPE_ICON_MAP } from 'org/common/config';
 import { produce } from 'immer';
 import issueFieldStore from 'org/stores/issue-field';
+import projectLabelStore from 'project/stores/label';
 import orgStore from 'app/org-home/stores/org';
 import { templateMap } from 'project/common/issue-config';
 
@@ -718,6 +719,9 @@ export const EditIssueDrawer = (props: IProps) => {
         getIssueStreams({ type: issueType, id, pageNo: 1, pageSize: 50 });
         getCustomFields();
       }
+      projectLabelStore.effects.getLabels({ type: 'issue' });
+      issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'BUG' });
+      issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'TASK' });
       getCustomFieldsByProject({
         propertyIssueType: issueType,
         orgID,
@@ -729,6 +733,8 @@ export const EditIssueDrawer = (props: IProps) => {
           issueID: undefined,
         });
       });
+    } else {
+      projectLabelStore.reducers.clearList();
     }
   }, [
     addRelatedMattersProjectId,

--- a/shell/app/modules/project/stores/issues.ts
+++ b/shell/app/modules/project/stores/issues.ts
@@ -147,18 +147,6 @@ const DETAIL_KEY_MAP = {
 const issueStore = createStore({
   name: 'issues',
   state: initState,
-  subscriptions({ listenRoute }: IStoreSubs) {
-    listenRoute(({ isEntering, isLeaving }) => {
-      if (isEntering('issues')) {
-        projectLabelStore.effects.getLabels({ type: 'issue' });
-        const orgID = orgStore.getState((s) => s.currentOrg.id);
-        issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'BUG' });
-        issueFieldStore.effects.getSpecialFieldOptions({ orgID, issueType: 'TASK' });
-      } else if (isLeaving('issues')) {
-        projectLabelStore.reducers.clearList();
-      }
-    });
-  },
   effects: {
     async getAllIssues({ call, update, select, getParams }, payload: ISSUE.IGetIssueQuery) {
       const { projectId: projectID, iterationId: iterationID } = getParams();


### PR DESCRIPTION
## What this PR does / why we need it:
Get options when opening issue detail.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Get options when opening issue detail. |
| 🇨🇳 中文    | 在打开协同详情时获取下拉选项。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=273037&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1090&type=BUG

