### PR TITLE
fix(common): configurable filter delete config bug

### DIFF
--- a/shell/app/common/components/configurable-filter/config-selector.tsx
+++ b/shell/app/common/components/configurable-filter/config-selector.tsx
@@ -104,7 +104,8 @@ const ConfigSelector = ({ className = '', list, defaultValue, value, onChange, o
           {changedId === item.id ? (
             <Badge text={i18n.t('dop:changed')} size="small" status="processing" showDot={false} className="ml-2" />
           ) : null}
-          {showOp ? configItemMore(item) : null}
+
+          {showOp ? <span onClick={(e) => e.stopPropagation()}>{configItemMore(item)}</span> : null}
         </div>
       </div>
     ));

--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -423,7 +423,11 @@ const SelectComp = ({ value, onChange, options, size, optionRender, ...restItemP
             <>
               <div className="p-2 text-white-4">
                 {fixOptions.map((item: IOption) => (
-                  <div key={item.label} className="px-1 text-purple-deep" onClick={() => onChange([item.value])}>
+                  <div
+                    key={item.label}
+                    className="px-1 text-purple-deep cursor-pointer"
+                    onClick={() => onChange([item.value])}
+                  >
                     {item.label}
                   </div>
                 ))}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter delete config bug

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a bug where filters were triggered when a filter deleted a filter configuration.  |
| 🇨🇳 中文    | 修复了筛选器删除筛选配置时会触发筛选的bug。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda.cloud/erda/dop/projects/387/issues/all?id=282215&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

