### PR TITLE
fix(common): display null when src of image is empty in react-markdown

### DIFF
--- a/shell/app/common/components/markdown-render/__tests__/index.test.tsx
+++ b/shell/app/common/components/markdown-render/__tests__/index.test.tsx
@@ -41,6 +41,7 @@ describe('MarkdownRender', () => {
   link: [link](https://erda.cloud)
 
   image: ![alt text](https://erda.cloud/img.png)
+  image: ![empty src]()
 
   bold: **bold**
   italic: *italic*

--- a/shell/app/common/components/markdown-render/index.tsx
+++ b/shell/app/common/components/markdown-render/index.tsx
@@ -62,7 +62,7 @@ const ScalableImage = ({ src, alt, ...rest }: ImgHTMLAttributes<HTMLImageElement
     emit('md-img-loaded');
   };
 
-  return (
+  return src ? (
     <span>
       <img
         style={{ cursor: 'zoom-in' }}
@@ -84,7 +84,7 @@ const ScalableImage = ({ src, alt, ...rest }: ImgHTMLAttributes<HTMLImageElement
         <img style={{ margin: 'auto' }} src={src} alt={alt || 'preview-image'} {...rest} />
       </span>
     </span>
-  );
+  ) : null;
 };
 
 const Link = ({ href, children }: LinkHTMLAttributes<HTMLAnchorElement>) => {


### PR DESCRIPTION
## What this PR does / why we need it:
display null when src of the image is empty in react-markdown

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | display null when zooming out the image and its src is empty in react-markdown |
| 🇨🇳 中文    | 在 react-markdown 中，当进行缩小图片操作且其 src 为空时不展示它 |


## Need cherry-pick to release versions?
✅ Yes(version is required)
/cherry-pick release/2.1-beta.4

