### PR TITLE
fix(msp): compatible with data and refactor code in MSP

### DIFF
--- a/shell/app/modules/cmp/common/alarm-strategy/notify-strategy-select.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/notify-strategy-select.tsx
@@ -23,6 +23,7 @@ const { Option } = Select;
 interface IProps {
   id: string;
   handleEditNotifyStrategy: (id: string, item: { key: string; value: string }) => void;
+  current: COMMON_STRATEGY_NOTIFY.INotifyGroupNotify;
   valueOptions: Array<{ key: string; display: string }>;
   addNotificationGroupAuth: boolean;
   goToNotifyGroup: () => void;

--- a/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
@@ -198,7 +198,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
     editingFormRule: {},
     activeGroupId: undefined,
     triggerConditionValueOptions: [],
-    triggerCondition: [] as unknown as COMMON_STRATEGY_NOTIFY.IAlertTriggerCondition[],
+    triggerCondition: [] as COMMON_STRATEGY_NOTIFY.OperationTriggerCondition[],
     notifies: [],
     notifyLevel: null,
     allChannelMethods: notifyChannelOptionsMap,
@@ -224,7 +224,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
   useMount(() => {
     if (strategyId) {
       getAlertDetail(Number(strategyId)).then(
-        ({ name, clusterNames, appIds, rules, notifies, triggerCondition }: any) => {
+        ({ name, clusterNames, appIds, rules, notifies, triggerCondition }: COMMON_STRATEGY_NOTIFY.IAlertBody) => {
           updater.editingFormRule({
             id: strategyId,
             name,
@@ -247,7 +247,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
           updater.activeGroupId(notifies[0].groupId);
 
           updater.triggerCondition(
-            (triggerCondition || []).map((x: COMMON_STRATEGY_NOTIFY.IAlertTriggerCondition) => ({
+            (triggerCondition || []).map((x) => ({
               id: uniqueId(),
               condition: x.condition,
               operator: x.operator,
@@ -263,7 +263,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
           );
 
           updater.notifies(
-            (notifies || []).map((x: COMMON_STRATEGY_NOTIFY.INotifyGroupNotify) => ({
+            (notifies || []).map((x) => ({
               id: uniqueId(),
               groupId: x.groupId,
               level: x.level ? x.level?.split(',') : undefined,
@@ -576,11 +576,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
                   keyOptions={alertTriggerConditions}
                   key={item.id}
                   id={item.id}
-                  current={
-                    state.triggerCondition?.find(
-                      (x) => x.id === item.id,
-                    ) as COMMON_STRATEGY_NOTIFY.IAlertTriggerCondition
-                  }
+                  current={find(state.triggerCondition, (x) => x.id === item.id)}
                   handleEditTriggerConditions={handleEditTriggerConditions}
                   handleRemoveTriggerConditions={handleRemoveTriggerConditions}
                   operatorOptions={conditionOperatorOptions}
@@ -871,12 +867,13 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
   // 编辑单条触发条件
   const handleEditTriggerConditions = (id: string, item: { key: string; value: any }) => {
     const rules = cloneDeep(state.triggerCondition);
+
     const rule = find(rules, { id });
     const index = findIndex(rules, { id });
     if (item.key === 'operator' && item.value === 'all') {
       fill(
         rules,
-        { id, ...rule, values: state.triggerCondition.valueOptions?.map((x) => x?.key)?.join(',') },
+        { id, ...rule, values: state.triggerCondition[index].valueOptions?.map((x) => x?.key)?.join(',') },
         index,
         index + 1,
       );

--- a/shell/app/modules/cmp/common/alarm-strategy/trigger-condition-select.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/trigger-condition-select.tsx
@@ -13,6 +13,7 @@
 import React from 'react';
 import { map } from 'lodash';
 import { ErdaIcon } from 'common';
+import { OperatorType } from 'cmp/common/alarm-strategy/strategy-form';
 import { Input, message, Select } from 'antd';
 import i18n from 'i18n';
 
@@ -21,16 +22,10 @@ const { Option } = Select;
 interface IProps {
   keyOptions: COMMON_STRATEGY_NOTIFY.IAlertTriggerCondition[];
   id: string;
-  current: {
-    id: string;
-    condition: string;
-    operator: string;
-    values: string;
-    valueOptions: Array<{ key: string; display: string }>;
-  };
+  current: COMMON_STRATEGY_NOTIFY.IAlertTriggerCondition;
   handleEditTriggerConditions: (id: string, data: { key: string; value: string }) => void;
   handleRemoveTriggerConditions: (id: string) => void;
-  operatorOptions: Array<{ key: string; display: string; type: 'input' | 'none' | 'multiple' | 'single' }>;
+  operatorOptions: Array<{ key: string; display: string; type: OperatorType }>;
   valueOptionsList: COMMON_STRATEGY_NOTIFY.IAlertTriggerConditionContent[];
 }
 

--- a/shell/app/modules/cmp/common/alarm-strategy/trigger-condition-select.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/trigger-condition-select.tsx
@@ -22,7 +22,7 @@ const { Option } = Select;
 interface IProps {
   keyOptions: COMMON_STRATEGY_NOTIFY.IAlertTriggerCondition[];
   id: string;
-  current: COMMON_STRATEGY_NOTIFY.IAlertTriggerCondition;
+  current: COMMON_STRATEGY_NOTIFY.TriggerCondition;
   handleEditTriggerConditions: (id: string, data: { key: string; value: string }) => void;
   handleRemoveTriggerConditions: (id: string) => void;
   operatorOptions: Array<{ key: string; display: string; type: OperatorType }>;

--- a/shell/app/modules/cmp/services/alarm-strategy.ts
+++ b/shell/app/modules/cmp/services/alarm-strategy.ts
@@ -22,7 +22,7 @@ export const getAlerts = (
     .then((response: any) => response.body);
 };
 
-export const getAlertDetail = (id: number): COMMON_STRATEGY_NOTIFY.IAlertDetail => {
+export const getAlertDetail = (id: number): COMMON_STRATEGY_NOTIFY.IAlertBody => {
   return agent.get(`/api/orgCenter/alerts/${id}`).then((response: any) => response.body);
 };
 

--- a/shell/app/modules/cmp/types/alarm-strategy.d.ts
+++ b/shell/app/modules/cmp/types/alarm-strategy.d.ts
@@ -60,8 +60,9 @@ declare namespace COMMON_STRATEGY_NOTIFY {
     type: 'notify_group';
     groupId: string;
     groupType: string;
-    notifyGroup?: INotifyGroup;
+    notifyGroup: INotifyGroup;
     dingdingUrl?: string;
+    level?: string;
   }
 
   interface INotifyTarget {
@@ -160,5 +161,13 @@ declare namespace COMMON_STRATEGY_NOTIFY {
     condition: string;
     filters: object;
     index: string;
+  }
+
+  interface IAlertTriggerCondition {
+    id: string;
+    condition: string;
+    operator: string;
+    values: string;
+    valueOptions: Array<{ key: string; display: string }>;
   }
 }

--- a/shell/app/modules/cmp/types/alarm-strategy.d.ts
+++ b/shell/app/modules/cmp/types/alarm-strategy.d.ts
@@ -22,6 +22,7 @@ declare namespace COMMON_STRATEGY_NOTIFY {
       value: any;
     }>;
     isRecover: boolean;
+    level: string;
   }
 
   interface IPageParam {
@@ -85,11 +86,11 @@ declare namespace COMMON_STRATEGY_NOTIFY {
         unit: string;
         policy: string;
       };
-      type: string;
       groupId: number;
       groupType: string;
       level: string;
     }>;
+    triggerCondition: TriggerCondition[];
   }
 
   interface IAlertDetail {
@@ -163,11 +164,14 @@ declare namespace COMMON_STRATEGY_NOTIFY {
     index: string;
   }
 
-  interface IAlertTriggerCondition {
-    id: string;
-    condition: string;
+  interface TriggerCondition {
+    condition: string | undefined;
     operator: string;
-    values: string;
+    values: string | undefined;
+  }
+
+  interface OperationTriggerCondition extends TriggerCondition {
+    id: string;
     valueOptions: Array<{ key: string; display: string }>;
   }
 }

--- a/shell/app/modules/msp/alarm-manage/alarm-strategy/services/alarm-strategy.ts
+++ b/shell/app/modules/msp/alarm-manage/alarm-strategy/services/alarm-strategy.ts
@@ -30,7 +30,7 @@ export const getAlertDetail = ({
 }: {
   id: number;
   tenantGroup: string;
-}): COMMON_STRATEGY_NOTIFY.IAlertDetail => {
+}): COMMON_STRATEGY_NOTIFY.IAlertBody => {
   return agent
     .get(`/api/tmc/micro-service/tenantGroup/${tenantGroup}/alerts/${id}`)
     .then((response: any) => response.body);


### PR DESCRIPTION
## What this PR does / why we need it:
compatible with data and refactor code in MSP

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  compatible with data and refactor code of alarm strategy in MSP   |
| 🇨🇳 中文    |  在微服务平台中的告警策略中兼容数据并重构代码 |


## Need cherry-pick to release versions?
❎ No

