### PR TITLE
fix(common): left menu background color bug

### DIFF
--- a/shell/app/layout/pages/page-container/components/sidebar/index.scss
+++ b/shell/app/layout/pages/page-container/components/sidebar/index.scss
@@ -92,7 +92,7 @@
   }
 }
 
-.side-nav-menu {
+div.side-nav-menu {
   display: flex;
   flex-direction: column;
   position: relative;


### PR DESCRIPTION
## What this PR does / why we need it:
Fix left menu background color bug

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/152937887-f596395e-4e46-4b65-b3fe-8ddc13f00ded.png)
->
![image](https://user-images.githubusercontent.com/82502479/152937843-64def13f-4559-47be-b51a-c3b6decd94c0.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix left menu background color bug. |
| 🇨🇳 中文    | 修复了左侧菜单背景色的bug。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

