### PR TITLE
fix(common): configurable filter select mode optimization in config page

### DIFF
--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -93,14 +93,20 @@ const getItemByValues = (val: Obj, list: ConfigData[], fieldsList: Field[]) => {
   return list?.find((item) => JSON.stringify(sortObj(item.values || {})) === JSON.stringify(values)) || null;
 };
 
-const defaultProcessField = (item: IFormItem) => {
-  const { type, itemProps, defaultValue, placeholder, disabled } = item;
+interface FieldItem extends IFormItem {
+  mode?: string;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const defaultProcessField = (item: FieldItem) => {
+  const { type, itemProps, defaultValue, placeholder, disabled, mode } = item;
   const field: IFormItem = { ...item };
 
   field.name = item.key;
   if (type === 'select' || type === 'tagsSelect') {
     field.itemProps = {
-      mode: 'multiple',
+      mode: mode !== 'single' ? 'multiple' : false,
       ...itemProps,
       showArrow: true,
       allowClear: true,


### PR DESCRIPTION
## What this PR does / why we need it:
Configurable filter select mode optimization in config page.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | In the config protocol page, configuration data structure optimization for optional filters can be configured.  |
| 🇨🇳 中文    |  在组件化协议的页面中，可配置筛选器单双选的配置数据结构优化。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

