### PR TITLE
fix: update backend url tip and default value

### DIFF
--- a/cli/lib/init.ts
+++ b/cli/lib/init.ts
@@ -56,8 +56,8 @@ export default async ({
       {
         type: 'input',
         name: 'backendUrl',
-        message: 'Backend Url(API server):',
-        default: 'https://openapi.erda.io',
+        message: 'Online ui url:',
+        default: 'https://erda.io',
       },
     ]);
     newConfig.BACKEND_URL = backendUrl;

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erda-ui/cli",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Command line interface for rapid Erda UI development",
   "bin": {
     "erda-ui": "dist/bin/erda.js"


### PR DESCRIPTION
## What this PR does / why we need it:
In local dev mode, the `BACKEND_URL` is actually the online UI url, so change the default value to `erda.io`

**api proxy flow:**
// online:
ui -> scheduler -> proxy: isProd ? **replaceOrg** : originPath -> BACKEND_URL(openAPI)

// local vite:
ui -> vite -> BACKEND_URL(online ui) -> online scheduler -> ...

// local webpack:
ui -> scheduler -> proxy: isProd ? replaceOrg : **originPath** -> BACKEND_URL(online ui) -> online scheduler -> ...



## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  update cli initial default value   |
| 🇨🇳 中文    |    更新 cli 初始化的初始默认值   |


## Need cherry-pick to release versions?
❎ No

