### PR TITLE
fix(msp): compatibility with old deployment center links

### DIFF
--- a/shell/app/modules/msp/alarm-manage/alert-list/notification/base-notification-detail.tsx
+++ b/shell/app/modules/msp/alarm-manage/alert-list/notification/base-notification-detail.tsx
@@ -35,7 +35,7 @@ const BaseNotificationDetail: React.FC<IProps> = ({ scope, scopeId, id }) => {
         e.preventDefault();
         let { href } = e.target as HTMLAnchorElement;
         const reg =
-          /^\S+?\/workBench\/projects\/(?<projectId>\d+)\/apps\/(?<appId>\d+)\/deploy\/runtimes\/(?<runtimeId>\d+)\/overview$/;
+          /^\S+?\/projects\/(?<projectId>\d+)\/apps\/(?<appId>\d+)\/deploy\/runtimes\/(?<runtimeId>\d+)\/overview$/;
         const match = href.match(reg);
         if (match && match.groups) {
           const { projectId, appId, runtimeId } = match.groups;

--- a/shell/app/modules/msp/alarm-manage/index.ts
+++ b/shell/app/modules/msp/alarm-manage/index.ts
@@ -95,6 +95,7 @@ const alarmManageRouters = [
     alwaysShowTabKey: 'events',
     routes: [
       {
+        layout: { noWrapper: true },
         getComp: (cb: RouterGetComp) => cb(import('msp/alarm-manage/alert-list/events')),
       },
       {


### PR DESCRIPTION
## What this PR does / why we need it:

compatibility with old deployment center links

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=288812&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1115&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | compatibility with old deployment center links |
| 🇨🇳 中文    | 兼容旧部署中心链接 |


## Need cherry-pick to release versions?
❎ No

