### PR TITLE
feat(msp): replace Tag with Badge in MSP project list

### DIFF
--- a/shell/app/modules/msp/pages/micro-service/overview.tsx
+++ b/shell/app/modules/msp/pages/micro-service/overview.tsx
@@ -30,22 +30,22 @@ import List from 'common/components/base-list';
 import i18n from 'i18n';
 import './overview.scss';
 
-const iconMap: {
+const baseProjectInfo: {
   [key in MS_INDEX.IMspProject['type']]: {
     icon: string;
-    tag: string;
-    color: string;
+    text: string;
+    status: string;
   };
 } = {
   DOP: {
     icon: 'DevOps',
-    tag: i18n.t('msp:DevOps'),
-    color: 'blue',
+    text: i18n.t('msp:DevOps'),
+    status: 'processing',
   },
   MSP: {
     icon: 'MSP',
-    tag: i18n.t('cmp:Monitor'),
-    color: 'green',
+    text: i18n.t('cmp:Monitor'),
+    status: 'warning',
   },
 };
 
@@ -121,18 +121,14 @@ const Overview = () => {
       .filter((item) => item.displayName.toLowerCase().includes(filterKey))
       .map((item) => {
         const { logo, desc, displayName, type, relationship, id } = item;
+        const { icon, ...titleState } = baseProjectInfo[type];
         return {
           ...item,
           logoURL: logo,
-          icon: logo ? undefined : iconMap[type].icon,
+          icon: logo ? undefined : icon,
           title: displayName,
           description: desc || i18n.t('no description yet'),
-          tags: [
-            {
-              label: iconMap[type].tag,
-              color: iconMap[type].color,
-            },
-          ],
+          titleState: [titleState],
           kvInfos: metric.map((t) => {
             return {
               key: t.name,


### PR DESCRIPTION
## What this PR does / why we need it:

replace Tag with Badge in MSP project list and  consistent with the Personal Workbench

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/23442144/154602593-f5774cc3-01fe-4254-9fb4-f341139569e2.png)
![image](https://user-images.githubusercontent.com/23442144/154602634-57a621d8-193b-4598-92a3-21d08f6ed0a1.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | replace Tag with Badge in MSP project list |
| 🇨🇳 中文    | 将 MSP 项目列表中的 Tag 替换为 Badge |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

