### PR TITLE
fix: fix filter style in select dropdown

### DIFF
--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -107,7 +107,8 @@ const defaultProcessField = (item: IFormItem) => {
       allowClear: true,
       suffixIcon: <ErdaIcon type="caret-down" color="currentColor" className="text-white-4" />,
       clearIcon: <span className="p-1">{i18n.t('common:clear')}</span>,
-      getPopupContainer: (triggerNode: HTMLElement) => triggerNode.parentElement as HTMLElement,
+      getPopupContainer: () => document.body,
+      dropdownClassName: `${itemProps?.dropdownClassName || ''} theme-dark`,
     };
 
     if (type === 'select') {

--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -397,7 +397,7 @@ interface SelectCompProps {
 
 const SelectComp = ({ value, onChange, options, size, optionRender, ...restItemProps }: SelectCompProps) => {
   const fixOptions = (typeof options === 'function' ? options() : options)?.filter?.((item: IOption) => item.fix) || [];
-  const optionType = typeof (typeof options === 'function' ? options() : options)[0]?.value;
+  const optionType = typeof (typeof options === 'function' ? options() : options)?.[0]?.value;
   const valueType = typeof (Array.isArray(value) ? value[0] : value);
   if (optionType !== 'undefined' && valueType !== 'undefined' && optionType !== valueType) {
     console.error(

--- a/shell/app/styles/antd-extension.scss
+++ b/shell/app/styles/antd-extension.scss
@@ -568,7 +568,7 @@ body {
       }
 
       .ant-select-item-option-state {
-        color: $color-purple-deep;
+        color: $color-purple-highlight;
       }
 
       .rc-virtual-list-holder {


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix filter style in select dropdown

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
before
![image](https://user-images.githubusercontent.com/15364706/153120782-f97f875c-0d82-4e11-b370-9e97a44405a7.png)

after
![image](https://user-images.githubusercontent.com/15364706/153120830-d5ed7729-14eb-4ea5-8287-09f21c6bcd85.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: fix filter style in select dropdown            |
| 🇨🇳 中文    |   fix: 修复筛选器select下拉样式           |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

