### PR TITLE
fix(dop): tab info should disable click

### DIFF
--- a/shell/app/common/components/menu/index.tsx
+++ b/shell/app/common/components/menu/index.tsx
@@ -23,6 +23,7 @@ interface IMenuItem {
   name: string;
   disabled?: boolean;
   split?: boolean;
+  readonly?: boolean;
   isActive?: (v: string) => boolean;
   className?: string;
 }
@@ -116,7 +117,7 @@ const PureMenu = (props: IMenu) => {
     <div className={tabClass}>
       <ul className="tab-item-wraps">
         {finalMenus.map((menu: IMenuItem) => {
-          const { disabled, key, name, split, isActive, className: itemClass = '' } = menu;
+          const { disabled, key, name, split, readonly, isActive, className: itemClass = '' } = menu;
           const menuItemClass = classnames({
             'tab-menu-item': true,
             'tab-menu-disabled': disabled,
@@ -129,7 +130,7 @@ const PureMenu = (props: IMenu) => {
               key={key}
               className={menuItemClass}
               onClick={() => {
-                if (!disabled && activeKey !== key) {
+                if (!readonly && !disabled && activeKey !== key) {
                   // click current not trigger
                   handleClick(activeKey, key);
                 }

--- a/shell/app/layout/pages/page-container/components/header.scss
+++ b/shell/app/layout/pages/page-container/components/header.scss
@@ -26,7 +26,7 @@
     .tab-menu-item {
       height: 30px;
       line-height: 30px;
-      margin-right: 24px;
+      margin-right: 16px;
     }
   }
 

--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -2730,7 +2730,6 @@
     "deploy at": "deploy at",
     "deploying, please operate later": "deploying, please operate later",
     "deployment canceled": "deployment canceled",
-    "deployment config": "deployment config",
     "deployment expired and cannot roll back": "deployment expired and cannot roll back",
     "deployment failed": "deployment failed",
     "deployment failed and cannot roll back": "deployment failed and cannot roll back",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -2730,7 +2730,6 @@
     "deploy at": "部署于",
     "deploying, please operate later": "正在部署中，请稍后操作",
     "deployment canceled": "部署取消",
-    "deployment config": "部署配置",
     "deployment expired and cannot roll back": "部署过期，无法回滚",
     "deployment failed": "部署失败",
     "deployment failed and cannot roll back": "部署失败，无法回滚",

--- a/shell/app/modules/application/router.ts
+++ b/shell/app/modules/application/router.ts
@@ -78,7 +78,8 @@ function getAppRouter(): RouteConfigItem {
             routes: [
               {
                 path: ':commitId',
-                backToUp: 'projectAppList',
+                backToUp: 'repo',
+                breadcrumbName: i18n.t('dop:code'),
                 ignoreTabQuery: true,
                 getComp: (cb) => cb(import('application/pages/repo/commit-detail')),
               },

--- a/shell/app/modules/application/tabs.tsx
+++ b/shell/app/modules/application/tabs.tsx
@@ -43,6 +43,7 @@ export const APP_TABS = () => {
     key: '_',
     className: 'mr-4',
     name: <HeadAppSelector />,
+    readonly: true,
   };
   const repo = {
     show: perm.repo.read.pass,

--- a/shell/app/modules/project/tabs.tsx
+++ b/shell/app/modules/project/tabs.tsx
@@ -38,6 +38,8 @@ export const ITERATION_DETAIL_TABS = (params: Obj) => {
           ) : null}
         </>
       ),
+      readonly: true,
+      className: 'cursor-default',
     },
     {
       key: 'all',


### PR DESCRIPTION
## What this PR does / why we need it:
fix(dop): tab info should disable click

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed an issue where clicking the TAB title of a page went to a page that did not exist     |
| 🇨🇳 中文    |   修复点击页面 tab 标题进入不存在页面的问题   |


## Does this PR need be patched to older version?
❎ No


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

