### PR TITLE
fix: line break in markdown render code block

### DIFF
--- a/shell/app/common/components/markdown-render/index.tsx
+++ b/shell/app/common/components/markdown-render/index.tsx
@@ -22,6 +22,7 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { CodeComponent } from 'react-markdown/lib/ast-to-react';
+import github from 'react-syntax-highlighter/dist/esm/styles/hljs/googlecode.js';
 import './index.scss';
 
 import js from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
@@ -107,21 +108,17 @@ const Link = ({ href, children }: LinkHTMLAttributes<HTMLAnchorElement>) => {
   );
 };
 
-const code: CodeComponent = ({ node, inline, className, children, ...props }) => {
-  const match = /language-(\w+)/.exec(className || '');
-  return !inline && match ? (
-    <SyntaxHighlighter language={match[1]} {...props}>
-      {String(children).replace(/\n$/, '')}
+// overwrite code will add duplicate pre wrappers(SyntaxHighlighter + original) in multiple line, so overwrite pre
+const pre = ({ children }: { children: React.ReactChild }) => {
+  const preProps = children?.[0].props;
+  const codeStr = preProps.children[0].replace(/\n$/, '');
+  const match = /language-(\w+)/.exec(preProps.className);
+  return (
+    <SyntaxHighlighter language={match?.[1]} style={github}>
+      {codeStr}
     </SyntaxHighlighter>
-  ) : (
-    <code className={className} {...props}>
-      {children}
-    </code>
   );
 };
-
-// multiple line code will add duplicate pre wrapper
-const pre = ({ children }: any) => children;
 
 interface IMdProps {
   value: string;
@@ -134,7 +131,7 @@ export const MarkdownRender = ({ value, className, style, noWrapper, components 
   const content = (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkBreaks]}
-      components={{ img: ScalableImage, a: Link, pre, code, ...components }}
+      components={{ img: ScalableImage, a: Link, pre, ...components }}
     >
       {value}
     </ReactMarkdown>


### PR DESCRIPTION
## What this PR does / why we need it:
fix: line break in markdown render code block

## I have checked the following points:
- [ ] I18n is finished and updated by cli
- [ ] Form fields validation is added and length is limited
- [ ] Display normally on small screen
- [ ] Display normally when some data is empty or null
- [ ] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
<img width="342" alt="image" src="https://user-images.githubusercontent.com/3955437/154002281-71917e48-30c3-49f4-a0c4-95b8f5c117f0.png">

<img width="255" alt="image" src="https://user-images.githubusercontent.com/3955437/154002431-bda06c8a-def2-4f09-9f37-cbf07ed242f6.png">



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: line break in markdown render code block  |
| 🇨🇳 中文    | 修复markdown 内容里的代码块没有换行的问题    |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

