### PR TITLE
fix: fix kanban request twice when switch type

### DIFF
--- a/shell/app/modules/project/pages/issue/board.tsx
+++ b/shell/app/modules/project/pages/issue/board.tsx
@@ -94,7 +94,7 @@ const compareObject = (sourceObj: object, targetObj: object) => {
 
 const IssueProtocol = ({ issueType: propsIssueType }: { issueType: string }) => {
   const [{ projectId, iterationId }, query] = routeInfoStore.useStore((s) => [s.params, s.query]);
-  const { id: queryId, iterationID: queryItertationID, ...restQuery } = query;
+  const { id: queryId, iterationID: queryItertationID, type, ...restQuery } = query;
   const orgID = orgStore.getState((s) => s.currentOrg.id);
   const [
     { filterObj, chosenIssueType, chosenIssueId, chosenIteration, urlQuery, urlQueryChangeByQuery, issueType },


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix kanban request twice when switch type

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix: fix kanban request twice when switch type          |
| 🇨🇳 中文    |    fix: 修复看板切换类型后请求两次接口         |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://erda.cloud/erda/dop/projects/387/issues/all?id=283874&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDM5MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTAwfQ%3D%3D&iterationID=1090&type=BUG
