### PR TITLE
fix(dop): project release filter empty groups

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -282,9 +282,11 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
         const { applicationReleaseList = [] } = values;
         payload = {
           ...payload,
-          applicationReleaseList: applicationReleaseList.map((group: { list: Array<{ releaseId: string }> }) =>
-            group.list.map((item: { releaseId: string }) => item.releaseId),
-          ),
+          applicationReleaseList: applicationReleaseList
+            .filter((group: { list: Array<{ releaseId: string }> }) => group.list?.length)
+            .map((group: { list: Array<{ releaseId: string }> }) =>
+              group.list.map((item: { releaseId: string }) => item.releaseId),
+            ),
           isStable: true,
           isFormal: false,
           isProjectRelease: true,


### PR DESCRIPTION
## What this PR does / why we need it:
Project release filter empty groups.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Project release filter empty group. |
| 🇨🇳 中文    | 项目级制品分组过滤掉空的组。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://erda.cloud/erda/dop/projects/387/issues/all?id=283440&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1090&type=BUG

