### PR TITLE
fix(msp): fixed tips not be fully displayed

### DIFF
--- a/shell/app/charts/utils/formatter.js
+++ b/shell/app/charts/utils/formatter.js
@@ -213,7 +213,6 @@ export const formatValue = (type, precision, value, min, max) => {
         formatStr = 'HH:mm:ss';
       }
     }
-    console.log(timer - 0, typeof (timer - 0), precision);
     return moment(timer - 0).format(formatStr);
   } else {
     return `${value} ${precision}`;

--- a/shell/app/modules/msp/alarm-manage/overview/base-overview.tsx
+++ b/shell/app/modules/msp/alarm-manage/overview/base-overview.tsx
@@ -67,6 +67,18 @@ const BaseOverview: React.FC<IProps> = ({ scope, scopeId }) => {
               gutter: 0,
             },
           },
+          ...['alertDurationAnalysisGrid', 'alertNotifyGrid', 'alertEventGrid'].reduce(
+            (previousValue, currentValue) => ({
+              ...previousValue,
+              [currentValue]: {
+                props: {
+                  wrapperClassName: 'overflow-visible',
+                  className: 'overflow-visible',
+                },
+              },
+            }),
+            {},
+          ),
           compositeHeader: {
             props: {
               showDefaultBgColor: false,


### PR DESCRIPTION
## What this PR does / why we need it:

fixed tips not be fully displayed

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fixed tips not be fully displayed  |
| 🇨🇳 中文    | 修复tips不能完全显示  |


## Does this PR need be patched to older version?
✅ Yes(version is required)

release/1.6-alpha.3


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

