### PR TITLE
fix(common): config table batch operations disabled bug

### DIFF
--- a/shell/app/config-page/components/table/table.tsx
+++ b/shell/app/config-page/components/table/table.tsx
@@ -271,7 +271,7 @@ const BatchOperation = (props: IBatchProps) => {
     return fullMenus.map((mItem) => {
       const disabledProps = selectedRowKeys?.length
         ? {
-            disabled: has(mItem, 'disabled') ? mItem.disabeld : !chosenOpts.includes(mItem.key),
+            disabled: has(mItem, 'disabled') ? mItem.disabled : !chosenOpts.includes(mItem.key),
             disabledTip: i18n.t('exist item which not match operation'),
           }
         : { disabled: true, disabledTip: i18n.t('no items selected') };


### PR DESCRIPTION
## What this PR does / why we need it:
Fix config table batch operations disabled bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed the disable bug of the table batch operation button on the componentized protocol page.  |
| 🇨🇳 中文    |  修复了组件化协议页面中表格批量操作按钮的禁用bug。  |


## Need cherry-pick to release versions?
❎ No

