### PR TITLE
fix(common): configurable filter input value display bug

### DIFF
--- a/shell/app/common/components/configurable-filter/index.tsx
+++ b/shell/app/common/components/configurable-filter/index.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import { Popover, Row, Col, Form, Button, Badge, Input, FormInstance } from 'antd';
 import { ErdaIcon, RenderFormItem, IFormItem } from 'common';
-import { isEmpty, has } from 'lodash';
+import { isEmpty, has, isEqual } from 'lodash';
 import ExternalItem from './external-item';
 import { useUpdateEffect } from 'react-use';
 import i18n from 'i18n';
@@ -210,8 +210,16 @@ const ConfigurableFilter = React.forwardRef(
     }, [formValue, form]);
 
     useUpdateEffect(() => {
-      onFilter();
+      if (!isEqual(_externalValue, externalValue)) {
+        onFilter();
+      }
     }, [externalValue]);
+
+    useUpdateEffect(() => {
+      if (!isEqual(_externalValue, externalValue)) {
+        setExternalValue(_externalValue);
+      }
+    }, [_externalValue]);
 
     const onConfigChange = (config: ConfigData) => {
       setCurrentConfig(config.id);


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter input value display bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/156171997-d9ec5d80-e53d-4ce1-9f3c-710f742167cc.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | In the project pipeline, the filter criteria are cleared when the pipeline classification is switched, but the input box in the filter still shows the previous filter value.  |
| 🇨🇳 中文    |  项目级流水线中，在切换流水线分类时会清空筛选的筛选条件，但是筛选器中的输入框还显示着之前的筛选值。  |


## Need cherry-pick to release versions?
❎ No

