### PR TITLE
fix(dop): release version name checking rule change

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -184,7 +184,7 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
         { required: true, message: i18n.t('please enter {name}', { name: i18n.t('version') }) },
         { max: 30, message: i18n.t('dop:no more than 30 characters') },
         {
-          pattern: /^[A-Za-z0-9._-]+$/,
+          pattern: /^[A-Za-z0-9._+-]+$/,
           message: i18n.t('dop:Must be composed of letters, numbers, underscores, hyphens and dots.'),
         },
         {


### PR DESCRIPTION
## What this PR does / why we need it:
Release version name checking rule change.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Add "+" to verification rule of item - level product version name. |
| 🇨🇳 中文    | 项目级制品版本名称校验规则增加“+”。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

