### PR TITLE
fix(dop): notify edit display bug

### DIFF
--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -397,6 +397,23 @@ interface SelectCompProps {
 
 const SelectComp = ({ value, onChange, options, size, optionRender, ...restItemProps }: SelectCompProps) => {
   const fixOptions = (typeof options === 'function' ? options() : options)?.filter?.((item: IOption) => item.fix) || [];
+  const typeErrorOptions =
+    value &&
+    (typeof options === 'function' ? options() : options).find((item: IOption) => {
+      if (Array.isArray(value)) {
+        return value.find((val) => typeof val !== typeof item.value);
+      } else {
+        return typeof item.value !== typeof value;
+      }
+    });
+
+  if (typeErrorOptions) {
+    console.error(
+      'Warning: The value type accepted by the select does not match the value type of the options, The options that have the wrong value are: ',
+      typeErrorOptions,
+    );
+  }
+
   return (
     <Select
       {...restItemProps}

--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -397,21 +397,10 @@ interface SelectCompProps {
 
 const SelectComp = ({ value, onChange, options, size, optionRender, ...restItemProps }: SelectCompProps) => {
   const fixOptions = (typeof options === 'function' ? options() : options)?.filter?.((item: IOption) => item.fix) || [];
-  const typeErrorOptions =
-    value &&
-    (typeof options === 'function' ? options() : options).find((item: IOption) => {
-      if (Array.isArray(value)) {
-        return value.find((val) => typeof val !== typeof item.value);
-      } else {
-        return typeof item.value !== typeof value;
-      }
-    });
-
-  if (typeErrorOptions) {
-    console.error(
-      'Warning: The value type accepted by the select does not match the value type of the options, The options that have the wrong value are: ',
-      typeErrorOptions,
-    );
+  const optionType = typeof (typeof options === 'function' ? options() : options)[0]?.value;
+  const valueType = typeof (Array.isArray(value) ? value[0] : value);
+  if (optionType !== 'undefined' && valueType !== 'undefined' && optionType !== valueType) {
+    console.error('Warning: The value type accepted by the select does not match the value type of the options.');
   }
 
   return (

--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -400,7 +400,12 @@ const SelectComp = ({ value, onChange, options, size, optionRender, ...restItemP
   const optionType = typeof (typeof options === 'function' ? options() : options)[0]?.value;
   const valueType = typeof (Array.isArray(value) ? value[0] : value);
   if (optionType !== 'undefined' && valueType !== 'undefined' && optionType !== valueType) {
-    console.error('Warning: The value type accepted by the select does not match the value type of the options.');
+    console.error(
+      'Warning: The value type accepted by the select does not match the value type of the options.The wrong options is ',
+      options,
+      '. The value is',
+      value,
+    );
   }
 
   return (

--- a/shell/app/modules/application/pages/settings/components/app-notify/notify-config.tsx
+++ b/shell/app/modules/application/pages/settings/components/app-notify/notify-config.tsx
@@ -103,7 +103,7 @@ export const NotifyConfig = ({ commonPayload, memberStore }: IProps) => {
     setActivedData({
       id,
       name,
-      notifyItemIds: map(items, ({ id: notifyItemId }) => `${notifyItemId}`),
+      notifyItemIds: map(items, ({ id: notifyItemId }) => notifyItemId),
       notifyGroupId,
       channels: channels.split(','),
     });


### PR DESCRIPTION
## What this PR does / why we need it:
Fix notify edit display bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/152946717-94904af6-8191-42a7-9134-d6459c560c75.png)
->
![image](https://user-images.githubusercontent.com/82502479/152946572-b27301cc-d82b-4c95-9bb6-6e7bad3e1acb.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed display issues when notifying editors. |
| 🇨🇳 中文    |   修复了通知编辑时的显示问题。   |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

