### PR TITLE
fix(dop): project release group style bug

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -347,7 +347,7 @@ const renderSelectedItem = (item: RELEASE.ReleaseDetail, isDark: boolean) => {
           </div>
         </div>
       </div>
-      <div className="text-default-6">
+      <div className={isDark ? 'text-white-6' : 'text-default-6'}>
         {item.createdAt ? moment(item.createdAt).format('YYYY/MM/DD HH:mm:ss') : null}
       </div>
     </div>


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project release group style bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/154229082-a564ec2c-c833-4070-8f4f-76c4c95e18d8.png)
->
![image](https://user-images.githubusercontent.com/82502479/154229063-04c7f3ee-34c1-43e2-ad47-1e420420254f.png)
## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed a time display issue when selecting an app release.  |
| 🇨🇳 中文    |  修复了选择应用制品时时间显示的问题。  |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

