### PR TITLE
fix: switch to execute page when pipeline exist

### DIFF
--- a/shell/app/modules/project/common/components/pipeline-new/detail/editor.tsx
+++ b/shell/app/modules/project/common/components/pipeline-new/detail/editor.tsx
@@ -131,7 +131,7 @@ const Editor = (props: IProps) => {
         title={`${i18n.t('dop:pipeline configuration')}`}
         onSubmit={onUpdate}
         onCancel={() => {
-          !fileChanged && switchToExecute();
+          !fileChanged && pipelineDetail && switchToExecute();
         }}
         onEditingChange={(editing: boolean) => {
           setEditMode(editing ? DetailMode.edit : DetailMode.file);


### PR DESCRIPTION
## What this PR does / why we need it:
fix: switch to execute page when pipeline exist

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      fix: switch to execute page when pipeline exist        |
| 🇨🇳 中文    |  fix: 切换流水线执行页面前判断是否存在            |


## Need cherry-pick to release versions?
❎ No

