### PR TITLE
fix: Tree component support node item draggable

### DIFF
--- a/shell/app/config-page/components/file-tree/file-tree.spec.d.ts
+++ b/shell/app/config-page/components/file-tree/file-tree.spec.d.ts
@@ -25,6 +25,8 @@ declare namespace CP_FILE_TREE {
     isColorIcon?: boolean;
     children?: INode[];
     selectable?: boolean;
+    draggable?: boolean;
+    dropPosition?: number[];
     clickToExpand?: boolean;
     isLeaf?: boolean;
     operations?: Obj;

--- a/shell/app/config-page/components/file-tree/file-tree.tsx
+++ b/shell/app/config-page/components/file-tree/file-tree.tsx
@@ -346,10 +346,18 @@ export const FileTree = (props: CP_FILE_TREE.Props) => {
     }
   };
 
+  const draggableFun = (node: CP_FILE_TREE.INode) => {
+    return node.draggable;
+  };
+
   let dragProps = {};
   if (draggable) {
     dragProps = {
       onDrop,
+      draggable: draggableFun,
+      allowDrop: ({ dropNode, dropPosition }: { dropNode: CP_FILE_TREE.INode; dropPosition: number }) => {
+        return (dropNode.dropPosition || []).includes(dropPosition);
+      },
     };
   }
 
@@ -369,7 +377,6 @@ export const FileTree = (props: CP_FILE_TREE.Props) => {
       <Tree
         {...rest}
         {...dragProps}
-        draggable={draggable}
         treeData={useData}
         onExpand={onExpand}
         onSelect={onClickNode}


### PR DESCRIPTION
## What this PR does / why we need it:
fix: Tree component support node item draggable

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=257907&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDM5MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTAwfQ%3D%3D&iterationID=-1&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![d27fc6fde8e4c0c9db66fdee9d06ae23](https://user-images.githubusercontent.com/15364706/157407358-53c751fe-fde3-4e71-824b-df32f19a9ea2.gif)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: Tree component support node item draggable            |
| 🇨🇳 中文    |    fix: Tree 组件支持节点的拖拽控制          |


## Need cherry-pick to release versions?
❎ No

