### PR TITLE
fix(common): tagsSelect supports radio selection

### DIFF
--- a/shell/app/common/components/render-form-item/index.tsx
+++ b/shell/app/common/components/render-form-item/index.tsx
@@ -572,7 +572,12 @@ const TagsSelect = ({ size, options, value = [], onChange, ...restItemProps }: T
     >
       {typeof options === 'function'
         ? options()
-        : options.map((item) => renderTagsSelectOption({ ...item, checked: value.includes(item.value) }))}
+        : options.map((item) =>
+            renderTagsSelectOption({
+              ...item,
+              checked: Array.isArray(value) ? value.includes(item.value) : value === item.value,
+            }),
+          )}
     </Select>
   );
 };


### PR DESCRIPTION
## What this PR does / why we need it:
TagsSelect supports radio selection.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed bug of Label selector setup radio options would report errors. |
| 🇨🇳 中文    | 修复了标签选择器设置单选会报错的问题。 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

