### PR TITLE
fix(scheduler): fix server crash when handling proxy error issue

### DIFF
--- a/.erda/pipelines/ci-build-ce.yml
+++ b/.erda/pipelines/ci-build-ce.yml
@@ -27,7 +27,7 @@ stages:
           params:
             build_cmd:
               - cd ${{ dirs.erda-ui }}
-              - npm i @erda-ui/cli@1.5.x -g
+              - npm i @erda-ui/cli@2.0.x -g
               - erda-ui init --online
               - erda-ui build --online
               - cp -r ${{ dirs.erda-ui }}/{public,scheduler} $WORKDIR

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erda-ui/cli",
-  "version": "1.5.5",
+  "version": "2.0.0",
   "description": "Command line interface for rapid Erda UI development",
   "bin": {
     "erda-ui": "dist/bin/erda.js"

--- a/cspell.json
+++ b/cspell.json
@@ -212,6 +212,7 @@
     "prewrap",
     "printf",
     "proctime",
+    "proxying",
     "puse",
     "PYTHONEXECUTE",
     "qrcode",

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -48,7 +48,7 @@ stages:
             build_cmd:
               - cd ${{ dirs.erda-ui }}/shell && npm run extra-logic
               - cd ${{ dirs.erda-ui }}
-              - npm i @erda-ui/cli@1.5.x -g
+              - npm i @erda-ui/cli@2.0.x -g
               - erda-ui init --online
               - erda-ui build --online
               - cp -r ${{ dirs.erda-ui }}/{public,scheduler} $WORKDIR


### PR DESCRIPTION
## What this PR does / why we need it:
seem this issue happens at `OnError` function

![image](https://user-images.githubusercontent.com/5175455/160338708-a6b2dbbf-a956-44f0-90a1-516be2761d9a.png)

![image](https://user-images.githubusercontent.com/5175455/160338780-90f62939-ca27-41a1-8525-b6deea1ea0f7.png)

maybe the res was ended before onError func, so that any further operation will cause unhandled error.
So that, this time add `try/catch` & `writableEnded ` check to avoid crash


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix frontend server crash issue          |
| 🇨🇳 中文    |  修复前端服务器崩溃重启问题            |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1-beta.3

