### PR TITLE
fix(msp): display nullDisplay when editing dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,7 +334,7 @@ importers:
       '@babel/preset-typescript': ^7.15.0
       '@babel/runtime': ^7.15.4
       '@babel/traverse': ^7.14.7
-      '@erda-ui/dashboard-configurator': 2.0.14
+      '@erda-ui/dashboard-configurator': 2.0.15
       '@erda-ui/react-markdown-editor-lite': ^1.4.7
       '@module-federation/automatic-vendor-federation': ^1.2.1
       '@paiva/translation-google': ^1.0.9
@@ -482,7 +482,7 @@ importers:
       webpack-merge: ^5.7.3
       xterm: 3.12.0
     dependencies:
-      '@erda-ui/dashboard-configurator': 2.0.14_react-dom@16.14.0+react@16.14.0
+      '@erda-ui/dashboard-configurator': 2.0.15_react-dom@16.14.0+react@16.14.0
       '@erda-ui/react-markdown-editor-lite': 1.4.7_react@16.14.0
       ace-builds: 1.4.12
       ansi_up: 5.0.1
@@ -5686,8 +5686,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@erda-ui/dashboard-configurator/2.0.14_react-dom@16.14.0+react@16.14.0:
-    resolution: {integrity: sha512-vqgvTduXS3akDcVMxE3+q7m2888MycwV9SfX3Mm8NnjPEz46aaXqMW3yJ/k9ZQLE8HwAroG8hLqKiaviJRdnXw==}
+  /@erda-ui/dashboard-configurator/2.0.15_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-G5wyP8GIPVv9ivWaDDCgrzRYuhkGqnXvneNAa3khy0rt3tJsABeFlH+nB5/96xeEEivCWWd1VqiCowQ2oxvjxA==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'

--- a/shell/package.json
+++ b/shell/package.json
@@ -42,7 +42,7 @@
   "author": "Erda-FE",
   "license": "AGPL",
   "dependencies": {
-    "@erda-ui/dashboard-configurator": "2.0.14",
+    "@erda-ui/dashboard-configurator": "2.0.15",
     "@erda-ui/react-markdown-editor-lite": "^1.4.7",
     "ace-builds": "^1.4.7",
     "ansi_up": "^5.0.1",


### PR DESCRIPTION
## What this PR does / why we need it:
 display the nullDisplay when editing the dashboard

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [【集成环境】【自定义大盘】编辑时空值显示字段没没有显示](https://erda.cloud/erda/dop/projects/387/issues/all?id=305219&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNzIzIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1174&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | display the nullDisplay when editing the dashboard |
| 🇨🇳 中文    | 编辑大盘的时候显示【空值显示字段】|


## Need cherry-pick to release versions?
❎ No

