### PR TITLE
fix: rename list-item class to prevent misused with tailwind

### DIFF
--- a/shell/app/config-page/components/kanban/kanban.scss
+++ b/shell/app/config-page/components/kanban/kanban.scss
@@ -106,7 +106,7 @@
       }
     }
 
-    .list-item {
+    .kanban-list-item {
       margin-bottom: 12px;
       background-color: $white;
       border-radius: $radius;

--- a/shell/app/config-page/components/kanban/kanban.tsx
+++ b/shell/app/config-page/components/kanban/kanban.tsx
@@ -379,7 +379,9 @@ const PureKanban = (props: IKanbanProps) => {
               CardRender={CardRender}
               cardType={cardType}
               draggable={curDragOp && !curDragOp.disabled}
-              className={`${isDrag ? 'hidden' : ''} list-item ${currentCard?.id === item.id ? 'dragged-card' : ''}`}
+              className={`${isDrag ? 'hidden' : ''} kanban-list-item ${
+                currentCard?.id === item.id ? 'dragged-card' : ''
+              }`}
               setIsDrag={setIsDrag}
               onClick={() => {
                 rest?.customOp?.clickCard?.(item);

--- a/shell/app/modules/application/pages/build/build.scss
+++ b/shell/app/modules/application/pages/build/build.scss
@@ -37,12 +37,6 @@
       height: 102px;
     }
 
-    .list-item {
-      flex-direction: column;
-      align-items: flex-start;
-      width: 100%;
-    }
-
     .iconfont {
       vertical-align: baseline;
     }

--- a/shell/app/modules/application/pages/build/build.tsx
+++ b/shell/app/modules/application/pages/build/build.tsx
@@ -282,7 +282,7 @@ export const Build = (props: IProps) => {
           });
           return (
             <div key={pipelineID} className={cls} {...liProps}>
-              <div className="list-item flex justify-between items-center">
+              <div className="w-full flex flex-col justify-between items-center">
                 <div className="title flex justify-between items-center">
                   <Tooltip title={toolTipName} overlayClassName="commit-tip">
                     <span className="branch-name font-medium nowrap">

--- a/shell/app/modules/org/pages/projects/issue-field-setting-modal.tsx
+++ b/shell/app/modules/org/pages/projects/issue-field-setting-modal.tsx
@@ -120,34 +120,32 @@ export const IssueFieldSettingModal = ({ visible, issueType = 'EPIC', closeModal
         const isLast = index === fieldList.length - 1;
         return (
           <div className="panel" key={propertyName}>
-            <div className="common-list-item">
-              <div className="list-item">
-                <div className="flex justify-between items-center">
-                  <div className="nowrap flex items-center justify-start">
-                    {renderFieldItem({ displayName, propertyType })}
-                  </div>
-                  <div className="table-operations">
-                    <Popconfirm
-                      title={`${i18n.t('dop:confirm to remove the quote?')}`}
-                      onConfirm={() => {
-                        onDelete(propertyID);
-                      }}
-                    >
-                      <span className="table-operations-btn">{i18n.t('remove')}</span>
-                    </Popconfirm>
-                    <span
-                      className={`table-operations-btn ${isFirst ? 'disabled' : ''}`}
-                      onClick={() => !isFirst && changePos(index, -1)}
-                    >
-                      {i18n.t('move up')}
-                    </span>
-                    <span
-                      className={`table-operations-btn ${isLast ? 'disabled' : ''}`}
-                      onClick={() => !isLast && changePos(index, 1)}
-                    >
-                      {i18n.t('move down')}
-                    </span>
-                  </div>
+            <div className="border-bottom px-4 py-2">
+              <div className="flex justify-between items-center">
+                <div className="nowrap flex items-center justify-start">
+                  {renderFieldItem({ displayName, propertyType })}
+                </div>
+                <div className="table-operations">
+                  <Popconfirm
+                    title={`${i18n.t('dop:confirm to remove the quote?')}`}
+                    onConfirm={() => {
+                      onDelete(propertyID);
+                    }}
+                  >
+                    <span className="table-operations-btn">{i18n.t('remove')}</span>
+                  </Popconfirm>
+                  <span
+                    className={`table-operations-btn ${isFirst ? 'disabled' : ''}`}
+                    onClick={() => !isFirst && changePos(index, -1)}
+                  >
+                    {i18n.t('move up')}
+                  </span>
+                  <span
+                    className={`table-operations-btn ${isLast ? 'disabled' : ''}`}
+                    onClick={() => !isLast && changePos(index, 1)}
+                  >
+                    {i18n.t('move down')}
+                  </span>
                 </div>
               </div>
             </div>

--- a/shell/app/modules/project/common/components/issue/issue-drawer.scss
+++ b/shell/app/modules/project/common/components/issue/issue-drawer.scss
@@ -127,15 +127,6 @@
     width: 100% !important;
   }
 
-  .list-item {
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    .ant-checkbox-checked::after {
-      height: 16px;
-    }
-  }
-
   .ant-checkbox-inner {
     display: inline-block;
   }


### PR DESCRIPTION
## What this PR does / why we need it:
fix: rename list-item class to prevent misused with tailwind

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix: rename list-item class to prevent misused with tailwind    |
| 🇨🇳 中文    |   重命名 list-item 样式类避免被 tailwind 加上错误样式   |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

