### PR TITLE
fix(common): configurable filter tags select scroll bar style bug

### DIFF
--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -569,7 +569,6 @@ const TagsSelect = ({ size, options, value = [], onChange, ...restItemProps }: T
       filterOption={(input, option) =>
         typeof option?.label === 'string' && option?.label.toLowerCase().indexOf(input.toLowerCase()) >= 0
       }
-      listItemHeight={0}
     >
       {typeof options === 'function'
         ? options()


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter tags select scroll bar style bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/154032382-880d7e17-81d1-434e-88f9-4eddeb889c8a.png)
->
![image](https://user-images.githubusercontent.com/82502479/154032422-5d046dce-662b-4506-95db-98787937abc5.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix style bug of filter tags select scroll bar. |
| 🇨🇳 中文    |  修复了筛选器中标签选择器滚动条的样式问题。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda.cloud/erda/dop/projects/387/issues/all?id=281968&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG

