### PR TITLE
feat(msp): replace antd table with erdaTable

### DIFF
--- a/shell/app/modules/msp/monitor/api-insight/common/components/apiDelayPanel.tsx
+++ b/shell/app/modules/msp/monitor/api-insight/common/components/apiDelayPanel.tsx
@@ -12,12 +12,13 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Table, Tooltip } from 'antd';
+import { Tooltip } from 'antd';
 import { get, round } from 'lodash';
 import { Copy, IF } from 'common';
+import ErdaTable from 'common/components/table';
 import i18n from 'i18n';
 
-export const apiDelayPanel = ({ data }: { data: object }) => {
+export const apiDelayPanel = ({ data, reload }: { data: object; reload: Function }) => {
   const list = get(data, 'list');
   const columns = [
     {
@@ -42,5 +43,6 @@ export const apiDelayPanel = ({ data }: { data: object }) => {
     },
   ];
 
-  return <Table columns={columns} dataSource={list} scroll={{ x: '100%' }} />;
+  // only show 10 pieces of data，not need pagination
+  return <ErdaTable columns={columns} dataSource={list} pagination={false} onReload={reload} />;
 };

--- a/shell/app/modules/msp/monitor/api-insight/common/components/apiSizePanel.tsx
+++ b/shell/app/modules/msp/monitor/api-insight/common/components/apiSizePanel.tsx
@@ -12,12 +12,13 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Table, Tooltip } from 'antd';
+import { Tooltip } from 'antd';
 import { get, round } from 'lodash';
 import { Copy, IF } from 'common';
+import ErdaTable from 'common/components/table';
 import i18n from 'i18n';
 
-export const apiSizePanel = ({ data }: { data: object }) => {
+export const apiSizePanel = ({ data, reload }: { data: object; reload: Function }) => {
   const list = get(data, 'list');
   const columns = [
     {
@@ -41,6 +42,6 @@ export const apiSizePanel = ({ data }: { data: object }) => {
       render: (size: number) => round(size, 3),
     },
   ];
-
-  return <Table columns={columns} dataSource={list} scroll={{ x: '100%' }} />;
+  // only show 10 pieces of data，not need pagination
+  return <ErdaTable columns={columns} dataSource={list} pagination={false} onReload={reload} />;
 };

--- a/shell/app/modules/msp/monitor/api-insight/common/components/topPVPanel.tsx
+++ b/shell/app/modules/msp/monitor/api-insight/common/components/topPVPanel.tsx
@@ -12,11 +12,12 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Table, Tooltip } from 'antd';
+import { Tooltip } from 'antd';
 import { get } from 'lodash';
 import { Copy } from 'common';
+import ErdaTable from 'common/components/table';
 
-export const topPVPanel = ({ data }: { data: object }) => {
+export const topPVPanel = ({ data, reload }: { data: object; reload: Function }) => {
   const list = get(data, 'list');
   const columns = [
     {
@@ -35,6 +36,6 @@ export const topPVPanel = ({ data }: { data: object }) => {
       width: 180,
     },
   ];
-
-  return <Table columns={columns} dataSource={list} scroll={{ x: '100%' }} />;
+  // only show 10 pieces of data，not need pagination
+  return <ErdaTable columns={columns} dataSource={list} pagination={false} onReload={reload} />;
 };

--- a/shell/app/modules/msp/monitor/monitor-common/components/chartFactory.tsx
+++ b/shell/app/modules/msp/monitor/monitor-common/components/chartFactory.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import { get, has, isEqual } from 'lodash';
 import { useEffectOnce } from 'react-use';
-import { MonitorChartNew, PieChart, MapChart, HollowPieChart } from 'charts';
+import { HollowPieChart, MapChart, MonitorChartNew, PieChart } from 'charts';
 import { CardContainer } from 'common';
 import monitorChartStore from 'app/modules/msp/monitor/monitor-common/stores/monitorChart';
 import routeInfoStore from 'core/stores/route';
@@ -31,6 +31,7 @@ interface ILoadObj {
 
 interface IChartProps {
   [pro: string]: any;
+
   titleText: string | boolean;
   viewType: string;
   viewRender: any;
@@ -197,6 +198,12 @@ const ChartBaseFactory = {
               _moduleName={moduleName} // TODO: use a inner named prop to prevent effect, only used in slow-tract-panel, need to refactor
               timeSpan={timeSpan}
               data={shouldLoad ? data : { loading: false }}
+              reload={() => {
+                loadChart({
+                  ...curQuery,
+                  dataHandler,
+                });
+              }}
               groupId={groupId}
               {...viewProps}
             />

--- a/shell/app/modules/msp/query-analysis/custom-dashboard/index.ts
+++ b/shell/app/modules/msp/query-analysis/custom-dashboard/index.ts
@@ -30,6 +30,7 @@ const CustomDashBoard = () => ({
       getComp: (cb: RouterGetComp) => cb(import('msp/query-analysis/custom-dashboard/pages/custom-dashboard')),
     },
     {
+      layout: { noWrapper: true },
       getComp: (cb: RouterGetComp) => cb(import('msp/query-analysis/custom-dashboard/pages')),
     },
   ],

--- a/shell/app/modules/msp/router.ts
+++ b/shell/app/modules/msp/router.ts
@@ -83,6 +83,7 @@ function getMspRouter(): RouteConfigItem[] {
                 {
                   path: ':terminusKey/member',
                   breadcrumbName: getMspBreadcrumb('MemberManagement'),
+                  layout: { noWrapper: true },
                   getComp: (cb) => cb(import('msp/env-setting/member-manage')),
                 },
                 {

--- a/shell/app/modules/msp/types/gateway.d.ts
+++ b/shell/app/modules/msp/types/gateway.d.ts
@@ -106,13 +106,14 @@ declare namespace GATEWAY {
 
   interface GetPackageDetailApiList {
     packageId: string;
-    apiPath: string;
-    method: string;
-    sortField: string;
-    sortType: string;
-    diceApp: string;
-    diceService: string;
+    apiPath?: string;
+    method?: string;
+    sortField?: string;
+    sortType?: string;
+    diceApp?: string;
+    diceService?: string;
     pageNo: number;
+    pageSize: number;
   }
 
   interface PackageDetailApiListItem {

--- a/shell/app/modules/msp/types/gateway.d.ts
+++ b/shell/app/modules/msp/types/gateway.d.ts
@@ -116,11 +116,24 @@ declare namespace GATEWAY {
   }
 
   interface PackageDetailApiListItem {
+    allowPassAuth: boolean;
+    apiId: string;
+    apiPath: string;
+    createAt: string;
+    description: string;
     diceApp: string;
     diceService: string;
-    apiPath: string;
+    hosts: null;
+    mutable: boolean;
+    origin: string;
+    redirectAddr: string;
+    redirectApp: string;
+    redirectPath: string;
+    redirectRuntimeId: string;
+    redirectRuntimeName: string;
+    redirectService: string;
+    redirectType: string;
     method: string;
-    createAt: string;
   }
 
   interface ApiFilterCondition {


### PR DESCRIPTION
## What this PR does / why we need it:

replace antd table with erdaTable [erda-project/erda-ui-enterprise#222](https://github.com/erda-project/erda-ui-enterprise/pull/222)

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | replace antd table with erdaTable |
| 🇨🇳 中文    | 使用 erdaTable 替换 antd table |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

