### PR TITLE
feat(dop): add statistics page to iteration

### DIFF
--- a/shell/app/modules/project/pages/issue/issue-dashboard.tsx
+++ b/shell/app/modules/project/pages/issue/issue-dashboard.tsx
@@ -16,9 +16,9 @@ import DiceConfigPage from 'app/config-page';
 import routeInfoStore from 'core/stores/route';
 
 const IssueDashboard = () => {
-  const [{ projectId }] = routeInfoStore.useStore((s) => [s.params]);
+  const [{ projectId, iterationId }] = routeInfoStore.useStore((s) => [s.params]);
 
-  const inParams = { projectId };
+  const inParams = { projectId, fixedIteration: iterationId };
 
   return <DiceConfigPage scenarioType={'issue-dashboard'} scenarioKey={'issue-dashboard'} inParams={inParams} />;
 };

--- a/shell/app/modules/project/pages/issue/statistics.tsx
+++ b/shell/app/modules/project/pages/issue/statistics.tsx
@@ -18,9 +18,11 @@ import { MEASURE_TABS } from 'project/tabs';
 import TaskSummary from './task-summary';
 import IssueDashboard from './issue-dashboard';
 
+const options = MEASURE_TABS.map((item) => ({ value: item.key, label: item.name }));
+
 const Statistics = () => {
   const [type, setType] = React.useState<string>('task');
-  const options = React.useMemo(() => MEASURE_TABS.map((item) => ({ value: item.key, label: item.name })), []);
+
   return (
     <div>
       <RadioTabs

--- a/shell/app/modules/project/pages/issue/statistics.tsx
+++ b/shell/app/modules/project/pages/issue/statistics.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import React from 'react';
+import { RadioTabs } from 'common';
+import { updateSearch } from 'common/utils';
+import { MEASURE_TABS } from 'project/tabs';
+import TaskSummary from './task-summary';
+import IssueDashboard from './issue-dashboard';
+
+const Statistics = () => {
+  const [type, setType] = React.useState<string>('task');
+  const options = React.useMemo(() => MEASURE_TABS.map((item) => ({ value: item.key, label: item.name })), []);
+  return (
+    <div>
+      <RadioTabs
+        options={options}
+        value={type}
+        onChange={(v: string) => {
+          updateSearch({ filter__urlQuery: '' });
+          setType(v);
+        }}
+        className="mb-2"
+      />
+      {type === 'task' ? <TaskSummary /> : null}
+      {type === 'bug' ? <IssueDashboard /> : null}
+    </div>
+  );
+};
+
+export default Statistics;

--- a/shell/app/modules/project/pages/issue/task-summary.tsx
+++ b/shell/app/modules/project/pages/issue/task-summary.tsx
@@ -16,9 +16,9 @@ import DiceConfigPage from 'app/config-page';
 import routeInfoStore from 'core/stores/route';
 
 const TaskSummary = () => {
-  const [{ projectId }] = routeInfoStore.useStore((s) => [s.params]);
+  const [{ projectId, iterationId }] = routeInfoStore.useStore((s) => [s.params]);
 
-  const inParams = { projectId };
+  const inParams = { projectId, fixedIteration: iterationId };
 
   return (
     <div>

--- a/shell/app/modules/project/router.tsx
+++ b/shell/app/modules/project/router.tsx
@@ -176,6 +176,16 @@ function getProjectRouter(): RouteConfigItem[] {
                         noWrapper: true,
                       },
                     },
+                    {
+                      path: 'statistics',
+                      tabs: ITERATION_DETAIL_TABS,
+                      backToUp: 'projectIteration',
+                      ignoreTabQuery: true,
+                      getComp: (cb) => cb(import('project/pages/issue/statistics')),
+                      layout: {
+                        noWrapper: true,
+                      },
+                    },
                   ],
                 },
               ],

--- a/shell/app/modules/project/tabs.tsx
+++ b/shell/app/modules/project/tabs.tsx
@@ -43,6 +43,10 @@ export const ITERATION_DETAIL_TABS = (params: Obj) => {
       key: 'board',
       name: i18n.t('dop:board'),
     },
+    {
+      key: 'statistics',
+      name: i18n.t('dop:statistics'),
+    },
   ];
 };
 


### PR DESCRIPTION
## What this PR does / why we need it:
Add statistics page to iteration.


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=298069&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1164&type=TASK)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/161954258-d014ac07-7a1e-450c-aabb-76c7873612da.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Add statistics pages within iterations. |
| 🇨🇳 中文    |  迭代内增加统计页。  |


## Need cherry-pick to release versions?
❎ No

