### PR TITLE
fix(dop): fix land page org list error

### DIFF
--- a/shell/app/common/utils/__tests__/index.test.tsx
+++ b/shell/app/common/utils/__tests__/index.test.tsx
@@ -13,33 +13,34 @@
 
 import React from 'react';
 import {
-  isPromise,
-  isImage,
-  removeProtocol,
-  ossImg,
-  uuid,
-  isValidJsonStr,
-  insertWhen,
-  reorder,
-  encodeHtmlTag,
+  batchExecute,
+  colorToRgb,
   convertToFormData,
-  getFileSuffix,
-  filterOption,
-  regRules,
-  isClassComponent,
   countPagination,
-  notify,
+  encodeHtmlTag,
   equalByKeys,
+  extractPathParams,
+  filterOption,
+  generatePath,
+  getFileSuffix,
+  getOrgFromPath,
+  getTimeRanges,
+  insertWhen,
+  interpolationComp,
+  isClassComponent,
+  isImage,
+  isPromise,
+  isValidJsonStr,
+  notify,
+  ossImg,
+  pickRandomlyFromArray,
+  regRules,
+  removeProtocol,
+  reorder,
   setApiWithOrg,
   sleep,
-  extractPathParams,
-  generatePath,
-  batchExecute,
+  uuid,
   validators,
-  getTimeRanges,
-  interpolationComp,
-  colorToRgb,
-  pickRandomlyFromArray,
 } from 'common/utils';
 
 class ClassComp extends React.Component {
@@ -219,5 +220,11 @@ describe('utils', () => {
     expect(pickRandomlyFromArray(arr, 0)).toEqual([]);
     expect(pickRandomlyFromArray(arr, 4)).toHaveLength(4);
     expect(pickRandomlyFromArray(arr, 7)).toEqual(arr);
+  });
+  it('getOrgFromPath should work well', () => {
+    window.location.pathname = '/';
+    expect(getOrgFromPath()).toBe('org');
+    window.location.pathname = process.env.mock_pathname!;
+    expect(getOrgFromPath()).toBe(process.env.mock_pathname?.split('/')[1]);
   });
 });

--- a/shell/app/common/utils/index.ts
+++ b/shell/app/common/utils/index.ts
@@ -403,7 +403,7 @@ export const isValidJsonStr = (_jsonStr = '') => {
 };
 
 export const getOrgFromPath = () => {
-  return get(location.pathname.split('/'), '[1]') || '-';
+  return get(location.pathname.split('/'), '[1]') || 'org';
 };
 
 export const setApiWithOrg = (api: string) => {

--- a/shell/app/org-home/pages/land/index.tsx
+++ b/shell/app/org-home/pages/land/index.tsx
@@ -16,23 +16,27 @@ import orgStore from 'app/org-home/stores/org';
 import { ErdaIcon } from 'common';
 import i18n from 'i18n';
 import React from 'react';
+import { debounce } from 'lodash';
 import { useClickAway } from 'react-use';
 import { erdaEnv } from 'common/constants';
 import UserMenu from 'layout/pages/page-container/components/navigation/user-menu';
 import './index.scss';
 
 const LandPage = () => {
-  const orgs = orgStore.useStore((s) => s.orgs);
+  const filteredList = orgStore.useStore((s) => s.orgs);
+  const { getJoinedOrgs } = orgStore.effects;
   const [activeOrg, setActiveOrg] = React.useState<any>(null);
   const [showOptions, setShowOptions] = React.useState(false);
   const [filterKey, setFilterKey] = React.useState('');
-
+  const debouncedChange = React.useRef(debounce(getJoinedOrgs, 1000));
   const ref = React.useRef(null);
   useClickAway(ref, () => {
     setShowOptions(false);
   });
 
-  const filteredList = orgs.filter((org) => org.displayName?.toLowerCase().includes(filterKey.toLowerCase()));
+  React.useEffect(() => {
+    debouncedChange.current({ q: filterKey, force: true });
+  }, [filterKey]);
 
   return (
     <div className="land-page flex items-center justify-center h-full">

--- a/shell/app/org-home/services/org.tsx
+++ b/shell/app/org-home/services/org.tsx
@@ -21,10 +21,10 @@ export const getOrgByDomain = (payload: ORG.IOrgReq): ORG.IOrg => {
     .then((response: any) => response.body);
 };
 
-export const getJoinedOrgs = (): Promise<RES_BODY<IPagingResp<ORG.IOrg>>> => {
+export const getJoinedOrgs = (payload?: { q?: string }): Promise<RES_BODY<IPagingResp<ORG.IOrg>>> => {
   return agent
     .get('/api/orgs')
-    .query({ pageNo: 1, pageSize: 100 })
+    .query({ pageNo: 1, pageSize: 100, ...payload })
     .then((response: any) => response.body);
 };
 

--- a/shell/app/org-home/stores/org.tsx
+++ b/shell/app/org-home/stores/org.tsx
@@ -11,12 +11,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 import { goTo } from 'common/utils';
-import { getSubSiderInfoMap, getAppCenterAppList } from 'app/menus';
+import { getAppCenterAppList, getSubSiderInfoMap } from 'app/menus';
 import layoutStore from 'layout/stores/layout';
 import { orgPerm } from 'user/stores/_perm-org';
 import { createStore } from 'core/cube';
 import userStore from 'app/user/stores';
-import { getOrgByDomain, getJoinedOrgs, updateOrg, getPublicOrgs } from '../services/org';
+import { getJoinedOrgs, getOrgByDomain, getPublicOrgs, updateOrg } from '../services/org';
 import { getResourcePermissions } from 'user/services/user';
 import permStore from 'user/stores/permission';
 import breadcrumbStore from 'app/layout/stores/breadcrumb';
@@ -93,7 +93,7 @@ const org = createStore({
     async updateOrg({ call, update }, payload: Merge<Partial<ORG.IOrg>, { id: number }>) {
       const currentOrg = await call(updateOrg, payload);
       breadcrumbStore.reducers.setInfo('curOrgName', payload.displayName);
-      await org.effects.getJoinedOrgs(true);
+      await org.effects.getJoinedOrgs({ force: true });
       update({ currentOrg });
     },
     async getOrgByDomain({ call, update, select }, payload: { orgName: string }) {
@@ -184,10 +184,11 @@ const org = createStore({
         }
       }
     },
-    async getJoinedOrgs({ call, select, update }, force?: boolean) {
+    async getJoinedOrgs({ call, select, update }, payload?: { force?: boolean; q?: string }) {
       const orgs = select((state) => state.orgs);
+      const { force, ...rest } = payload || {};
       if (!orgs.length || force) {
-        const { list } = await call(getJoinedOrgs);
+        const { list } = await call(getJoinedOrgs, rest);
         update({ orgs: list });
       }
     },


### PR DESCRIPTION
## What this PR does / why we need it:


## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [有平台管理员角色的账号着陆页可选择参与的企业列表数据错误](https://erda.cloud/erda/dop/projects/387/issues/all?id=281865&iterationID=1115&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix bug that landing page ORG list is incorrect under the platform administrator account |
| 🇨🇳 中文    | 修复平台管理员角色帐号下的着陆页 org 列表数据错误的问题 |


## Need cherry-pick to release versions?
✅ Yes(version is required)

release/2.0

