### PR TITLE
fix: fix params-config tab switch error

### DIFF
--- a/shell/app/common/components/radio-tabs/index.tsx
+++ b/shell/app/common/components/radio-tabs/index.tsx
@@ -78,7 +78,7 @@ const RadioTabs = <T extends string | number>(props: RadioTabsProps<T>) => {
       value={convertValue(value)}
       onChange={(e) => {
         const [curVal, curOption] = valueHandle(e.target.value);
-        setValue(curVal);
+        propsValue === undefined && setValue(curVal);
         onChange?.(curVal, curOption);
       }}
     >
@@ -92,7 +92,7 @@ const RadioTabs = <T extends string | number>(props: RadioTabsProps<T>) => {
             return (
               <Menu
                 onClick={(e) => {
-                  setValue(e.key as T);
+                  propsValue === undefined && setValue(e.key as T);
                   setSubValues((prev) => ({ ...prev, [itemValue]: e.key } as Obj<T>));
                   onChange?.(e.key as T, child);
                 }}

--- a/shell/app/modules/project/common/components/params-config/list-edit.tsx
+++ b/shell/app/modules/project/common/components/params-config/list-edit.tsx
@@ -224,8 +224,12 @@ const ListEditConfig = (props: IProps) => {
             rowKey="key"
             onRow={(record) => ({
               onClick: () => {
-                form.setFieldsValue(record);
-                updater.editData(record);
+                if (editData && !editData.key) {
+                  message.error(i18n.t('common:please save first'));
+                } else {
+                  form.setFieldsValue(record);
+                  updater.editData(record);
+                }
               },
             })}
             components={{


### PR DESCRIPTION
## What this PR does / why we need it:
feat: fix params-config tab switch error

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix: fix params-config tab switch error          |
| 🇨🇳 中文    |    fix: 修复参数配置tab切换错误          |


## Need cherry-pick to release versions?
❎ No

