### PR TITLE
fix(dop): create release remove groups number limit

### DIFF
--- a/shell/app/modules/project/pages/release/components/release-select.tsx
+++ b/shell/app/modules/project/pages/release/components/release-select.tsx
@@ -223,7 +223,7 @@ function ReleaseSelect<T extends { applicationId: string; title: string }>(props
             </Collapse>
           </Timeline.Item>
         ))}
-        {!readOnly && groupList.length < 5 ? (
+        {!readOnly ? (
           <Timeline.Item
             dot={
               <div className="leading-4">


### PR DESCRIPTION
## What this PR does / why we need it:
Create release remove groups number limit.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Remove the limit on the number of groupings of artifacts when creating project-level artifacts.  |
| 🇨🇳 中文    |  创建项目级制品时，去掉制品分组的数量限制。  |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.0

