### PR TITLE
fix(dop): fix tabs not display when there is too much content

### DIFF
--- a/shell/app/modules/project/pages/release/components/application-detail.tsx
+++ b/shell/app/modules/project/pages/release/components/application-detail.tsx
@@ -12,18 +12,18 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Button, Tabs, Modal, message, Form, Divider } from 'antd';
+import { Button, Divider, Form, Modal, Tabs } from 'antd';
 import moment from 'moment';
 import i18n from 'i18n';
 import { goTo } from 'common/utils';
-import { UserInfo, FileEditor, RenderFormItem, MarkdownEditor } from 'common';
+import { FileEditor, MarkdownEditor, RenderFormItem, UserInfo } from 'common';
 import ErdaTable from 'common/components/table';
 import routeInfoStore from 'core/stores/route';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import orgStore from 'app/org-home/stores/org';
 import FileContainer from 'application/common/components/file-container';
-import { getReleaseDetail, formalRelease, updateRelease, checkVersion } from 'project/services/release';
+import { checkVersion, formalRelease, getReleaseDetail, updateRelease } from 'project/services/release';
 
 import './form.scss';
 
@@ -138,8 +138,8 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
 
   return (
     <div className="release-releaseDetail release-form h-full pb-16 relative">
-      <Form layout="vertical" form={form} className="h-full overflow-auto">
-        <Tabs defaultActiveKey="1">
+      <Form layout="vertical" form={form} className="h-full">
+        <Tabs defaultActiveKey="1" className="h-full">
           <TabPane tab={i18n.t('dop:basic information')} key="1">
             <div className="mb-4 pl-0.5">
               {isEdit ? (
@@ -202,7 +202,7 @@ const ReleaseApplicationDetail = ({ isEdit = false }: { isEdit: boolean }) => {
             />
           </TabPane>
           <TabPane tab="dice.yml" key="3">
-            <FileContainer className="mt-3" name="dice.yml">
+            <FileContainer name="dice.yml">
               <FileEditor name="dice.yml" fileExtension="yml" value={releaseDetail.diceyml} readOnly />
             </FileContainer>
           </TabPane>

--- a/shell/app/modules/project/pages/release/components/form.scss
+++ b/shell/app/modules/project/pages/release/components/form.scss
@@ -19,4 +19,13 @@
     background-color: $color-default-04 !important;
     border: none;
   }
+
+  .ant-tabs {
+    display: flex;
+
+    .ant-tabs-content-holder {
+      flex: 1;
+      overflow: auto;
+    }
+  }
 }


### PR DESCRIPTION
## What this PR does / why we need it:

 fix tabs not display when there is too much content

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [【线上问题】【制品】制品详情中 dice.yml内容比较多的时候滚动后菜单也跟着滚动不显示了](https://erda.cloud/erda/dop/projects/387/issues/all?id=285643&iterationID=1090&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix tabs not display when there is too much content in dice.yml |
| 🇨🇳 中文    | 修复了 dice.yml  中内容过多时，tab不显示的问题 |


## Need cherry-pick to release versions?
✅ Yes(version is required)

release/1.6-alpha.4
