### PR TITLE
fix(msp): textMap is undefined in line option

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,7 +334,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.8
+      '@erda-ui/dashboard-configurator': 2.0.11
       '@erda-ui/react-markdown-editor-lite': ^1.4.7
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -482,7 +482,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.8_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.11_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -5686,8 +5686,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.8_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-sRg7NX+iD5i10eSm0RE3EwmHc2S3HooWq5umG/W+pUDaM0UbWLWI9378D3Mhzjc4Df4ft+L+QrUhI4uQCPXkVA==}
+  /@erda-ui/dashboard-configurator/2.0.11_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-I8ebsY3BuF95rFVQcPxuxvWD6RIe8LhJZsWMjafa+oEEaU5MlEvu6ex46LZ+0yBdCV6epV3O1UNUovGpLckatQ==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'

--- a/shell/package.json
+++ b/shell/package.json
@@ -42,7 +42,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.8",
+    "@erda-ui/dashboard-configurator": "2.0.11",
     "@erda-ui/react-markdown-editor-lite": "^1.4.7",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:
'textMap' is undefined in line chart option causing the console to report an error, the same as [fix(msp): textMap is undefined in line option #3188](https://github.com/erda-project/erda-ui/pull/3188)
 
## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | 'textMap' is undefined in line chart option causing the console to report an error |
| 🇨🇳 中文    |  线状图的 option 文件中的 'textMap' 未定义，导致控制台报错  |


## Need cherry-pick to release versions?
✅ No

