### PR TITLE
fix: refresh issue detail after relation mr

### DIFF
--- a/shell/app/modules/project/common/components/issue/issue-relation.tsx
+++ b/shell/app/modules/project/common/components/issue/issue-relation.tsx
@@ -331,6 +331,7 @@ export const IssueConnection = ({ issueDetail, iterationID, editAuth, setHasEdit
   const [expand, setExpand] = React.useState(false);
   const issueType = issueDetail?.type;
   const data = getIssueRelation.useData();
+
   const _iterationID = iterationID === -1 ? undefined : iterationID; // 如果当前事项是待规划的，待规划不在迭代列表里，默认“全部”时其实还是会带上 -1 作为 id，所以为-1 时就传 undefined
   const issueConnectionList = (data?.relatedTo || [])?.concat(
     (data?.relatedBy || []).map((item) => ({ ...item, isRelatedBy: true })),
@@ -349,7 +350,10 @@ export const IssueConnection = ({ issueDetail, iterationID, editAuth, setHasEdit
   const [relateMrOperation, relateMrContent, relateMrList] = useAddMrRelation({
     expand,
     issueDetail,
-    afterAdd: () => getIssueStreams({ type: issueType, id: issueDetail.id, pageNo: 1, pageSize: 100 }),
+    afterAdd: () => {
+      getIssueDetail({ id: issueDetail.id });
+      return getIssueStreams({ type: issueType, id: issueDetail.id, pageNo: 1, pageSize: 100 });
+    },
     editAuth,
   });
 
@@ -395,7 +399,7 @@ export const IssueConnection = ({ issueDetail, iterationID, editAuth, setHasEdit
     ]),
   ];
   const [activeTabKey, setActiveTabKey] = React.useState(tabs[0].key);
-  const { getIssueStreams } = issueStore.effects;
+  const { getIssueStreams, getIssueDetail } = issueStore.effects;
   if (!issueDetail) return null;
   const curTab = tabs.find((t) => t.key === activeTabKey) as typeof tabs[0];
 


### PR DESCRIPTION
## What this PR does / why we need it:
fix: refresh issue detail after relation mr

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix: refresh issue detail after relation mr           |
| 🇨🇳 中文    |     fix: 关联mr后，刷新事项详情         |


## Need cherry-pick to release versions?
❎ No

