### PR TITLE
fix(dop): click menu after switch project bug

### DIFF
--- a/shell/app/modules/project/stores/project.tsx
+++ b/shell/app/modules/project/stores/project.tsx
@@ -90,6 +90,11 @@ const project = createStore({
       }
       if (isIn('project')) {
         if (`${curProjectId}` !== projectId) {
+          // To update the projectID in the menus in a timely manner
+          layoutStore.reducers.setSubSiderInfoMap({
+            key: 'project',
+            menu: getProjectMenu(projectId, location.pathname),
+          });
           loadingInProject = true;
           issueWorkflowStore.getStatesByIssue({ projectID: +projectId });
           // 项目切换后才重新checkRouteAuth


### PR DESCRIPTION
## What this PR does / why we need it:
Fix click menu after switch project bug.


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=305704&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1174&tab=ALL&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed an issue where switching items would not work if you clicked the menu quickly after switching items. |
| 🇨🇳 中文    |  修复了在切换项目后快速点击菜单，切换项目无效的问题。   |


## Need cherry-pick to release versions?
❎ No

