### PR TITLE
feat(msp): add description filter to the custom dashboard

### DIFF
--- a/shell/app/modules/cmp/common/custom-dashboard/import-export.tsx
+++ b/shell/app/modules/cmp/common/custom-dashboard/import-export.tsx
@@ -14,7 +14,6 @@
 import React from 'react';
 import { Button, Modal, Spin, Radio, Space, Upload, message, Avatar, Select, Tooltip } from 'antd';
 import { SimpleTabs, ErdaIcon, Badge } from 'common';
-import { useUpdate } from 'common/use-hooks';
 import { getUploadProps } from 'common/utils/upload-props';
 import EmptySVG from 'app/images/upload_empty.svg';
 import { useMount, useInterval } from 'react-use';
@@ -39,9 +38,11 @@ interface IProps {
   scopeId: string;
   scope: string;
   visible: boolean;
+  tabValue: string;
   relationship?: Custom_Dashboard.Relationship[];
   title?: string;
   tabs?: Array<{ key: string; text: string; disabled?: boolean }>;
+  changeTabValue: (tabValue: string) => void;
   onVisibleChange: (visible: boolean) => void;
   getCustomDashboard: (pageNo: number) => void;
 }
@@ -98,22 +99,21 @@ const ImportExport = (props: IProps) => {
     tabs = defaultTabs,
     visible,
     relationship,
+    tabValue,
+    changeTabValue,
     onVisibleChange,
     getCustomDashboard,
   } = props;
 
   const getDefaultTabs = () => tabs.find((item) => !item.disabled)?.key || 'record';
-  const [{ tabValue }, updater, update] = useUpdate({
-    tabValue: getDefaultTabs(),
-  });
+
+  useMount(() => changeTabValue(getDefaultTabs()));
 
   const closeModal = () => {
     onVisibleChange(false);
-    update({
-      tabValue: getDefaultTabs(),
-    });
+    changeTabValue(getDefaultTabs());
   };
-  const toRecord = () => update({ tabValue: 'record' });
+  const toRecord = () => changeTabValue('record');
 
   const CompMap = {
     export: (
@@ -157,7 +157,7 @@ const ImportExport = (props: IProps) => {
               mode="underline"
               className="text-sm font-normal"
               tabs={tabs}
-              onSelect={updater.tabValue}
+              onSelect={changeTabValue}
               value={tabValue}
             />
           </div>

--- a/shell/app/modules/cmp/common/custom-dashboard/index.tsx
+++ b/shell/app/modules/cmp/common/custom-dashboard/index.tsx
@@ -56,11 +56,12 @@ const CustomDashboardList = ({
   relationship?: Custom_Dashboard.Relationship[];
 }) => {
   const params = routeInfoStore.useStore((s) => s.params);
-  const [{ formData, filterData, recordModalVisible, formModalVisible }, updater, update] = useUpdate({
+  const [{ formData, filterData, recordModalVisible, formModalVisible, tabValue }, updater, update] = useUpdate({
     formData: null,
     filterData: { creator: [], createdAt: '', title: undefined } as Custom_Dashboard.CustomLIstQuery,
     recordModalVisible: false,
     formModalVisible: false,
+    tabValue: 'export',
   });
 
   const isEditing = formData !== null;
@@ -246,6 +247,7 @@ const CustomDashboardList = ({
         onClick: () => {
           exportCustomDashboard({ scope, scopeId, viewIds: [String(record.id)] });
           updater.recordModalVisible(true);
+          updater.tabValue('record');
         },
       },
       {
@@ -303,6 +305,8 @@ const CustomDashboardList = ({
           onVisibleChange={updater.recordModalVisible}
           getCustomDashboard={_getCustomDashboard}
           relationship={relationship}
+          changeTabValue={updater.tabValue}
+          tabValue={tabValue}
         />
         <Button
           type="primary"

--- a/shell/app/modules/cmp/common/custom-dashboard/index.tsx
+++ b/shell/app/modules/cmp/common/custom-dashboard/index.tsx
@@ -12,8 +12,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
-import { Button, Modal, FormInstance } from 'antd';
-import { formatTime, fromNow, goTo } from 'common/utils';
+import { Button, Modal, FormInstance, Avatar } from 'antd';
+import { formatTime, fromNow, goTo, getAvatarChars } from 'common/utils';
 import { useUserMap } from 'core/stores/userMap';
 import { useMount } from 'react-use';
 import { useUpdate } from 'common/use-hooks';
@@ -28,7 +28,7 @@ import { CustomDashboardScope } from 'app/modules/cmp/stores/_common-custom-dash
 import { getCustomDashboardCreators, exportCustomDashboard } from 'app/modules/cmp/services/_common-custom-dashboard';
 import { map } from 'lodash';
 import { ColumnProps, IActions } from 'common/components/table/interface';
-import { UserInfo, ConfigurableFilter, FormModal } from 'common';
+import { ConfigurableFilter, FormModal } from 'common';
 import ImportExport from 'cmp/common/custom-dashboard/import-export';
 
 const storeMap = {
@@ -148,7 +148,23 @@ const CustomDashboardList = ({
     {
       title: i18n.t('Creator'),
       dataIndex: 'creator',
-      render: (text: string) => <UserInfo id={text} />,
+      render: (text: string) => {
+        const cU = userMap[Number(text)];
+        if (text && cU) {
+          return (
+            <span>
+              <Avatar size="small" src={cU.avatar}>
+                {cU.nick ? getAvatarChars(cU.nick) : i18n.t('None')}
+              </Avatar>
+              <span className="ml-0.5 mr-1" title={cU.name}>
+                {cU.nick || cU.name || text || i18n.t('None')}
+              </span>
+            </span>
+          );
+        }
+
+        return '-';
+      },
     },
     {
       title: i18n.t('create time'),
@@ -164,6 +180,13 @@ const CustomDashboardList = ({
       label: i18n.t('Creator'),
       options: creatorOptions,
       placeholder: i18n.t('filter by {name}', { name: i18n.t('Submitter') }),
+    },
+    {
+      key: 'description',
+      type: 'input',
+      label: i18n.t('Description'),
+      options: creatorOptions,
+      placeholder: i18n.t('filter by {name}', { name: i18n.t('Description') }),
     },
     {
       key: 'createdAt',


### PR DESCRIPTION
## What this PR does / why we need it:
1. add a description filter to the custom dashboard
2. update the creator with the avatar in the table
3. go to record after exporting files

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | add a description filter to the custom dashboard  |
| 🇨🇳 中文    |  自定义大盘中增加按描述过滤的筛选项  |


## Need cherry-pick to release versions?
❎ No

