### PR TITLE
fix: create release style bug in firefox

### DIFF
--- a/shell/app/modules/project/pages/release/components/form.tsx
+++ b/shell/app/modules/project/pages/release/components/form.tsx
@@ -341,7 +341,7 @@ const renderSelectedItem = (item: RELEASE.ReleaseDetail, isDark: boolean) => {
         >
           {item.version}
         </div>
-        <div className="text-xs flex mt-1">
+        <div className="text-xs flex my-1">
           <div className={isDark ? 'text-white-6' : 'text-default-6'}>{i18n.t('dop:owned application')}</div>
           <div className="ml-2 flex-1 min-w-0 truncate" title={item.applicationName}>
             {item.applicationName}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix create release style bug in firefox.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/155639181-765c464d-07b1-4fc4-a478-ca537ce9fd49.png)
->
![image](https://user-images.githubusercontent.com/82502479/155639350-fbae7fd3-9272-43a2-b46c-b5b7d08dc1fd.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed styling issues when creating project artifacts in Firefox.  |
| 🇨🇳 中文    | 修复了在火狐浏览器下创建项目制品时的样式问题。 |


## Need cherry-pick to release versions?
❎ No

