### PR TITLE
fix(msp): fix datePicker validate

### DIFF
--- a/shell/app/configForm/nusi-form/form-items/date-picker.tsx
+++ b/shell/app/configForm/nusi-form/form-items/date-picker.tsx
@@ -13,7 +13,7 @@
 
 import { DatePicker, Form } from 'antd';
 import React from 'react';
-import { isArray, isEmpty, isString } from 'lodash';
+import { isArray, isNil, isString } from 'lodash';
 import { getLabel, noop } from './common';
 import { checkWhen, commonFields } from './common/config';
 import i18n from 'i18n';
@@ -110,7 +110,7 @@ export const config = {
   Component: FormDatePicker, // 某React组件，props中必须有value、onChange
   requiredCheck: (value) => {
     // 必填校验时，特殊的校验规则
-    return [!isEmpty(value), i18n.t('can not be empty')];
+    return [!isNil(value), i18n.t('can not be empty')];
   },
   fixOut: (value, options) => {
     const { valueType = 'moment' } = options || {};


### PR DESCRIPTION
## What this PR does / why we need it:

fix datapick validate

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix datePicker validate |
| 🇨🇳 中文    | 修复 datePicker 校验逻辑 |

## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

