### PR TITLE
feat(msp): bump @erda-ui/dashboard-configurator from 2.0.12 to 2.0.13

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,7 +334,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.12
+      '@erda-ui/dashboard-configurator': 2.0.13
       '@erda-ui/react-markdown-editor-lite': ^1.4.7
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -482,7 +482,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.12_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.13_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -5686,8 +5686,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.12_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-w520OY0nYXpDGn6NtrVyH9vv/BFfvglGU1FUqyVAgk5ydGVQL6AEUjrl0YXbJCui2BHmQ103D6tlloE2/z3QNQ==}
+  /@erda-ui/dashboard-configurator/2.0.13_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-cHQMJEOmkKeW9Lc6nwHx3sxWVN2AyNyzM4yfwz4Adv1qnAOV22wjsa0G6tL6mFZuY86fpTxrjXoC1/dv2PQJqA==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -5709,6 +5709,7 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       react-grid-layout: 1.3.0_react-dom@16.14.0+react@16.14.0
       react-use: 15.3.8_react-dom@16.14.0+react@16.14.0
+      sass: 1.50.0
       use-immer: 0.4.2_immer@9.0.6+react@16.14.0
     transitivePeerDependencies:
       - prop-types
@@ -13852,18 +13853,18 @@ packages:
       eslint-plugin-testing-library:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.25.0_15a8c6a214b1547f8382842b92f9dbe9
-      '@typescript-eslint/parser': 4.25.0_eslint@7.27.0+typescript@4.4.2
+      '@typescript-eslint/eslint-plugin': 4.25.0_6fb86b31e39dbd15f93824c03ca6ca0c
+      '@typescript-eslint/parser': 4.25.0_eslint@7.27.0+typescript@4.2.4
       babel-eslint: 10.1.0_eslint@7.27.0
       confusing-browser-globals: 1.0.10
       eslint: 7.27.0
       eslint-plugin-flowtype: 5.7.2_eslint@7.27.0
       eslint-plugin-import: 2.23.3_eslint@7.27.0
-      eslint-plugin-jest: 24.3.6_c82f5996322cd9ede56a955914b627f7
+      eslint-plugin-jest: 24.3.6_37bf39ebe0f22c2c661de72fa9962677
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.27.0
       eslint-plugin-react: 7.23.2_eslint@7.27.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.27.0
-      eslint-plugin-testing-library: 3.10.2_eslint@7.27.0+typescript@4.4.2
+      eslint-plugin-testing-library: 3.10.2_eslint@7.27.0+typescript@4.2.4
     dev: false
 
   /eslint-import-resolver-node/0.3.4:
@@ -16493,6 +16494,10 @@ packages:
 
   /immer/9.0.6:
     resolution: {integrity: sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==}
+    dev: false
+
+  /immutable/4.0.0:
+    resolution: {integrity: sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==}
     dev: false
 
   /import-cwd/2.1.0:
@@ -25426,6 +25431,16 @@ packages:
     dependencies:
       chokidar: 3.5.1
     dev: true
+
+  /sass/1.50.0:
+    resolution: {integrity: sha512-cLsD6MEZ5URXHStxApajEh7gW189kkjn4Rc8DQweMyF+o5HF5nfEz8QYLMlPsTOD88DknatTmBWkOcw5/LnJLQ==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.2
+      immutable: 4.0.0
+      source-map-js: 0.6.2
+    dev: false
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}

--- a/shell/package.json
+++ b/shell/package.json
@@ -42,7 +42,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.12",
+    "@erda-ui/dashboard-configurator": "2.0.13",
     "@erda-ui/react-markdown-editor-lite": "^1.4.7",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:

bump [@erda-ui/dashboard-configurator](https://github.com/Erda-FE/dashboard-configuration) from 2.0.12 to 2.0.13

Commits
- [6d0f429](https://github.com/Erda-FE/dashboard-configuration/pull/70/commits/6d0f429301f8636629013f9c2682ddb2666008ee) chore: replace node-sass with sass


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | - |
| 🇨🇳 中文    | - |


## Need cherry-pick to release versions?
❎ No

