### PR TITLE
feat(msp): export tab is set as default tab

### DIFF
--- a/shell/app/modules/cmp/common/custom-dashboard/import-export.tsx
+++ b/shell/app/modules/cmp/common/custom-dashboard/import-export.tsx
@@ -50,11 +50,6 @@ const { Option } = Select;
 
 const defaultTabs = [
   {
-    key: 'record',
-    text: i18n.t('Records'),
-    disabled: false,
-  },
-  {
     key: 'export',
     text: i18n.t('Export'),
     disabled: false,
@@ -62,6 +57,11 @@ const defaultTabs = [
   {
     key: 'import',
     text: i18n.t('Import'),
+    disabled: false,
+  },
+  {
+    key: 'record',
+    text: i18n.t('Records'),
     disabled: false,
   },
 ];


### PR DESCRIPTION
## What this PR does / why we need it:
feat: export tab is set as the default tab in the custom dashboard

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | export tab is set as the default tab in the custom dashboard |
| 🇨🇳 中文    | 在自定义大盘中将导出 tab 作默认 tab |


## Need cherry-pick to release versions?
❎ No

