### PR TITLE
fix: return to first page after filter value change

### DIFF
--- a/shell/app/modules/application/pages/problem/problem-list.tsx
+++ b/shell/app/modules/application/pages/problem/problem-list.tsx
@@ -231,7 +231,7 @@ export const ProblemList = () => {
               hideSave
               value={filterData}
               fieldsList={fieldsList}
-              onFilter={(values) => filterFn(undefined, values)}
+              onFilter={(values) => filterFn({ pageNo: 1 }, values)}
             />
           }
         />


### PR DESCRIPTION
## What this PR does / why we need it:
fix: return to first page after filter value change

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |fix: return to first page after filter value change |
| 🇨🇳 中文    |   问题列表筛选改变后返回第一页 |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

