### PR TITLE
fix(msp): can not get error when parse file

### DIFF
--- a/shell/app/modules/cmp/common/custom-dashboard/import-export.tsx
+++ b/shell/app/modules/cmp/common/custom-dashboard/import-export.tsx
@@ -329,14 +329,18 @@ const Import = (props: ImportProps) => {
       }
       return isLt20M;
     },
-    action: `/api/${getOrgFromPath()}/dashboard/blocks/parse`,
+    action: `/api/${getOrgFromPath()}/dashboard/blocks/parse?scopeId=${scopeId}&scope=${scope}`,
     onChange: ({ file }: any) => {
       setFileData(file);
       if (file.status === 'uploading') {
         setFileStatus('uploading');
       }
       if (file.status === 'done') {
-        setFileStatus('done');
+        if (file.response?.success) {
+          setFileStatus('done');
+        } else {
+          setFileStatus('error');
+        }
       }
       if (file.status === 'error') {
         setFileStatus('error');

--- a/shell/app/modules/cmp/common/custom-dashboard/index.tsx
+++ b/shell/app/modules/cmp/common/custom-dashboard/index.tsx
@@ -86,8 +86,8 @@ const CustomDashboardList = ({
   const [loading] = useLoading(store, ['getCustomDashboard']);
 
   const _getCustomDashboard = React.useCallback(
-    (no: number, size?: number, queryObj?: Custom_Dashboard.CustomLIstQuery) => {
-      const { createdAt, ...rest } = queryObj || {};
+    (no: number, size?: number, queryObj: Custom_Dashboard.CustomLIstQuery = filterData) => {
+      const { createdAt, ...rest } = queryObj;
       let query = queryObj;
       if (createdAt) {
         query = { ...rest, startTime: createdAt[0], endTime: createdAt[1] };
@@ -100,7 +100,7 @@ const CustomDashboardList = ({
         ...query,
       });
     },
-    [getCustomDashboard, scope, scopeId],
+    [getCustomDashboard, scope, scopeId, filterData],
   );
 
   useMount(() => {
@@ -120,7 +120,7 @@ const CustomDashboardList = ({
       title: `${i18n.t('common:confirm to delete')}?`,
       onOk: async () => {
         await deleteCustomDashboard({ id, scopeId });
-        _getCustomDashboard(total - 1 > (pageNo - 1) * pageSize ? pageNo : 1, pageSize);
+        _getCustomDashboard(total - 1 > (pageNo - 1) * pageSize ? pageNo : 1);
       },
     });
   };
@@ -309,7 +309,7 @@ const CustomDashboardList = ({
           pageSize,
         }}
         onChange={({ current = 1, pageSize: size }) => {
-          _getCustomDashboard(current, size, filterData);
+          _getCustomDashboard(current, size);
         }}
         scroll={{ x: '100%' }}
         slot={slot}


### PR DESCRIPTION
## What this PR does / why we need it:
fix(msp): can not get the error when parsing file

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | can not get the error when parsing file |
| 🇨🇳 中文    | 未获取解析文件时的报错信息 |


## Need cherry-pick to release versions?
❎ No


