### PR TITLE
fix(common): configurable filter bug when form items depend on each other

### DIFF
--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import { Popover, Row, Col, Form, Button, Badge, Input } from 'antd';
 import { ErdaIcon, RenderFormItem, IFormItem } from 'common';
-import { cloneDeep, isEmpty, has } from 'lodash';
+import { isEmpty, has } from 'lodash';
 import ExternalItem from './external-item';
 import { useUpdateEffect } from 'react-use';
 import i18n from 'i18n';
@@ -150,9 +150,11 @@ const convertValue = (value: Obj, fieldList: Field[]) => {
   return { formValue, externalValue };
 };
 
+const emptyArr = [] as ConfigData[];
+
 const ConfigurableFilter = ({
   fieldsList,
-  configList = [],
+  configList = emptyArr,
   defaultConfig,
   value,
   onFilter: onFilterProps,
@@ -163,7 +165,8 @@ const ConfigurableFilter = ({
 }: IProps) => {
   const { externalValue: _externalValue, formValue } = React.useMemo(
     () => convertValue(value, fieldsList),
-    [value, fieldsList],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value],
   );
 
   const [form] = Form.useForm();
@@ -176,7 +179,6 @@ const ConfigurableFilter = ({
 
   React.useEffect(() => {
     if (formValue) {
-      form.setFieldsValue(formValue || {});
       const config = getItemByValues(formValue, configList, fieldsList);
       config?.id && setCurrentConfig(config?.id);
       setIsNew(!config);
@@ -188,6 +190,12 @@ const ConfigurableFilter = ({
       }
     }
   }, [configList, defaultConfig, form, formValue, onFilterProps, fieldsList]);
+
+  React.useEffect(() => {
+    if (formValue) {
+      form.setFieldsValue(formValue || {});
+    }
+  }, [formValue, form]);
 
   useUpdateEffect(() => {
     onFilter();
@@ -229,7 +237,7 @@ const ConfigurableFilter = ({
     });
   };
 
-  React.useEffect(() => {
+  useUpdateEffect(() => {
     if (visible && formValue) {
       form.resetFields();
       form.setFieldsValue(formValue || {});
@@ -237,7 +245,7 @@ const ConfigurableFilter = ({
       config?.id && setCurrentConfig(config?.id);
       setIsNew(!config);
     }
-  }, [visible, form, configList, formValue, fieldsList]);
+  }, [visible, form, configList, formValue]);
 
   const externalField = fieldsList.filter((item) => item.outside);
 

--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Popover, Row, Col, Form, Button, Badge, Input } from 'antd';
+import { Popover, Row, Col, Form, Button, Badge, Input, FormInstance } from 'antd';
 import { ErdaIcon, RenderFormItem, IFormItem } from 'common';
 import { isEmpty, has } from 'lodash';
 import ExternalItem from './external-item';
@@ -33,6 +33,8 @@ export interface IProps {
   onConfigChange?: (config: ConfigData) => void;
   processField?: (field: Field) => IFormItem;
   hideSave?: boolean;
+  onClear: () => void;
+  onClose: () => void;
 }
 
 export interface Option {
@@ -152,288 +154,309 @@ const convertValue = (value: Obj, fieldList: Field[]) => {
 
 const emptyArr = [] as ConfigData[];
 
-const ConfigurableFilter = ({
-  fieldsList,
-  configList = emptyArr,
-  defaultConfig,
-  value,
-  onFilter: onFilterProps,
-  onDeleteFilter,
-  onSaveFilter,
-  processField,
-  hideSave,
-}: IProps) => {
-  const { externalValue: _externalValue, formValue } = React.useMemo(
-    () => convertValue(value, fieldsList),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [value],
-  );
+const ConfigurableFilter = React.forwardRef(
+  (
+    {
+      fieldsList,
+      configList = emptyArr,
+      defaultConfig,
+      value,
+      onFilter: onFilterProps,
+      onDeleteFilter,
+      onSaveFilter,
+      processField,
+      hideSave,
+      onClear,
+      onClose,
+    }: IProps,
+    ref: React.Ref<{ form: FormInstance }>,
+  ) => {
+    const { externalValue: _externalValue, formValue } = React.useMemo(
+      () => convertValue(value, fieldsList),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [value],
+    );
 
-  const [form] = Form.useForm();
-  const [addForm] = Form.useForm();
-  const [externalValue, setExternalValue] = React.useState<Obj<string>>(_externalValue);
-  const [visible, setVisible] = React.useState(false);
-  const [currentConfig, setCurrentConfig] = React.useState<string | number>();
-  const [isNew, setIsNew] = React.useState(false);
-  const [addVisible, setAddVisible] = React.useState(false);
+    const [form] = Form.useForm();
+    const [addForm] = Form.useForm();
+    const [externalValue, setExternalValue] = React.useState<Obj<string>>(_externalValue);
+    const [visible, setVisible] = React.useState(false);
+    const [currentConfig, setCurrentConfig] = React.useState<string | number>();
+    const [isNew, setIsNew] = React.useState(false);
+    const [addVisible, setAddVisible] = React.useState(false);
 
-  React.useEffect(() => {
-    if (formValue) {
-      const config = getItemByValues(formValue, configList, fieldsList);
-      config?.id && setCurrentConfig(config?.id);
-      setIsNew(!config);
-    } else if (configList && configList.length !== 0) {
-      const configData: ConfigData = configList?.find((item) => item.id === defaultConfig) || ({} as ConfigData);
-      if (configData.values) {
-        configData.values && form.setFieldsValue(configData.values);
-        onFilterProps?.(configData.values);
+    React.useImperativeHandle(ref, () => ({
+      form,
+    }));
+
+    React.useEffect(() => {
+      if (formValue) {
+        const config = getItemByValues(formValue, configList, fieldsList);
+        config?.id && setCurrentConfig(config?.id);
+        setIsNew(!config);
+      } else if (configList && configList.length !== 0) {
+        const configData: ConfigData = configList?.find((item) => item.id === defaultConfig) || ({} as ConfigData);
+        if (configData.values) {
+          configData.values && form.setFieldsValue(configData.values);
+          onFilterProps?.(configData.values);
+        }
       }
-    }
-  }, [configList, defaultConfig, form, formValue, onFilterProps, fieldsList]);
+    }, [configList, defaultConfig, form, formValue, onFilterProps, fieldsList]);
 
-  React.useEffect(() => {
-    if (formValue) {
-      form.setFieldsValue(formValue || {});
-    }
-  }, [formValue, form]);
+    React.useEffect(() => {
+      if (formValue) {
+        form.setFieldsValue(formValue || {});
+      }
+    }, [formValue, form]);
 
-  useUpdateEffect(() => {
-    onFilter();
-  }, [externalValue]);
+    useUpdateEffect(() => {
+      onFilter();
+    }, [externalValue]);
 
-  const onConfigChange = (config: ConfigData) => {
-    setCurrentConfig(config.id);
-    setIsNew(false);
-    form.resetFields();
-    form.setFieldsValue(config.values || {});
-    onFilter();
-  };
+    const onConfigChange = (config: ConfigData) => {
+      setCurrentConfig(config.id);
+      setIsNew(false);
+      form.resetFields();
+      form.setFieldsValue(config.values || {});
+      onFilter();
+    };
 
-  const onValuesChange = (_, allValues: Obj) => {
-    const config = getItemByValues(allValues, configList, fieldsList);
-    if (config?.id) {
+    const onValuesChange = (_, allValues: Obj) => {
+      const config = getItemByValues(allValues, configList, fieldsList);
+      if (config?.id) {
+        setCurrentConfig(config?.id);
+        setIsNew(false);
+      } else {
+        setIsNew(true);
+      }
+    };
+
+    const saveFilter = (label: string) => {
+      onSaveFilter?.(label, form.getFieldsValue());
+    };
+
+    const setAllOpen = () => {
+      form.resetFields();
+      const config = getItemByValues(form.getFieldsValue(), configList, fieldsList);
       setCurrentConfig(config?.id);
       setIsNew(false);
-    } else {
-      setIsNew(true);
-    }
-  };
+      onClear?.();
+    };
 
-  const saveFilter = (label: string) => {
-    onSaveFilter?.(label, form.getFieldsValue());
-  };
+    const onFilter = () => {
+      form.validateFields().then((values) => {
+        onFilterProps({ ...values, ...externalValue });
+        setVisible(false);
+      });
+    };
 
-  const setAllOpen = () => {
-    form.resetFields();
-    const config = getItemByValues(form.getFieldsValue(), configList, fieldsList);
-    setCurrentConfig(config?.id);
-    setIsNew(false);
-  };
+    useUpdateEffect(() => {
+      if (visible && formValue) {
+        form.resetFields();
+        form.setFieldsValue(formValue || {});
+        const config = getItemByValues(formValue, configList, fieldsList);
+        config?.id && setCurrentConfig(config?.id);
+        setIsNew(!config);
+      }
+    }, [visible, form, configList, formValue]);
 
-  const onFilter = () => {
-    form.validateFields().then((values) => {
-      onFilterProps({ ...values, ...externalValue });
-      setVisible(false);
-    });
-  };
+    const externalField = fieldsList.filter((item) => item.outside);
 
-  useUpdateEffect(() => {
-    if (visible && formValue) {
-      form.resetFields();
-      form.setFieldsValue(formValue || {});
-      const config = getItemByValues(formValue, configList, fieldsList);
-      config?.id && setCurrentConfig(config?.id);
-      setIsNew(!config);
-    }
-  }, [visible, form, configList, formValue]);
-
-  const externalField = fieldsList.filter((item) => item.outside);
-
-  const addConfigContent = (
-    <div>
-      <Form form={addForm} layout="vertical" className="p-4">
-        <Form.Item
-          label={i18n.t('dop:filter name')}
-          name="label"
-          rules={[
-            { required: true, message: i18n.t('please enter {name}', { name: i18n.t('dop:filter name') }) },
-            { max: 10, message: i18n.t('dop:within {num} characters', { num: 10 }) },
-          ]}
-        >
-          <Input placeholder={i18n.t('dop:please enter, within {num} characters', { num: 10 })} />
-        </Form.Item>
-        <div className="mt-3">
-          <Button
-            type="primary"
-            onClick={() => {
-              addForm.validateFields().then(({ label }) => {
-                saveFilter?.(label);
-                setAddVisible(false);
-              });
-            }}
+    const addConfigContent = (
+      <div>
+        <Form form={addForm} layout="vertical" className="p-4">
+          <Form.Item
+            label={i18n.t('dop:filter name')}
+            name="label"
+            rules={[
+              { required: true, message: i18n.t('please enter {name}', { name: i18n.t('dop:filter name') }) },
+              { max: 10, message: i18n.t('dop:within {num} characters', { num: 10 }) },
+            ]}
           >
-            {i18n.t('ok')}
-          </Button>
-          <span
-            className="text-white ml-3 cursor-pointer"
-            onClick={() => {
-              addForm.resetFields();
-              setAddVisible(false);
-            }}
-          >
-            {i18n.t('cancel')}
-          </span>
-        </div>
-      </Form>
-    </div>
-  );
-
-  const content = (
-    <div className="flex-1">
-      <div className="h-full flex flex-col overflow-hidden">
-        <div className=" h-[48px] flex-h-center justify-between">
-          <div className="flex-h-center">
-            <span>{i18n.t('common:filter')}</span>
-          </div>
-          <ErdaIcon
-            type="guanbi"
-            fill="white"
-            color="white"
-            size={20}
-            className="text-white cursor-pointer"
-            onClick={() => setVisible(false)}
-          />
-        </div>
-        <div className="flex justify-start flex-1 overflow-hidden">
-          {!hideSave ? (
-            <ConfigSelector
-              className="overflow-auto"
-              list={configList}
-              value={currentConfig}
-              isNew={isNew}
-              defaultValue={defaultConfig}
-              onChange={onConfigChange}
-              onDeleteFilter={onDeleteFilter}
-              onSaveFilter={saveFilter}
-            />
-          ) : null}
-          <div className={'erda-configurable-filter-body ml-4 pr-2 overflow-auto flex-1'}>
-            <Form form={form} layout="vertical" onValuesChange={onValuesChange}>
-              <Row>
-                {fieldsList
-                  ?.filter((item) => !item.outside)
-                  ?.map((item, index: number) => {
-                    return (
-                      <Col span={12} key={item.key} className={index % 2 === 1 ? 'pl-2' : 'pr-2'}>
-                        <RenderFormItem
-                          required={false}
-                          {...defaultProcessField(processField ? processField(item) : item)}
-                        />
-                      </Col>
-                    );
-                  })}
-              </Row>
-            </Form>
-          </div>
-        </div>
-
-        <div className="erda-configurable-filter-footer flex justify-end mt-3">
-          {hideSave ? (
-            <Button className="mx-1" onClick={setAllOpen}>
-              {i18n.t('clear')}
-            </Button>
-          ) : isNew && currentConfig ? (
-            <Popover
-              content={addConfigContent}
-              visible={addVisible}
-              onVisibleChange={setAddVisible}
-              trigger={['click']}
-              overlayClassName="erda-configurable-filter-add"
-              getPopupContainer={(triggerNode) => triggerNode.parentElement as HTMLElement}
-            >
-              <Button
-                className="mx-1 cursor-pointer rounded-sm px-2 py-1 flex-h-center"
-                onClick={() => setAddVisible(true)}
-              >
-                <ErdaIcon size={16} fill="white" type="baocun" className="mr-1" /> {i18n.t('dop:new filter')}
-              </Button>
-            </Popover>
-          ) : null}
-          <Button className="mx-1" onClick={() => setVisible(false)}>
-            {i18n.t('cancel')}
-          </Button>
-          <Button type="primary" className="ml-1 mr-2 bg-purple-deep border-purple-deep" onClick={onFilter}>
-            {i18n.t('common:filter')}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-  const getFilterName = () => {
-    return getItemByValues(formValue, configList, fieldsList)?.label || i18n.t('common:filter');
-  };
-
-  const isAllOpen = !!(
-    formValue &&
-    !isEmpty(formValue) &&
-    Object.keys(formValue).find((key) => formValue[key] && !isEmpty(formValue[key]))
-  );
-
-  return (
-    <div className={'flex items-center'}>
-      <div className="flex-h-center bg-default-06 rounded-sm">
-        <Popover
-          content={content}
-          visible={visible}
-          forceRender
-          trigger={['click']}
-          overlayClassName={`erda-configurable-filter ${hideSave ? 'w-[720px]' : 'w-[960px]'}`}
-          placement="bottomLeft"
-          onVisibleChange={setVisible}
-        >
-          <div
-            className={`flex-h-center erda-configurable-filter-btn py-1 px-2 rounded-sm leading-none cursor-pointer`}
-            onClick={() => setVisible(true)}
-          >
-            <Badge dot={isAllOpen}>
-              <div className="flex-h-center">
-                <ErdaIcon type="futaishaixuan" className="filter-icon" size={14} />
-                <span className="mx-1 filter-text">{getFilterName()}</span>
-              </div>
-            </Badge>
-            <ErdaIcon type="caret-down" />
-          </div>
-        </Popover>
-        {isAllOpen ? (
-          <div
-            className="erda-configurable-filter-clear-btn p-1 rounded-sm leading-none cursor-pointer"
-            onClick={() => {
-              setAllOpen();
-              onFilter();
-            }}
-          >
-            <ErdaIcon type="zhongzhi" color="currentColor" size={20} className="relative top-px" />
-          </div>
-        ) : null}
-      </div>
-
-      <div className="flex-h-center">
-        {externalField?.map((item) => {
-          return (
-            <ExternalItem
-              itemData={item}
-              value={externalValue?.[item.key]}
-              onChange={(v) => {
-                setExternalValue((prev) => ({ ...prev, [item.key]: v }));
+            <Input placeholder={i18n.t('dop:please enter, within {num} characters', { num: 10 })} />
+          </Form.Item>
+          <div className="mt-3">
+            <Button
+              type="primary"
+              onClick={() => {
+                addForm.validateFields().then(({ label }) => {
+                  saveFilter?.(label);
+                  setAddVisible(false);
+                });
               }}
-              key={item.key}
-              className="ml-2"
-            />
-          );
-        })}
+            >
+              {i18n.t('ok')}
+            </Button>
+            <span
+              className="text-white ml-3 cursor-pointer"
+              onClick={() => {
+                addForm.resetFields();
+                setAddVisible(false);
+              }}
+            >
+              {i18n.t('cancel')}
+            </span>
+          </div>
+        </Form>
       </div>
-    </div>
-  );
-};
+    );
+
+    const content = (
+      <div className="flex-1">
+        <div className="h-full flex flex-col overflow-hidden">
+          <div className=" h-[48px] flex-h-center justify-between">
+            <div className="flex-h-center">
+              <span>{i18n.t('common:filter')}</span>
+            </div>
+            <ErdaIcon
+              type="guanbi"
+              fill="white"
+              color="white"
+              size={20}
+              className="text-white cursor-pointer"
+              onClick={() => setVisible(false)}
+            />
+          </div>
+          <div className="flex justify-start flex-1 overflow-hidden">
+            {!hideSave ? (
+              <ConfigSelector
+                className="overflow-auto"
+                list={configList}
+                value={currentConfig}
+                isNew={isNew}
+                defaultValue={defaultConfig}
+                onChange={onConfigChange}
+                onDeleteFilter={onDeleteFilter}
+                onSaveFilter={saveFilter}
+              />
+            ) : null}
+            <div className={'erda-configurable-filter-body ml-4 pr-2 overflow-auto flex-1'}>
+              <Form form={form} layout="vertical" onValuesChange={onValuesChange}>
+                <Row>
+                  {fieldsList
+                    ?.filter((item) => !item.outside)
+                    ?.map((item, index: number) => {
+                      return (
+                        <Col span={12} key={item.key} className={index % 2 === 1 ? 'pl-2' : 'pr-2'}>
+                          <RenderFormItem
+                            required={false}
+                            {...defaultProcessField(processField ? processField(item) : item)}
+                          />
+                        </Col>
+                      );
+                    })}
+                </Row>
+              </Form>
+            </div>
+          </div>
+
+          <div className="erda-configurable-filter-footer flex justify-end mt-3">
+            {hideSave ? (
+              <Button className="mx-1" onClick={setAllOpen}>
+                {i18n.t('clear')}
+              </Button>
+            ) : isNew && currentConfig ? (
+              <Popover
+                content={addConfigContent}
+                visible={addVisible}
+                onVisibleChange={setAddVisible}
+                trigger={['click']}
+                overlayClassName="erda-configurable-filter-add"
+                getPopupContainer={(triggerNode) => triggerNode.parentElement as HTMLElement}
+              >
+                <Button
+                  className="mx-1 cursor-pointer rounded-sm px-2 py-1 flex-h-center"
+                  onClick={() => setAddVisible(true)}
+                >
+                  <ErdaIcon size={16} fill="white" type="baocun" className="mr-1" /> {i18n.t('dop:new filter')}
+                </Button>
+              </Popover>
+            ) : null}
+            <Button
+              className="mx-1"
+              onClick={() => {
+                setVisible(false);
+                onClose?.();
+              }}
+            >
+              {i18n.t('cancel')}
+            </Button>
+            <Button type="primary" className="ml-1 mr-2 bg-purple-deep border-purple-deep" onClick={onFilter}>
+              {i18n.t('common:filter')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+    const getFilterName = () => {
+      return getItemByValues(formValue, configList, fieldsList)?.label || i18n.t('common:filter');
+    };
+
+    const isAllOpen = !!(
+      formValue &&
+      !isEmpty(formValue) &&
+      Object.keys(formValue).find((key) => formValue[key] && !isEmpty(formValue[key]))
+    );
+
+    return (
+      <div className={'flex items-center'}>
+        <div className="flex-h-center bg-default-06 rounded-sm">
+          <Popover
+            content={content}
+            visible={visible}
+            forceRender
+            trigger={['click']}
+            overlayClassName={`erda-configurable-filter ${hideSave ? 'w-[720px]' : 'w-[960px]'}`}
+            placement="bottomLeft"
+            onVisibleChange={(v: boolean) => {
+              setVisible(v);
+              !v && onClose?.();
+            }}
+          >
+            <div
+              className={`flex-h-center erda-configurable-filter-btn py-1 px-2 rounded-sm leading-none cursor-pointer`}
+              onClick={() => setVisible(true)}
+            >
+              <Badge dot={isAllOpen}>
+                <div className="flex-h-center">
+                  <ErdaIcon type="futaishaixuan" className="filter-icon" size={14} />
+                  <span className="mx-1 filter-text">{getFilterName()}</span>
+                </div>
+              </Badge>
+              <ErdaIcon type="caret-down" />
+            </div>
+          </Popover>
+          {isAllOpen ? (
+            <div
+              className="erda-configurable-filter-clear-btn p-1 rounded-sm leading-none cursor-pointer"
+              onClick={() => {
+                setAllOpen();
+                onFilter();
+              }}
+            >
+              <ErdaIcon type="zhongzhi" color="currentColor" size={20} className="relative top-px" />
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex-h-center">
+          {externalField?.map((item) => {
+            return (
+              <ExternalItem
+                itemData={item}
+                value={externalValue?.[item.key]}
+                onChange={(v) => {
+                  setExternalValue((prev) => ({ ...prev, [item.key]: v }));
+                }}
+                key={item.key}
+                className="ml-2"
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  },
+);
 
 export default ConfigurableFilter;


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter bug when form items depend on each other

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link]()


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix configurable filter bug when form items depend on each other. |
| 🇨🇳 中文    |  修复了可配置筛选器在表单项相互依赖时的bug。  |


## Need cherry-pick to release versions?
❎ No

