### PR TITLE
fix(common): load more selector icon change

### DIFF
--- a/shell/app/common/components/load-more-selector/index.tsx
+++ b/shell/app/common/components/load-more-selector/index.tsx
@@ -542,7 +542,7 @@ const DefaultLoadMoreRender = ({ onLoadMore, loading }: { onLoadMore: () => void
         onLoadMore();
       }}
     >
-      <ErdaIcon type="loading" className="align-middle" spin={loading} />
+      <ErdaIcon type="refresh1" className="align-middle mr-1" />
       {i18n.t('load more')}
     </div>
   );


### PR DESCRIPTION
## What this PR does / why we need it:
Load more selector icon change

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/154246889-c5b654b5-4e3c-4ac4-92d6-bc7fcf81609e.png)
->
![image](https://user-images.githubusercontent.com/82502479/154246928-67f40f77-1f10-4854-85c4-57bfe5327aa2.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Manually click load more button icon changed to static. |
| 🇨🇳 中文    | 手动点击的加载更多按钮图标改成静态的。 |


## Does this PR need be patched to older version?
✅ Yes(version is required)
release/1.6-alpha.3

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

