### PR TITLE
fix: always position to today after filter in gantt

### DIFF
--- a/shell/app/config-page/components/gantt/components/gantt/gantt.tsx
+++ b/shell/app/config-page/components/gantt/components/gantt/gantt.tsx
@@ -75,6 +75,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
   onSelect,
   onExpanderClick,
   onScreenChange,
+  positionToTodayKey,
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const taskListRef = useRef<HTMLDivElement>(null);
@@ -242,6 +243,10 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
       positionToTodayAtInit.current = true;
     }
   }, [h_number, scrollToToday]);
+
+  React.useEffect(() => {
+    scrollToToday();
+  }, [positionToTodayKey, scrollToToday]);
 
   // useEffect(() => {
   //   if (wrapperRef.current) {

--- a/shell/app/config-page/components/gantt/gantt.tsx
+++ b/shell/app/config-page/components/gantt/gantt.tsx
@@ -151,6 +151,7 @@ const CP_Gantt = (props: CP_GANTT.Props) => {
     listCellWidth = '320px',
     rootWrapper,
     onScreenChange,
+    positionToTodayKey,
   } = pProps;
   const boxRef = React.useRef<HTMLDivElement>();
   const [ganttHeight, setGanttHeight] = React.useState(0);
@@ -225,6 +226,7 @@ const CP_Gantt = (props: CP_GANTT.Props) => {
           onScreenChange={onScreenChange}
           TaskListHeader={TaskListHeader}
           listCellWidth={listCellWidth}
+          positionToTodayKey={positionToTodayKey}
           TaskListTable={(p) => <TaskTree {...p} TreeNodeRender={TreeNodeRender} />}
         />
       ) : (

--- a/shell/app/config-page/components/gantt/types/public-types.ts
+++ b/shell/app/config-page/components/gantt/types/public-types.ts
@@ -153,4 +153,5 @@ export interface StylingOption {
 
 export interface GanttProps extends EventOption, DisplayOption, StylingOption {
   tasks: Task[];
+  positionToTodayKey?: number;
 }

--- a/shell/app/config-page/index.tsx
+++ b/shell/app/config-page/index.tsx
@@ -218,9 +218,10 @@ const ConfigPage = React.forwardRef((props: IProps, ref: any) => {
             },
           };
         });
+        // execute callback before, to update outside props before next render
+        operationCallBack?.(reqConfig, newConfig, op);
         updateConfig ? updateConfig(newConfig) : updater.pageConfig(newConfig);
         pageConfigRef.current = newConfig;
-        operationCallBack?.(reqConfig, newConfig, op);
         callBack?.(newConfig);
 
         if (op?.successMsg) notify('success', op.successMsg);

--- a/shell/app/modules/project/pages/issue/gantt/index.tsx
+++ b/shell/app/modules/project/pages/issue/gantt/index.tsx
@@ -148,6 +148,7 @@ const IssuePlan = () => {
     isFullScreen: false,
   });
   const ganttRef = React.useRef<HTMLDivElement>(null);
+  const positionToTodayKey = React.useRef(1);
 
   const onChosenIssue = (val: Obj) => {
     const { id, extra, pId } = val || {};
@@ -232,6 +233,13 @@ const IssuePlan = () => {
     updater.isFullScreen(value);
   };
 
+  const operationCallBack = (config: CONFIG_PAGE.RenderConfig) => {
+    const curEvent = config.event;
+    if (curEvent?.component === 'filter' && curEvent?.operation === 'filter') {
+      positionToTodayKey.current += 1;
+    }
+  };
+
   return (
     <div className={`h-full bg-white ${isFullScreen ? 'gantt-fullscreen' : ''}`} ref={ganttRef}>
       <DiceConfigPage
@@ -240,6 +248,7 @@ const IssuePlan = () => {
         scenarioType={'issue-gantt'}
         scenarioKey={'issue-gantt'}
         inParams={inParams}
+        operationCallBack={operationCallBack}
         customProps={{
           topHead: {
             props: {
@@ -259,6 +268,7 @@ const IssuePlan = () => {
               TreeNodeRender: (p) => <TreeNodeRender {...p} clickNode={onChosenIssue} />,
               onScreenChange: handleScreenChange,
               rootWrapper: ganttRef,
+              positionToTodayKey: positionToTodayKey.current,
             },
           },
           issueAddButton: {


### PR DESCRIPTION
## What this PR does / why we need it:
fix: always position to today after filter

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: always position to today after filter in gantt  |
| 🇨🇳 中文    |   甘特图中搜索后总是定位到今天   |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

