### PR TITLE
fix(dop): configurable filter text color bug

### DIFF
--- a/shell/app/common/components/configurable-filter/index.scss
+++ b/shell/app/common/components/configurable-filter/index.scss
@@ -48,11 +48,6 @@
 
     .ant-select-item {
       padding: 5px 8px;
-      color: $white;
-    }
-
-    div.ant-select-item-option-active {
-      background-color: rgba($white, 0.08);
     }
 
     .ant-select-item-option-selected {
@@ -113,7 +108,6 @@
   }
 
   .ant-input {
-    color: rgba($white, 0.6);
     background-color: $color-default-06 !important;
     border: none;
   }
@@ -124,9 +118,6 @@
   }
 
   &-body {
-    div.ant-form-item-label label {
-      color: $color-white-6;
-    }
     .ant-form-vertical .ant-form-item-label {
       padding-bottom: 4px;
     }
@@ -157,7 +148,6 @@
       }
 
       .ant-select-item-group {
-        color: rgba($white, 0.6);
         font-weight: bold;
       }
     }


### PR DESCRIPTION
## What this PR does / why we need it:
Fix configurable filter text color bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=292616&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1115&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/158141404-76e774a7-0d59-4e75-9380-125256f98d4c.png)
->
![image](https://user-images.githubusercontent.com/82502479/158141435-41920bc7-28b5-4d49-a662-3057cc5e1e63.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed a text color bug in configurable filters.  |
| 🇨🇳 中文    |   修复了可配置筛选器的文字颜色bug。  |


## Need cherry-pick to release versions?
❎ No

