### PR TITLE
fix(common): change Chinese translation of backlog

### DIFF
--- a/shell/app/config-page/components/table/render-types.tsx
+++ b/shell/app/config-page/components/table/render-types.tsx
@@ -285,9 +285,9 @@ export const getRender = (val: any, record: CP_TABLE.RowData, extra: any) => {
               return (
                 <div>
                   {displayValue.map((item) => {
-                    const { avatar, nick, name } = item;
+                    const { avatar, nick, name, id } = item;
                     return (
-                      <div>
+                      <div key={id}>
                         <Avatar src={avatar} size="small">
                           {nick ? getAvatarChars(nick) : i18n.t('none')}
                         </Avatar>

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -1009,7 +1009,7 @@
     "auto test": "自动化测试",
     "auto-push-after-relate": "关联发布内容后，将自动推送版本到该内容",
     "automatic test report": "自动化测试报告",
-    "backlog": "待处理",
+    "backlog": "待规划",
     "backup": "备份",
     "based on source": "基于源",
     "basic edition": "基础版",

--- a/shell/app/modules/project/common/components/issue/subscribers-selector.tsx
+++ b/shell/app/modules/project/common/components/issue/subscribers-selector.tsx
@@ -153,7 +153,7 @@ export const SubscribersSelector = (props: IProps) => {
             {subscribers.map((item) => {
               const user = usersMap[item] || {};
               return (
-                <div key={user.id}>
+                <div key={user.userId}>
                   <Avatar src={user.avatar} size="small">
                     {user.nick ? getAvatarChars(user.nick) : i18n.t('none')}
                   </Avatar>


### PR DESCRIPTION
## What this PR does / why we need it:
Change Chinese translation of backlog.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/153135542-a1c5e96f-ef80-4ada-bbd9-d9d4eddf0d02.png)
->
![image](https://user-images.githubusercontent.com/82502479/153135514-1b625853-5c01-4459-afeb-7cca13475971.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Text "待处理" changed to "待规划".  |
| 🇨🇳 中文    | 文案“待处理”改为“待规划”。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

