### PR TITLE
fix: repo file is notfound when refresh page

### DIFF
--- a/scheduler/src/filters/not-found.filter.ts
+++ b/scheduler/src/filters/not-found.filter.ts
@@ -60,7 +60,7 @@ export class NotFoundExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>();
     const response = ctx.getResponse<Response>();
     const extension = path.extname(request.path);
-    if (!extension || request.path.match(/^\/\w+\/dop\/projects\/\d+\/apps\/\d+\/repo/)) {
+    if (!extension || request.path.match(/^\/[\w-]+\/dop\/projects\/\d+\/apps\/\d+\/repo/)) {
       response.setHeader('cache-control', 'no-store');
       if (process.env.DEV) {
         if (!fs.existsSync(newIndexHtmlPath)) {


### PR DESCRIPTION
## What this PR does / why we need it:
org name may have "-", current proxy regexp is not match.



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | repo file is notfound when refresh page |
| 🇨🇳 中文    |   在代码仓库文件页面刷新后展示 notfound  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

