### PR TITLE
fix: disable markdown editor underline plugin

### DIFF
--- a/shell/app/common/components/markdown-editor/editor.tsx
+++ b/shell/app/common/components/markdown-editor/editor.tsx
@@ -67,6 +67,27 @@ const Editor = React.forwardRef((props: IProps, ref) => {
       ref={ref}
       style={{ height: `${defaultHeight}px`, ...style }}
       {...restEditorProps}
+      plugins={[
+        'header',
+        'font-bold',
+        'font-italic',
+        // 'font-underline',
+        'font-strikethrough',
+        'list-unordered',
+        'list-ordered',
+        'block-quote',
+        'block-wrap',
+        'block-code-inline',
+        'block-code-block',
+        'table',
+        'image',
+        'link',
+        'clear',
+        'logger',
+        'mode-toggle',
+        'full-screen',
+        'upload',
+      ]}
       config={config}
       htmlClass="md-content"
       renderHTML={(text: string) => <MarkdownRender value={text} />}

--- a/shell/app/styles/antd-extension.scss
+++ b/shell/app/styles/antd-extension.scss
@@ -511,6 +511,9 @@ body {
   .ant-avatar {
     background-color: rgb(89, 81, 108);
   }
+  .ant-avatar-image {
+    background: transparent;
+  }
 
   .ant-radio-group.ant-radio-group-solid {
     .ant-radio-button-wrapper {


### PR DESCRIPTION
## What this PR does / why we need it:
disable markdown editor underline plugin for not support syntax
update image avatar background to transparent

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/3955437/153354706-feec7ae7-5664-4231-b0f8-6dccf7897229.png)
![image](https://user-images.githubusercontent.com/3955437/153354827-7fe08f0e-bb1d-42c2-ab5e-2ca92c1ac2aa.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  disable markdown editor underline plugin for not support syntax   |
| 🇨🇳 中文    |  禁用 markdown 编辑器的下划线插件    |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

