### PR TITLE
feat: create release add latest filter

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -108,6 +108,7 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
 
   const getReleases = React.useCallback(
     async (_pageNo: number, applicationId?: string | number) => {
+      setPageNo(_pageNo);
       const res = await getReleaseList({
         projectId,
         applicationId: applicationId !== 0 ? applicationId : undefined,
@@ -139,10 +140,9 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
   const selectApp = React.useCallback(
     (item: RELEASE.ApplicationDetail) => {
       setAppId(item.id);
-      setPageNo(1);
       getReleases(1, item.id);
     },
-    [setAppId, setPageNo, getReleases],
+    [setAppId, getReleases],
   );
 
   const searchApp = (q: string) => {
@@ -217,15 +217,14 @@ const ReleaseForm = ({ readyOnly = false }: { readyOnly?: boolean }) => {
               current: pageNo,
               pageSize: PAGINATION.pageSize,
               onChange: (_pageNo: number) => {
-                setPageNo(_pageNo);
                 getReleases(_pageNo, appId);
               },
             },
-            // rightSlot: (
-            //   <Checkbox checked={isLatest} onChange={(e: CheckboxChangeEvent) => setIsLatest(e.target.checked)}>
-            //     <span className="text-white">{i18n.t('dop:aggregate by branch')}</span>
-            //   </Checkbox>
-            // ),
+            rightSlot: (
+              <Checkbox checked={isLatest} onChange={(e: CheckboxChangeEvent) => setIsLatest(e.target.checked)}>
+                <span className="text-white">{i18n.t('dop:aggregate by branch')}</span>
+              </Checkbox>
+            ),
           },
           readOnlyRender: (value: { active: boolean; list: RELEASE.ReleaseDetail[] }) => {
             return (


### PR DESCRIPTION
## What this PR does / why we need it:
Create release add latest filter.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/155500951-251ed395-f027-49b0-ad53-14495ff7eb1e.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Added filter by branch aggregation when creating project artifacts to select application artifacts. |
| 🇨🇳 中文    | 创建项目制品选择应用制品时，增加按分支聚合的筛选。 |


## Need cherry-pick to release versions?
❎ No

