### PR TITLE
fix(common): table sorter style bug

### DIFF
--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -277,8 +277,8 @@ function WrappedTable<T extends object = any>({
                 className={`cursor-pointer erda-table-sorter flex items-center ${(align && alignMap[align]) || ''}`}
               >
                 {typeof title === 'function' ? title({ sortColumn: sort?.column, sortOrder: sort?.order }) : title}
-                <span className={`sorter-icon pl-1 ${(sort.columnKey === args.dataIndex && sort.order) || ''}`}>
-                  {sort.order && sort.columnKey === args.dataIndex ? (
+                <span className={`sorter-icon pl-1 ${(sort.columnKey === dataIndex && sort.order) || ''}`}>
+                  {sort.order && sort.columnKey === dataIndex ? (
                     sortIcon[sort.order]
                   ) : (
                     <ErdaIcon type="caret-down" fill="log-font" size={20} className="relative top-0.5" />


### PR DESCRIPTION
## What this PR does / why we need it:
Fix table sorter style bug.

## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/161218625-634d9663-be0b-477d-95f5-9552be43191d.png)
->
![image](https://user-images.githubusercontent.com/82502479/161218595-2bc7fc54-6628-4b36-b1ee-3f8b2bf45f08.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed an issue where the sequence header icon did not change after table sorting.  |
| 🇨🇳 中文    |  修复了表格排序后排序列头图标不变化的问题。 |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1-beta.3-2
