### PR TITLE
fix(msp): remove noWrapper from the alarm strategy

### DIFF
--- a/shell/app/modules/msp/alarm-manage/alarm-strategy/index.js
+++ b/shell/app/modules/msp/alarm-manage/alarm-strategy/index.js
@@ -23,7 +23,6 @@ function AlarmRouter() {
     {
       path: 'add-strategy',
       breadcrumbName: i18n.t('cmp:new alarm strategy'),
-      layout: { noWrapper: true },
       pageNameInfo: AddStrategyPageName,
       getComp: (cb) => cb(import('msp/alarm-manage/alarm-strategy/pages/alarm-index/msp-strategy')),
     },
@@ -31,7 +30,6 @@ function AlarmRouter() {
       path: 'edit-strategy/:id',
       breadcrumbName: i18n.t('cmp:edit alarm strategy'),
       pageNameInfo: EditStrategyPageName,
-      layout: { noWrapper: true },
       getComp: (cb) => cb(import('msp/alarm-manage/alarm-strategy/pages/alarm-index/msp-strategy')),
     },
   ];


### PR DESCRIPTION
## What this PR does / why we need it:

remove noWrapper from the alarm strategy

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | remove noWrapper from the alarm strategy |
| 🇨🇳 中文    | 移除告警策略中的 noWrapper 配置项 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

