### PR TITLE
fix(dop): domain names are deleted in the wrong order

### DIFF
--- a/shell/app/modules/runtime/pages/overview/components/domain-modal.tsx
+++ b/shell/app/modules/runtime/pages/overview/components/domain-modal.tsx
@@ -218,7 +218,6 @@ const DomainModal = (props: IProps) => {
                   <FormItem className="hidden" name={`${domainType}@@${id}`} initialValue={serviceName}>
                     <Input />
                   </FormItem>
-                  {id}
                   <FormItem
                     name={`${domainType}@domain@${id}`}
                     initialValue={domain}


### PR DESCRIPTION
## What this PR does / why we need it:
domain names are deleted in the wrong order

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [【线上问题】runtime 详情中域名管理删除自定义域名异常](https://erda.cloud/erda/dop/projects/387/issues/all?id=296788&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1146&type=BUG)

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->

❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix that domain names are deleted in the wrong order |
| 🇨🇳 中文    | 修复域名删除顺序错误问题 |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1-beta.2
