### PR TITLE
fix(common): config table progress column optimization

### DIFF
--- a/shell/app/config-page/components/table/render-types.tsx
+++ b/shell/app/config-page/components/table/render-types.tsx
@@ -190,12 +190,13 @@ export const getRender = (val: any, record: CP_TABLE.RowData, extra: any) => {
       break;
     case 'progress':
       {
-        const { value: _val, tip, status, renderType, ...rest } = val || {};
+        const { value: _val, tip, status, renderType, hiddenText, ...rest } = val || {};
         let value = +(_val ?? 0);
         value = +(`${value}`.indexOf('.') ? value.toFixed(2) : value);
         Comp = !isNaN(+_val) ? (
           <Tooltip title={tip}>
             <Progress
+              className="mr-2"
               percent={value}
               {...rest}
               type="circle"
@@ -204,7 +205,7 @@ export const getRender = (val: any, record: CP_TABLE.RowData, extra: any) => {
               format={(v) => null}
               strokeColor={statusColorMap[status]}
             />
-            <span className="text-black-8  ml-2">{`${value.toFixed(1)}%`}</span>
+            {!hiddenText ? <span className="text-black-8">{`${value.toFixed(1)}%`}</span> : null}
           </Tooltip>
         ) : (
           _val


### PR DESCRIPTION
## What this PR does / why we need it:
Config table progress column optimization.

## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/161369473-a3b6dee1-3d25-43db-bd3f-ed9692f42c85.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   The circular progress bar column of the componentized table allows the percentage to be left undisplayed on the right side of the progress bar.  |
| 🇨🇳 中文    |  组件化表格的环状进度条列允许进度条右侧不显示百分比。  |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1-beta.3-2
