### PR TITLE
fix(cmp): i18n dashboard in O&M report

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,7 +334,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.7
+      '@erda-ui/dashboard-configurator': 2.0.8
       '@erda-ui/react-markdown-editor-lite': ^1.4.7
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -483,7 +483,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.7_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.8_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -5688,8 +5688,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.7_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-Kwj5fnOCIACjs+Uzsmt1Qqk7ueKHCKWSWyzgZWN9Jbln8vkB05JPdNCnF/OHeRllEHpdyFEQ6bYEdj21qy5M/Q==}
+  /@erda-ui/dashboard-configurator/2.0.8_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-sRg7NX+iD5i10eSm0RE3EwmHc2S3HooWq5umG/W+pUDaM0UbWLWI9378D3Mhzjc4Df4ft+L+QrUhI4uQCPXkVA==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -7041,6 +7041,10 @@ packages:
     resolution: {integrity: sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs=, tarball: '@nodelib/fs.stat/download/@nodelib/fs.stat-1.1.3.tgz'}
     engines: {node: '>= 6'}
     dev: true
+
+  /@nodelib/fs.stat/2.0.5:
+    resolution: {integrity: sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=, tarball: '@nodelib/fs.stat/download/@nodelib/fs.stat-2.0.5.tgz'}
+    engines: {node: '>= 8'}
 
   /@npmcli/ci-detect/1.3.0:
     resolution: {integrity: sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==}
@@ -14807,7 +14811,7 @@ packages:
     resolution: {integrity: sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==}
     engines: {node: '>=8'}
     dependencies:
-      '@nodelib/fs.stat': registry.npmmirror.com/@nodelib/fs.stat/2.0.5
+      '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': registry.nlark.com/@nodelib/fs.walk/1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
@@ -29445,9 +29449,3 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': registry.nlark.com/@nodelib/fs.scandir/2.1.5
       fastq: 1.13.0
-
-  registry.npmmirror.com/@nodelib/fs.stat/2.0.5:
-    resolution: {integrity: sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=, registry: https://registry.npmmirror.com/, tarball: https://registry.npmmirror.com/@nodelib/fs.stat/download/@nodelib/fs.stat-2.0.5.tgz}
-    name: '@nodelib/fs.stat'
-    version: 2.0.5
-    engines: {node: '>= 8'}

--- a/shell/app/modules/cmp/pages/alarm-report/report-records/index.tsx
+++ b/shell/app/modules/cmp/pages/alarm-report/report-records/index.tsx
@@ -59,7 +59,7 @@ const ReportRecords = () => {
         }
         if (['chart:line', 'chart:bar', 'chart:area'].includes(chartType)) {
           const { time, results } = staticData;
-          if (results[0].data.length > 1) {
+          if (results[0].data?.length > 1) {
             set(_item, 'view.staticData', {
               time,
               metricData: map(results[0].data, (itemData) => values(itemData)[0]),
@@ -67,7 +67,7 @@ const ReportRecords = () => {
           } else {
             set(_item, 'view.staticData', {
               time,
-              metricData: results[0].data[0],
+              metricData: results[0].data?.[0],
             });
           }
         }

--- a/shell/package.json
+++ b/shell/package.json
@@ -42,7 +42,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.7",
+    "@erda-ui/dashboard-configurator": "2.0.8",
     "@erda-ui/react-markdown-editor-lite": "^1.4.7",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:
fix: i18n dashboard in O&M report

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [【集成环境】【国际化】运维报告，报告中的图例没有翻译](https://erda.cloud/erda/dop/projects/387/issues/all?id=279274&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=0&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  O&M report legend internationalization  |
| 🇨🇳 中文    | 运维报告图例国际化 |


## Need cherry-pick to release versions?
❎ No

