### PR TITLE
fix(dop): project pipeline table display bug when pipeline names are too long

### DIFF
--- a/shell/app/config-page/components/table/v2/utils.tsx
+++ b/shell/app/config-page/components/table/v2/utils.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 import { Avatar, Dropdown, Menu, Popconfirm, Progress, Tooltip } from 'antd';
 import moment from 'moment';
-import { Badge, Copy, ErdaIcon, TagsRow } from 'common';
+import { Badge, Copy, ErdaIcon, TagsRow, Ellipsis } from 'common';
 import { filter, get, has, isArray, map, sortBy } from 'lodash';
 import { getAvatarChars } from 'app/common/utils';
 import { WithAuth } from 'user/common';
@@ -228,10 +228,12 @@ export const getRender = (val: Obj, record: Obj, extra?: Extra) => {
 
         if (tip) {
           value = (
-            <Tooltip overlayClassName="whitespace-pre" title={tip}>
+            <Tooltip overlayClassName="whitespace-pre" title={tip} className="truncate w-full inline-block">
               {value}
             </Tooltip>
           );
+        } else {
+          value = <Ellipsis title={value} />;
         }
 
         Comp = enableCopy ? (


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project pipeline table display bug when pipeline names are too long.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=289496&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1090&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/156518541-af1e5b8e-bf75-451e-b9a7-5d9d1e445292.png)
->
![image](https://user-images.githubusercontent.com/82502479/156518450-ad37aa86-f249-4ce4-8eec-97758e39dbf8.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed a bug where pipeline names were too long and the list was not complete. |
| 🇨🇳 中文    |  修复了流水线名称过长时，列表中显示不全的bug。  |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.0

