### PR TITLE
fix(dop): export issue not pass filter params in kanban page

### DIFF
--- a/shell/app/modules/project/pages/issue/board.tsx
+++ b/shell/app/modules/project/pages/issue/board.tsx
@@ -220,7 +220,7 @@ const IssueProtocol = ({ issueType: propsIssueType }: { issueType: string }) => 
     />
   );
   const pageData = reloadRef.current?.getPageConfig();
-  const useableFilterObj = pageData?.protocol?.state?.IssuePagingRequest || {};
+  const useableFilterObj = pageData?.protocol?.components?.IssuePagingRequestKanban || {};
 
   const tabs = [
     {


### PR DESCRIPTION
## What this PR does / why we need it:
fix: export issue not pass filter params in kanban page

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: export issue not pass filter params in kanban page  |
| 🇨🇳 中文    |  看板页面导出事项时没有带上过滤参数  |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

