### PR TITLE
fix(dop): dop application list router remove

### DIFF
--- a/shell/app/modules/dop/router.ts
+++ b/shell/app/modules/dop/router.ts
@@ -93,13 +93,6 @@ export default function getDopRouter(): RouteConfigItem[] {
             },
           ],
         },
-        // TODO: remove
-        {
-          path: 'apps',
-          breadcrumbName: i18n.t('joined apps'),
-          layout: { fullHeight: true },
-          getComp: (cb) => cb(import('application/common/app-list-protocol'), 'MyAppList'),
-        },
         {
           path: 'projects',
           breadcrumbName: i18n.t('dop:projects'),


### PR DESCRIPTION
## What this PR does / why we need it:
Dop application list router remove.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  The application list route in DevOps was deleted.  |
| 🇨🇳 中文    |  DevOps平台下的应用列表路由删除。  |


## Need cherry-pick to release versions?
❎ No

