### PR TITLE
fix(common): save the display status of table columns

### DIFF
--- a/shell/app/common/components/members-table/index.tsx
+++ b/shell/app/common/components/members-table/index.tsx
@@ -71,6 +71,7 @@ interface IProps {
     showAuthorize?: boolean;
   };
   roleFilter?(data: Obj): Obj;
+  tableKey?: string;
 }
 
 const MembersTable = ({
@@ -84,6 +85,7 @@ const MembersTable = ({
   buttonInCard = false,
   topContent = null,
   roleFilter,
+  tableKey,
 }: IProps) => {
   const memberLabels = memberLabelStore.useStore((s) => s.memberLabels);
   const { getMemberLabels } = memberLabelStore.effects;
@@ -559,6 +561,7 @@ const MembersTable = ({
     };
     return (
       <ErdaTable
+        tableKey={tableKey}
         slot={<FilterGroup list={filterList} onChange={debounce(onSearchMembers, 1000)} />}
         rowKey={'userId'}
         rowSelection={

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -49,6 +49,14 @@ export interface IProps<T extends object = any> extends TableProps<T> {
   hideColumnConfig?: boolean;
   whiteFooter?: boolean;
   whiteHead?: boolean;
+  tableKey?: string;
+}
+
+interface ColumnsConfig {
+  [key: string]: {
+    dataIndex: string;
+    hidden: boolean;
+  };
 }
 
 const sortIcon = {
@@ -60,6 +68,15 @@ const alignMap = {
   center: 'justify-center',
   left: 'justify-start',
   right: 'justify-end',
+};
+
+const saveColumnsConfig = (key: string, config: ColumnsConfig) => {
+  localStorage.setItem(`table-key-${key}`, JSON.stringify(config));
+};
+
+const getColumnsConfig = (key: string) => {
+  const str = localStorage.getItem(`table-key-${key}`);
+  return str ? JSON.parse(str) : {};
 };
 
 function WrappedTable<T extends object = any>({
@@ -82,11 +99,12 @@ function WrappedTable<T extends object = any>({
   wrapperClassName = '',
   whiteFooter = false,
   whiteHead = false,
+  tableKey,
   ...props
 }: IProps<T>) {
   const dataSource = React.useMemo<T[]>(() => (ds as T[]) || [], [ds]);
   const [columns, setColumns] = React.useState<Array<ColumnProps<T>>>(allColumns);
-  const columnsConfig = React.useRef({});
+  const columnsConfig = React.useRef(tableKey ? getColumnsConfig(tableKey) : {});
   const [sort, setSort] = React.useState<SorterResult<T>>({});
   const [selectedRowKeys, setSelectedRowKeys] = React.useState(rowSelection?.selectedRowKeys || []);
   const sortCompareRef = React.useRef<((a: T, b: T) => number) | null>(null);
@@ -224,8 +242,19 @@ function WrappedTable<T extends object = any>({
   React.useEffect(() => {
     const _columnsConfig = {};
     const _columns = allColumns.map(
-      ({ width = 300, sorter, title, render, icon, align, show, dataIndex, ...args }: ColumnProps<T>) => {
-        const _columnConfig = columnsConfig.current[dataIndex] || { dataIndex, hidden: show === false };
+      ({
+        width = 300,
+        sorter,
+        title,
+        render,
+        icon,
+        align,
+        show,
+        dataIndex,
+        hidden = false,
+        ...args
+      }: ColumnProps<T>) => {
+        const _columnConfig = columnsConfig.current[dataIndex] || { dataIndex, hidden: show === false || hidden };
         _columnsConfig[dataIndex] = _columnConfig;
 
         const { subTitle } = args;
@@ -305,7 +334,8 @@ function WrappedTable<T extends object = any>({
 
     columnsConfig.current = _columnsConfig;
     setColumns(_columns);
-  }, [allColumns, sorterMenu, sort, onRow]);
+    tableKey && saveColumnsConfig(tableKey, _columnsConfig);
+  }, [allColumns, sorterMenu, sort, onRow, tableKey]);
 
   const onReload = () => {
     if (onReloadProps) {
@@ -344,6 +374,8 @@ function WrappedTable<T extends object = any>({
             val.forEach((item) => {
               columnsConfig.current[item.dataIndex].hidden = item.hidden;
             });
+
+            tableKey && saveColumnsConfig(tableKey, columnsConfig.current);
             setColumns(val);
           }}
           onReload={onReload}

--- a/shell/app/common/components/table/interface.ts
+++ b/shell/app/common/components/table/interface.ts
@@ -34,6 +34,7 @@ export interface IActions<T> {
 }
 
 export interface ColumnProps<T> extends AntdColumnProps<T> {
+  dataIndex: string;
   width?: number | string;
   subTitle?: ((text: string, record: T, index: number) => React.ReactNode) | React.ReactNode;
   icon?: ((text: string, record: T, index: number) => React.ReactNode) | React.ReactNode;

--- a/shell/app/modules/application/pages/settings/components/app-notify/common-notify-group.tsx
+++ b/shell/app/modules/application/pages/settings/components/app-notify/common-notify-group.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import moment from 'moment';
 import i18n from 'i18n';
 import { cloneDeep, debounce, forEach, head, isEmpty, map, take } from 'lodash';
-import { Avatar,Button, FormInstance, Input, message, Modal, Select, Spin, Tooltip } from 'antd';
+import { Avatar, Button, FormInstance, Input, message, Modal, Select, Spin, Tooltip } from 'antd';
 import { ColumnProps, IActions } from 'app/common/components/table/interface';
 import { ErdaIcon, FormModal, MemberSelector } from 'common';
 import ErdaTable from 'common/components/table';
@@ -103,6 +103,7 @@ interface IProps {
     projectId?: number;
   };
   memberStore: any;
+  tableKey?: string;
 }
 
 export const ListTargets = ({
@@ -181,7 +182,7 @@ export const ListTargets = ({
   return targetsEle;
 };
 
-const NotifyGroup = ({ memberStore, commonPayload }: IProps) => {
+const NotifyGroup = ({ memberStore, commonPayload, tableKey }: IProps) => {
   const [notifyGroups, notifyGroupsPaging] = notifyGroupStore.useStore((s) => [s.notifyGroups, s.notifyGroupsPaging]);
   const { pageNo, pageSize, total } = notifyGroupsPaging;
   const userMap = useUserMap();
@@ -547,6 +548,7 @@ const NotifyGroup = ({ memberStore, commonPayload }: IProps) => {
       />
       <Spin spinning={loading}>
         <ErdaTable
+          tableKey={tableKey}
           rowKey="id"
           pagination={{ pageSize, current: pageNo, total }}
           dataSource={notifyGroups}

--- a/shell/app/modules/application/pages/settings/components/app-notify/notify-config.tsx
+++ b/shell/app/modules/application/pages/settings/components/app-notify/notify-config.tsx
@@ -42,9 +42,10 @@ interface IProps {
     module: string;
   };
   memberStore: any;
+  tableKey?: string;
 }
 
-export const NotifyConfig = ({ commonPayload, memberStore }: IProps) => {
+export const NotifyConfig = ({ commonPayload, memberStore, tableKey }: IProps) => {
   const roleMap = memberStore.useStore((s) => s.roleMap);
   const { getRoleMap } = memberStore.effects;
   const [notifyConfigs, notifyItems] = appNotifyStore.useStore((s) => [s.notifyConfigs, s.notifyItems]);
@@ -293,6 +294,7 @@ export const NotifyConfig = ({ commonPayload, memberStore }: IProps) => {
       />
       <Spin spinning={getNotifyConfigsLoading}>
         <ErdaTable
+          tableKey={tableKey}
           columns={columns}
           dataSource={notifyConfigs}
           actions={actions}

--- a/shell/app/modules/project/common/components/branch-rule.tsx
+++ b/shell/app/modules/project/common/components/branch-rule.tsx
@@ -46,6 +46,7 @@ interface IProps {
   operationAuth: boolean;
   scopeId: number;
   scopeType: string;
+  tableKey?: string;
 }
 
 const extraFieldsMap = {
@@ -161,7 +162,7 @@ const extraColumnsMap = {
 };
 
 const BranchRule = (props: IProps) => {
-  const { operationAuth, scopeId, scopeType } = props;
+  const { operationAuth, scopeId, scopeType, tableKey } = props;
   const branchRules = branchRuleStore.useStore((s) => s.branchRules);
   const { addBranchRule, getBranchRules, deleteBranchRule, updateBranchRule, clearBranchRule } = branchRuleStore;
   const [loading] = useLoading(branchRuleStore, ['getBranchRules']);
@@ -323,6 +324,7 @@ const BranchRule = (props: IProps) => {
         </WithAuth>
       </div>
       <ErdaTable
+        tableKey={tableKey}
         loading={loading}
         rowKey="id"
         dataSource={branchRules}

--- a/shell/app/modules/project/common/components/scan-rule.tsx
+++ b/shell/app/modules/project/common/components/scan-rule.tsx
@@ -27,6 +27,7 @@ interface IProps {
   operationAuth: boolean;
   scopeId: string;
   scopeType: string;
+  tableKey?: string;
 }
 
 const valueTypeMap = {
@@ -48,7 +49,7 @@ const valueRateMap = {
 const { Option } = Select;
 
 export default function ScanRule(props: IProps) {
-  const { operationAuth, scopeId, scopeType } = props;
+  const { operationAuth, scopeId, scopeType, tableKey } = props;
   const [
     { isEdit, visible, currentId, metricValue, appendedRowKeys, optionalRowKeys, loading, operationOptionalRules },
     updater,
@@ -395,6 +396,7 @@ export default function ScanRule(props: IProps) {
         )}
       </div>
       <ErdaTable
+        tableKey={tableKey}
         loading={tableLoading}
         columns={appendedColumns}
         dataSource={appendedScanRules}

--- a/shell/app/modules/project/pages/issue/issue-protocol.tsx
+++ b/shell/app/modules/project/pages/issue/issue-protocol.tsx
@@ -208,6 +208,7 @@ const IssueProtocol = ({ issueType }: IProps) => {
           },
           issueTable: {
             props: {
+              tableKey: 'issue-table',
               menuItemRender: (item: { text: string; status: string }) => (
                 <Badge text={item.text} status={item.status} showDot={false} />
               ),

--- a/shell/app/modules/project/pages/iteration/table.tsx
+++ b/shell/app/modules/project/pages/iteration/table.tsx
@@ -215,6 +215,7 @@ export const Iteration = () => {
         className="mb-2"
       />
       <ErdaTable
+        tableKey="issue-iteration"
         rowKey="id"
         dataSource={list}
         columns={columns}

--- a/shell/app/modules/project/pages/pipelines/components/pipeline-protocol.tsx
+++ b/shell/app/modules/project/pages/pipelines/components/pipeline-protocol.tsx
@@ -140,6 +140,7 @@ const PipelineProtocol = ({ application, getApps, setApp }: IProps) => {
                 whiteFooter: true,
                 styleNames: 'h-full',
                 wrapperClassName: 'flex-1',
+                tableKey: 'project-pipeline',
               },
               columnsRender: {
                 source: (_val: string, _record: string, map: { [key: string]: React.ReactNode }) => {

--- a/shell/app/modules/project/pages/release/release-protocol.tsx
+++ b/shell/app/modules/project/pages/release/release-protocol.tsx
@@ -103,6 +103,7 @@ const ReleaseProtocol = ({ isProjectRelease, applicationID }: IProps) => {
         customProps={{
           releaseTable: {
             props: {
+              tableKey: 'project-release',
               onRow: (record: RELEASE.ApplicationDetail) => ({
                 onClick: () => {
                   record.id && goTo(`${record.id}`);

--- a/shell/app/modules/project/pages/settings/components/project-cluster.tsx
+++ b/shell/app/modules/project/pages/settings/components/project-cluster.tsx
@@ -150,6 +150,7 @@ const ProjectCluster = ({ hasEditAuth }: IProps) => {
 
   const readonlyForm = (
     <ErdaTable
+      tableKey="project-setting-quota"
       loading={loading || projectInfoLoading}
       rowKey="workspace"
       dataSource={tableData}

--- a/shell/app/modules/project/pages/settings/components/project-settings.tsx
+++ b/shell/app/modules/project/pages/settings/components/project-settings.tsx
@@ -71,7 +71,14 @@ const ProjectSettings = () => {
                       </Link>
                     </div>
                   ),
-                  children: <MembersTable scopeKey={MemberScope.PROJECT} showAuthorize hasConfigAppAuth />,
+                  children: (
+                    <MembersTable
+                      tableKey="project-setting-member"
+                      scopeKey={MemberScope.PROJECT}
+                      showAuthorize
+                      hasConfigAppAuth
+                    />
+                  ),
                 },
               ]}
             />
@@ -94,6 +101,7 @@ const ProjectSettings = () => {
                   desc: i18n.t('dop:branch-config-tip'),
                   children: (
                     <BranchRule
+                      tableKey="project-setting-branch-rule"
                       operationAuth={permMap.setting.branchRule.operation.pass}
                       scopeId={+projectId}
                       scopeType="project"
@@ -120,6 +128,7 @@ const ProjectSettings = () => {
                       operationAuth={permMap.setting.scanRule.operation.pass}
                       scopeId={projectId}
                       scopeType="project"
+                      tableKey="project-setting-scan"
                     />
                   ),
                 },
@@ -183,6 +192,7 @@ const ProjectSettings = () => {
                     <NotifyConfig
                       memberStore={memberStore}
                       commonPayload={{ scopeType: 'project', scopeId: projectId, module: 'workbench' }}
+                      tableKey="project-setting-notify"
                     />
                   ),
                 },
@@ -202,6 +212,7 @@ const ProjectSettings = () => {
                     <NotifyGroup
                       memberStore={memberStore}
                       commonPayload={{ scopeType: 'project', scopeId: String(projectId) }}
+                      tableKey="project-setting-notify-group"
                     />
                   ),
                 },

--- a/shell/app/modules/project/pages/test-env/test-env.tsx
+++ b/shell/app/modules/project/pages/test-env/test-env.tsx
@@ -168,6 +168,7 @@ const TestEnv = ({ testType = 'manual', envID: _envID, envType: _envType, isSing
         showIcon
       />
       <ErdaTable
+        tableKey={testType === 'manual' ? 'manual-test-env' : 'auto-test-env'}
         rowKey={testType === 'manual' ? 'id' : 'ns'}
         columns={columns}
         dataSource={testType === 'manual' ? envList : autoEnvList}

--- a/shell/app/modules/project/pages/test-plan/test-plan-protocol.tsx
+++ b/shell/app/modules/project/pages/test-plan/test-plan-protocol.tsx
@@ -27,6 +27,13 @@ const AutoTestPlanList = () => {
         scenarioKey="auto-test-plan-list"
         scenarioType="auto-test-plan-list"
         inParams={inParams}
+        customProps={{
+          table: {
+            props: {
+              tableKey: 'auto-test-plan',
+            },
+          },
+        }}
       />
     </div>
   );

--- a/shell/app/modules/project/pages/test-plan/test-plan.tsx
+++ b/shell/app/modules/project/pages/test-plan/test-plan.tsx
@@ -293,6 +293,7 @@ const TestPlan = () => {
       </div>
       <Spin spinning={isFetching}>
         <ErdaTable
+          tableKey="manual-test-plan"
           className="test-plan-list"
           rowKey="id"
           columns={columns}

--- a/shell/app/modules/project/pages/test-report/index.tsx
+++ b/shell/app/modules/project/pages/test-report/index.tsx
@@ -48,6 +48,9 @@ const TestReport = () => {
         inParams={inParams}
         customProps={{
           table: {
+            props: {
+              tableKey: 'project-test-report',
+            },
             op: {
               operations: {
                 download: (op: IMeta) => {

--- a/shell/app/modules/project/pages/ticket/index.tsx
+++ b/shell/app/modules/project/pages/ticket/index.tsx
@@ -378,6 +378,7 @@ const Ticket = () => {
         </WithAuth>
       </div>
       <ErdaTable
+        tableKey="project-ticket"
         loading={loading}
         columns={columns}
         dataSource={list}


### PR DESCRIPTION
## What this PR does / why we need it:
Save the display status of table columns.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=293043&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1146&type=REQUIREMENT)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Save the display state of each table column so that the table column remains explicitly and implicitly unchanged as its data changes.  |
| 🇨🇳 中文    |  保存每个表格列的展示状态，使其数据发生变化时表格列显隐保持不变。  |


## Need cherry-pick to release versions?
❎ No

