### PR TITLE
fix: card component crashed in gallery page

### DIFF
--- a/shell/app/config-page/components/card/card.mock.ts
+++ b/shell/app/config-page/components/card/card.mock.ts
@@ -14,19 +14,53 @@
 const mockData: CP_CARD.Spec = {
   type: 'Card',
   props: {
-    data: {
-      a: {
-        id: 'id',
-        titleIcon: 'titleIcon',
-        title: 'title',
-        // operations: Obj<CP_COMMON.Operation>,
-        subContent: 'subContent',
-        description: 'description',
-        extraInfo: {},
-        type: 'type',
-      },
-    },
     cardType: 'string',
+  },
+  data: {
+    title: '标题',
+    titleSummary: '标题描述',
+    cards: [
+      {
+        id: 'id',
+        icon: 'unlock',
+        star: true,
+        title: 'title',
+        extraInfo: {},
+        titleState: [
+          {
+            status: 'success',
+            text: 'success',
+          },
+        ],
+        textMeta: [
+          {
+            mainText: 'mainText',
+            subText: 'subText',
+          },
+        ],
+        iconOperations: [],
+      },
+      {
+        id: 'id',
+        icon: 'lock',
+        star: true,
+        title: 'title',
+        extraInfo: {},
+        titleState: [
+          {
+            status: 'error',
+            text: 'error',
+          },
+        ],
+        textMeta: [
+          {
+            mainText: 'mainText',
+            subText: 'subText',
+          },
+        ],
+        iconOperations: [],
+      },
+    ],
   },
 };
 

--- a/shell/app/config-page/components/card/card.tsx
+++ b/shell/app/config-page/components/card/card.tsx
@@ -180,7 +180,7 @@ export const CardItem = (props: CardItemProps) => {
 };
 
 export const Card = (props: CP_CARD.Props) => {
-  const { props: configProps, execOperation = noop, customOp = {}, data } = props;
+  const { props: configProps, execOperation = noop, customOp = {}, data = {} } = props;
   const {
     cardType = 'cp-card',
     className = '',

--- a/shell/app/modules/project/router.tsx
+++ b/shell/app/modules/project/router.tsx
@@ -143,6 +143,7 @@ function getProjectRouter(): RouteConfigItem[] {
                       getComp: (cb) => cb(import('project/pages/issue/gantt')),
                       layout: {
                         fullHeight: true,
+                        noWrapper: true,
                       },
                     },
                     {


### PR DESCRIPTION
## What this PR does / why we need it:
fix: card component crashed in gallery page

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: card component crashed in gallery page   |
| 🇨🇳 中文    |   修复卡片组件在组件预览页崩溃的问题  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

