### PR TITLE
fix(dop): create issue bug

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
@@ -135,6 +135,7 @@ export const EditIssueDrawer = (props: IProps) => {
     };
   }, [bugStageList, defaultCustomFormData, isEditMode, issueType, iterationID, taskTypeList]);
   const [formData, setFormData] = React.useState(defaultFormData as any);
+  const drawerVisibleRef = React.useRef(visible);
   const issueDetail: ISSUE.IssueType = issueStore.useStore((s) => s[`${type}Detail`]);
 
   // 监听bugDetail、taskDetail、requirementDetail的变化，切换类型后触发刷新
@@ -191,6 +192,10 @@ export const EditIssueDrawer = (props: IProps) => {
   React.useEffect(() => {
     setIssueType(propsIssueType);
   }, [propsIssueType]);
+
+  React.useEffect(() => {
+    drawerVisibleRef.current = visible;
+  }, [visible]);
 
   React.useEffect(() => {
     if (visible) {
@@ -456,6 +461,10 @@ export const EditIssueDrawer = (props: IProps) => {
   };
 
   const setFieldCb = (value: Obj<any>, fieldType?: string) => {
+    if (!drawerVisibleRef.current) {
+      return;
+    }
+
     if (fieldType && fieldType === 'markdown') {
       setTempDescContent(value?.content);
       return;
@@ -475,6 +484,7 @@ export const EditIssueDrawer = (props: IProps) => {
 
   const onClose = (isCreate = false, isDelete = false) => {
     if (savingRef.current) return;
+    drawerVisibleRef.current = false;
     setFormData(defaultFormData);
     closeDrawer({ hasEdited, isCreate, isDelete });
     setTempDescContent('');


### PR DESCRIPTION
## What this PR does / why we need it:
Fix create issue bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=299627&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=-1&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed a bug in project coordination where the details popup window would be closed directly after modifying the status without filling in the estimated time, and then new items would fill in the previous item content.  |
| 🇨🇳 中文    |  修复了项目协同中，在没有填预估时间的情况下修改状态后直接关闭详情弹窗，然后新增事项会填入上一事项内容的bug。  |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1-beta.3
