### PR TITLE
fix: fix params config list item to long style error

### DIFF
--- a/shell/app/modules/project/common/components/params-config/list-edit.tsx
+++ b/shell/app/modules/project/common/components/params-config/list-edit.tsx
@@ -120,24 +120,29 @@ const ListEditConfig = (props: IProps) => {
     {
       dataIndex: 'key',
       title: 'Key',
+      width: 200,
     },
     {
       dataIndex: 'value',
       title: 'Value',
+      width: 200,
       render: (v: string, record: PROJECT_DEPLOY.IAppParams) => (record.encrypt ? '******' : v),
     },
     {
       dataIndex: 'encrypt',
       title: i18n.t('dop:encrypt'),
+      width: 100,
       render: (v: boolean) => (v ? i18n.t('common:yes') : i18n.t('common:no')),
     },
     {
       dataIndex: 'comment',
       title: i18n.t('dop:remark'),
+      width: 200,
     },
     {
       dataIndex: 'op',
       title: i18n.t('operate'),
+      width: 100,
       render: (_: Obj, record: PIPELINE_CONFIG.ConfigItem) => {
         return (
           <div className="operate-list" onClick={(e) => e.stopPropagation()}>
@@ -184,6 +189,7 @@ const ListEditConfig = (props: IProps) => {
         fullConfigData,
         list: value,
         title: col.title,
+        width: col.width,
         editing: editData?.uuid === record.uuid,
       }),
     };
@@ -260,6 +266,8 @@ interface EditCellProps {
   fullConfigData: PIPELINE_CONFIG.ConfigItem[];
   list: PIPELINE_CONFIG.ConfigItem[];
   children: React.ReactElement;
+  width?: number;
+  style?: Obj;
   cancel: () => void;
   save: () => void;
 }
@@ -276,6 +284,8 @@ const EditableCell = ({
   record,
   index,
   children,
+  width,
+  style = {},
   ...restProps
 }: EditCellProps) => {
   const getComp = () => {
@@ -370,7 +380,7 @@ const EditableCell = ({
   };
 
   return (
-    <td onClick={(e) => editing && e.stopPropagation()} {...restProps}>
+    <td onClick={(e) => editing && e.stopPropagation()} style={{ ...style, maxWidth: width }} {...restProps}>
       {editing ? getComp() : children}
     </td>
   );


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix params config list item to long style error

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=301047&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1164&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/15364706/160992112-193b169d-00ed-440c-8cca-391dd559506e.png)

![image](https://user-images.githubusercontent.com/15364706/160992254-2c4ba8c9-036a-4171-a100-c051a0de2b7f.png)

## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: fix params config list item to long style error         |
| 🇨🇳 中文    |    fix: 修复参数配置单元格过长样式问题         |


## Need cherry-pick to release versions?
❎ No

