### PR TITLE
fix(dop): config page table batch selection bug

### DIFF
--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -123,6 +123,10 @@ function WrappedTable<T extends object = any>({
     }
   }, [dataSource, rowKey, isFrontendPaging, getKey]);
 
+  React.useEffect(() => {
+    setSelectedRowKeys(rowSelection?.selectedRowKeys || []);
+  }, [rowSelection?.selectedRowKeys]);
+
   const onTableChange = React.useCallback(
     ({ pageNo, pageSize: size, sorter: currentSorter }) => {
       const { onChange: onPageChange } = pagination as TablePaginationConfig;


### PR DESCRIPTION
## What this PR does / why we need it:
Fix config page table batch selection bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/158544113-bdc3e7d9-d1d4-47be-b23c-a5be7a91be16.png)
->
![image](https://user-images.githubusercontent.com/82502479/158543697-3f6663ac-5b32-4ede-8731-9b87ecb45824.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed display bug for batch selection of componentized tables.  |
| 🇨🇳 中文    |  修复了组件化表格批量选择的显示bug。  |


## Need cherry-pick to release versions?
release/2.1-beta.1

