### PR TITLE
fix: fix params config list edit add empty key error

### DIFF
--- a/shell/app/modules/project/common/components/params-config/list-edit.tsx
+++ b/shell/app/modules/project/common/components/params-config/list-edit.tsx
@@ -224,8 +224,12 @@ const ListEditConfig = (props: IProps) => {
             rowKey="key"
             onRow={(record) => ({
               onClick: () => {
-                form.setFieldsValue(record);
-                updater.editData(record);
+                if (editData && !editData.key) {
+                  message.error(i18n.t('common:please save first'));
+                } else {
+                  form.setFieldsValue(record);
+                  updater.editData(record);
+                }
               },
             })}
             components={{


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix params config list edit add empty key error

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix: fix params config list edit add empty key error           |
| 🇨🇳 中文    |     fix: 修复参数配置中添加为空的key错误         |


## Need cherry-pick to release versions?
❎ No

