### PR TITLE
fix(dop): type in issue share link cause wrong filter item

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
@@ -195,7 +195,7 @@ export const EditIssueDrawer = (props: IProps) => {
   React.useEffect(() => {
     if (visible) {
       if (id) {
-        getIssueDetail({ type: issueType, id });
+        getIssueDetail({ id });
         getIssueStreams({ type: issueType, id, pageNo: 1, pageSize: 100 });
         getCustomFields();
       }
@@ -426,7 +426,7 @@ export const EditIssueDrawer = (props: IProps) => {
           savingRef.current = true;
           promise = updateIssue({ ...params, customUrl }).then(() => {
             getIssueStreams({ type: issueType, id: id as number, pageNo: 1, pageSize: 100 });
-            getIssueDetail({ type: issueType, id: id as number }).then(() => {
+            getIssueDetail({ id: id as number }).then(() => {
               savingRef.current = false;
             });
             // setHasEdited(false); // 更新后置为false

--- a/shell/app/modules/project/common/components/issue/subscribers-selector.tsx
+++ b/shell/app/modules/project/common/components/issue/subscribers-selector.tsx
@@ -58,7 +58,7 @@ export const SubscribersSelector = (props: IProps) => {
   }, [issueID, loginUserId]);
 
   const updateIssueDrawer = () => {
-    getIssueDetail({ id: issueID as number, type: issueType });
+    getIssueDetail({ id: issueID as number });
     getIssueStreams({ type: issueType, id: issueID as number, pageNo: 1, pageSize: 50 });
   };
 

--- a/shell/app/modules/project/common/components/workflow-state-form.tsx
+++ b/shell/app/modules/project/common/components/workflow-state-form.tsx
@@ -22,7 +22,7 @@ import issueWorkflowStore from 'project/stores/issue-workflow';
 
 const { Option } = Select;
 interface IWorkflowFormProps {
-  issueType: ISSUE_WORKFLOW.IIssueType;
+  issueType: ISSUE_WORKFLOW.ISSUE_TYPE;
   onOk: () => void;
   onCancel: () => void;
 }

--- a/shell/app/modules/project/pages/backlog/backlog.tsx
+++ b/shell/app/modules/project/pages/backlog/backlog.tsx
@@ -382,10 +382,7 @@ const Backlog = () => {
         <EditIssueDrawer
           iterationID={-1}
           id={curIssueDetail.id}
-          shareLink={`${location.href.split('?')[0]}?${mergeSearch(
-            { id: curIssueDetail.id, type: curIssueDetail.type },
-            true,
-          )}`}
+          shareLink={`${location.href.split('?')[0]}?${mergeSearch({ id: curIssueDetail.id }, true)}`}
           issueType={curIssueDetail.type}
           visible={drawerVisible}
           closeDrawer={closeDrawer}

--- a/shell/app/modules/project/pages/backlog/iteration-item.tsx
+++ b/shell/app/modules/project/pages/backlog/iteration-item.tsx
@@ -155,10 +155,7 @@ export const IterationItem = (props: IProps) => {
         <EditIssueDrawer
           iterationID={data.id}
           id={curIssueDetail.id}
-          shareLink={`${location.href.split('?')[0]}?${mergeSearch(
-            { id: curIssueDetail.id, type: curIssueDetail.type },
-            true,
-          )}`}
+          shareLink={`${location.href.split('?')[0]}?${mergeSearch({ id: curIssueDetail.id }, true)}`}
           issueType={curIssueDetail.type}
           visible={drawerVisible}
           closeDrawer={closeDrawer}

--- a/shell/app/modules/project/pages/issue/issue-protocol.tsx
+++ b/shell/app/modules/project/pages/issue/issue-protocol.tsx
@@ -33,21 +33,20 @@ interface IProps {
 
 const IssueProtocol = ({ issueType }: IProps) => {
   const [{ projectId, iterationId }, query] = routeInfoStore.useStore((s) => [s.params, s.query]);
-  const { id: queryId, iterationID: queryItertationID, type: _queryType } = query;
+  const { id: queryId, iterationID: queryIterationID, type: _queryType } = query;
   const orgID = orgStore.getState((s) => s.currentOrg.id);
   const queryType = _queryType && _queryType.toUpperCase();
   const [{ filterObj, chosenIssueType, chosenIssueId, chosenIteration }, updater, update] = useUpdate({
     filterObj: {},
     chosenIssueId: queryId,
-    chosenIteration: queryItertationID || 0,
+    chosenIteration: +queryIterationID || 0,
     chosenIssueType: queryType as undefined | ISSUE_TYPE,
     pageNo: 1,
     viewType: '',
     viewGroup: '',
   });
-  const { getFieldsByIssue: getCustomFieldsByProject } = issueFieldStore.effects;
   useMount(() => {
-    getCustomFieldsByProject({
+    issueFieldStore.effects.getFieldsByIssue({
       propertyIssueType: issueType,
       orgID,
     });
@@ -58,7 +57,7 @@ const IssueProtocol = ({ issueType }: IProps) => {
   const reloadRef = React.useRef<{ reload: () => void }>(null);
   const filterObjRef = React.useRef<Obj>(null);
 
-  const [drawerVisible, openDrawer, closeDrawer] = useSwitch(queryId || false);
+  const [drawerVisible, openDrawer, closeDrawer] = useSwitch(!!queryId || false);
 
   const inParams = {
     fixedIteration: iterationId,
@@ -103,7 +102,6 @@ const IssueProtocol = ({ issueType }: IProps) => {
     // 当前选中唯一迭代，创建的时候默认为这个迭代，否则，迭代为0
     update({
       chosenIteration: iterationId || (filterIterationIDs.length === 1 ? filterIterationIDs[0] : 0),
-      chosenIssueType: curType || issueType,
     });
     openDrawer();
   };
@@ -230,7 +228,7 @@ const IssueProtocol = ({ issueType }: IProps) => {
           id={chosenIssueId}
           issueType={chosenIssueType as ISSUE_TYPE}
           shareLink={`${location.href.split('?')[0]}?${mergeSearch(
-            { id: chosenIssueId, iterationID: chosenIteration, type: chosenIssueType },
+            { id: chosenIssueId, iterationID: chosenIteration, type: queryType },
             true,
           )}`}
           visible={drawerVisible}

--- a/shell/app/modules/project/stores/issues.ts
+++ b/shell/app/modules/project/stores/issues.ts
@@ -196,9 +196,9 @@ const issueStore = createStore({
       update({ [listKey]: newList });
       return list;
     },
-    async getIssueDetail({ call, update }, { type, id }: Merge<ISSUE.IssueDetailQuery, { type: string }>) {
+    async getIssueDetail({ call, update }, { id }: ISSUE.IssueDetailQuery) {
       const detail = await call(getIssueDetail, { id });
-      const detailKey = DETAIL_KEY_MAP[type];
+      const detailKey = DETAIL_KEY_MAP[detail.type];
       update({ [detailKey]: detail });
     },
     async getIssueStreams({ call, update }, { type, ...rest }: Merge<ISSUE.IssueStreamListQuery, { type: string }>) {


### PR DESCRIPTION
## What this PR does / why we need it:
query `type` is used for locate the target tab, but now, when copy issue share link in 'ALL' type tab, will put the issue type to query, so open the share link, the query filter not match.
<img width="393" alt="image" src="https://user-images.githubusercontent.com/3955437/158744887-d064b908-5743-4fca-8d03-a28b50d7c4e8.png">


## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fixed issue where some of the status entries in the event filter were displayed as numbers   |
| 🇨🇳 中文    |   修复事项筛选器的部分状态条目展示为数字的问题   |


## Need cherry-pick to release versions?
❎ No

