### PR TITLE
fix(msp): fix sort key

### DIFF
--- a/shell/app/config-page/components/table/v2/table.tsx
+++ b/shell/app/config-page/components/table/v2/table.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { Button, Checkbox, Dropdown, Menu } from 'antd';
-import { TablePaginationConfig } from 'app/common/components/table/interface';
+import { ColumnProps, TablePaginationConfig } from 'app/common/components/table/interface';
 import { compact, difference, has, intersection, isNil, map } from 'lodash';
 import { ErdaIcon, Title } from 'common';
 import ErdaTable from 'common/components/table';
@@ -26,6 +26,10 @@ import { convertTableData } from './utils';
 interface ISorter {
   order: 'ascend' | 'descend' | undefined;
   field: string;
+  column: ColumnProps<any> & {
+    fieldBindToOrder?: string;
+    enableSort?: boolean;
+  };
 }
 
 interface ITableAction {
@@ -115,7 +119,7 @@ const Table = (props: CP_TABLE2.Props) => {
         ...changeSort,
         clientData: {
           dataRef: {
-            fieldBindToOrder: _sorter.field,
+            fieldBindToOrder: _sorter.column.fieldBindToOrder || _sorter.field,
             ascOrder: isNil(_sorter?.order) ? null : _sorter?.order === 'ascend',
           },
         },


### PR DESCRIPTION
## What this PR does / why we need it:

fix sort key

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix a bug that sort is invalid |
| 🇨🇳 中文    | 修复排序无效的bug |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

