### PR TITLE
fix(common): configurable filter required form item remove the clear button

### DIFF
--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -102,7 +102,7 @@ interface FieldItem extends IFormItem {
 }
 
 const defaultProcessField = (item: FieldItem) => {
-  const { type, itemProps, defaultValue, placeholder, disabled, mode } = item;
+  const { type, itemProps, defaultValue, placeholder, disabled, mode, required } = item;
   const field: IFormItem = { ...item };
 
   field.name = item.key;
@@ -111,7 +111,7 @@ const defaultProcessField = (item: FieldItem) => {
       mode: mode !== 'single' ? 'multiple' : false,
       ...itemProps,
       showArrow: true,
-      allowClear: true,
+      allowClear: !required,
       suffixIcon: <ErdaIcon type="caret-down" color="currentColor" className="text-white-4" />,
       clearIcon: <span className="p-1">{i18n.t('common:clear')}</span>,
       getPopupContainer: () => document.body,


### PR DESCRIPTION
## What this PR does / why we need it:
Configurable filter required form item remove the clear.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/155944601-749ed2f6-4da5-4699-901d-3706fc1401b1.png)
->
![image](https://user-images.githubusercontent.com/82502479/155944631-7b0e06a8-9865-4d25-8f9f-ba86f255ad99.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Remove the clear button from the mandatory field in configurable filters. |
| 🇨🇳 中文    |  可配置筛选器中，必填项去掉清除按钮。  |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.0
