### PR TITLE
fix(dop): pipeline build detail release link change to project releas…

### DIFF
--- a/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
+++ b/shell/app/modules/application/pages/pipeline/run-detail/build-detail.tsx
@@ -300,7 +300,11 @@ const BuildDetail = (props: IProps) => {
       case 'release-link': {
         const target = node.findInMeta((item: BUILD.MetaData) => item.name === 'releaseID');
         if (target) {
-          goTo(goTo.pages.release, { appId: query.applicationId, ...params, q: target.value, jumpOut: true });
+          goTo(goTo.pages.applicationReleaseDetail, {
+            ...params,
+            releaseId: target.value,
+            jumpOut: true,
+          });
         }
         break;
       }


### PR DESCRIPTION
…e detail

## What this PR does / why we need it:
pipeline build detail release link change to project release detail

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  The artifact link in the pipeline execution details has been changed to jump to project-level artifact details. |
| 🇨🇳 中文    | 流水线执行明细中制品链接改为跳转到项目级制品详情。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

