### PR TITLE
fix(common): table reload and config button add hover style

### DIFF
--- a/shell/app/common/components/table/index.scss
+++ b/shell/app/common/components/table/index.scss
@@ -143,6 +143,20 @@
     .no-label .ant-form-item-label {
       display: none;
     }
+
+    &-ops {
+      iconpark-icon {
+        color: $color-default-4;
+        cursor: pointer;
+        font-size: 20px;
+        padding: 4px;
+        margin-left: 12px;
+        &:hover {
+          background-color: $color-default-08;
+          color: $color-default-8;
+        }
+      }
+    }
   }
 
   .erda-table-columns-filter {

--- a/shell/app/config-page/components/table/table.tsx
+++ b/shell/app/config-page/components/table/table.tsx
@@ -136,6 +136,12 @@ export function Table(props: CP_TABLE.Props) {
     };
   }
 
+  if (operations?.reload) {
+    extra.onReload = () => {
+      execOperation(operations.reload);
+    };
+  }
+
   if (configProps?.expandedProps) {
     const { rowKey, columns: exColumns } = configProps.expandedProps || {};
     const exTableColumns = map([...(exColumns || [])], (cItem) => ({


### PR DESCRIPTION
## What this PR does / why we need it:
- Table reload and config button add hover style.
- In config page, table add reload operations.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/153330168-5bf09855-87b8-477a-bf85-310ea1382ff7.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | The table header button adds a floating background color. |
| 🇨🇳 中文    |  表格头部按钮增加悬浮背景色。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

