### PR TITLE
fix(common): project setting quota table reload bug

### DIFF
--- a/shell/app/modules/project/pages/settings/components/project-cluster.tsx
+++ b/shell/app/modules/project/pages/settings/components/project-cluster.tsx
@@ -118,13 +118,14 @@ const ProjectCluster = ({ hasEditAuth }: IProps) => {
   const clusterList = clusterStore.useStore((s) => s.list);
   const { getClusterList } = clusterStore.effects;
   const info = projectStore.useStore((s) => s.info);
-  const { updateProject } = projectStore.effects;
+  const { updateProject, getProjectInfo } = projectStore.effects;
   const [loading] = useLoading(clusterStore, ['getClusterList']);
+  const [projectInfoLoading] = useLoading(projectStore, ['getProjectInfo']);
 
   React.useEffect(() => {
     hasEditAuth && getClusterList();
   }, [getClusterList, hasEditAuth]);
-  const { resourceConfig } = info;
+  const { resourceConfig, id } = info;
 
   const options: object[] = [];
   clusterList.forEach((item) => {
@@ -149,10 +150,13 @@ const ProjectCluster = ({ hasEditAuth }: IProps) => {
 
   const readonlyForm = (
     <ErdaTable
-      loading={loading}
+      loading={loading || projectInfoLoading}
       rowKey="workspace"
       dataSource={tableData}
-      onChange={() => getClusterList()}
+      onChange={() => {
+        getProjectInfo(id);
+        hasEditAuth && getClusterList();
+      }}
       columns={[
         {
           key: 'workspace',


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project setting quota table reload bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed bug where project settings - project quota table refresh button would not work.  |
| 🇨🇳 中文    |  修复了项目设置-项目配额表格刷新按钮失效的bug。  |


## Need cherry-pick to release versions?
❎ No

