### PR TITLE
fix(dop): project release group edit bug

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -87,7 +87,7 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
       ..._releaseDetail,
       applicationReleaseList: _releaseDetail?.applicationReleaseList?.map?.((group, index) => ({
         active: index === 0,
-        list: [...group.map((item) => ({ ...item, releaseId: item.releaseID }))],
+        list: [...group.map((item) => ({ ...item, releaseId: item.releaseID, applicationId: item.applicationID }))],
       })),
     };
   }, [_releaseDetail]);

--- a/shell/app/modules/project/pages/release/components/release-select.tsx
+++ b/shell/app/modules/project/pages/release/components/release-select.tsx
@@ -103,7 +103,9 @@ function ReleaseSelect<T extends { applicationId: string; title: string }>(props
 
   const removeGroup = (index: number, e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
-    setGroupList((prev) => prev.filter((_item, i) => i !== index));
+    const _groupList = groupList.filter((_item, i) => i !== index);
+    setGroupList(_groupList);
+    onChange?.(_groupList);
   };
 
   const clear = () => {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project release group edit bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed issues where project artifacts and application artifacts were not mutually exclusive when editing and deletion failed. |
| 🇨🇳 中文    | 修复了项目制品编辑时同应用制品未互斥和删除失效的问题。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda.cloud/erda/dop/projects/387/issues/all?id=283327&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1090&type=BUG

https://erda.cloud/erda/dop/projects/387/issues/all?id=283325&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1090&type=BUG

