### PR TITLE
feat(dop): display all MR types count in MR requests page

### DIFF
--- a/shell/app/modules/application/pages/repo/repo-mr.tsx
+++ b/shell/app/modules/application/pages/repo/repo-mr.tsx
@@ -17,18 +17,22 @@ import { find } from 'lodash';
 import { goTo } from 'common/utils';
 import { RepoMrTable } from './components/repo-mr-table';
 import i18n from 'i18n';
-import repoStore from 'application/stores/repo';
+import repoStore, { getAppDetail } from 'application/stores/repo';
+import { getAppMRStatsCount } from 'application/services/repo';
 import { WithAuth, usePerm } from 'user/common';
 import { ErdaAlert, RadioTabs } from 'common';
 
 const PureRepoMR = () => {
-  const [info, mrStatsCount] = repoStore.useStore((s) => [s.info, s.mrStatsCount]);
-  const { getAppMRStatsCount } = repoStore.effects;
+  const info = repoStore.useStore((s) => s.info);
+  const mrStatsCount = getAppMRStatsCount.useData();
   const permObj = usePerm((s) => s.app.repo.mr);
   const [mrType, setMrType] = React.useState('open');
 
   React.useEffect(() => {
-    getAppMRStatsCount();
+    getAppDetail().then((res) => {
+      const [projectName, appName] = res.gitRepoAbbrev.split('/');
+      getAppMRStatsCount.fetch({ projectName, appName });
+    });
   }, [mrType]);
 
   const getMrTypeCount = (type: string) => {

--- a/shell/app/modules/application/services/repo.ts
+++ b/shell/app/modules/application/services/repo.ts
@@ -18,9 +18,16 @@ const apis = {
   getAppMR: {
     api: '/api/repo/:projectName/:appName/merge-requests',
   },
+  getAppMRStatsCount: {
+    api: '/api/repo/:projectName/:appName/merge-request-stats',
+  },
 };
 
 export const getAppMR = apiCreator<(p: REPOSITORY.QueryMrs) => IPagingResp<REPOSITORY.MRItem>>(apis.getAppMR);
+
+export const getAppMRStatsCount = apiCreator<(p: { projectName: string; appName: string }) => REPOSITORY.MRStatsCount>(
+  apis.getAppMRStatsCount,
+);
 
 export const getRepoInfo = ({ repoPrefix, branch }: REPOSITORY.GetInfo): REPOSITORY.IInfo => {
   const api = `/api/repo/${repoPrefix}/stats${branch ? `/${branch}` : ''}`;
@@ -178,10 +185,6 @@ export const getMRStats = ({
     .get(`/api/repo/${repoPrefix}/merge-stats`)
     .query(data)
     .then((response: any) => response.body);
-};
-
-export const getAppMRStatsCount = ({ repoPrefix }: { repoPrefix: string }): REPOSITORY.MRStatsCount => {
-  return agent.get(`/api/repo/${repoPrefix}/merge-request-stats`).then((response: any) => response.body);
 };
 
 export const createMR = ({

--- a/shell/app/modules/application/services/repo.ts
+++ b/shell/app/modules/application/services/repo.ts
@@ -180,6 +180,10 @@ export const getMRStats = ({
     .then((response: any) => response.body);
 };
 
+export const getAppMRStatsCount = ({ repoPrefix }: { repoPrefix: string }): REPOSITORY.MRStatsCount => {
+  return agent.get(`/api/repo/${repoPrefix}/merge-request-stats`).then((response: any) => response.body);
+};
+
 export const createMR = ({
   repoPrefix,
   ...data

--- a/shell/app/modules/application/stores/repo.ts
+++ b/shell/app/modules/application/stores/repo.ts
@@ -39,6 +39,7 @@ import {
   getAvailableAddonList,
   createMR,
   getMRStats,
+  getAppMRStatsCount,
   getMRDetail,
   getAddonVersions,
   getAddonInstanceList,
@@ -148,6 +149,7 @@ const initState = {
   mr: {} as REPOSITORY.MRItem,
   mrList: [] as REPOSITORY.MRItem[],
   mrStats: {} as REPOSITORY.IMrStats,
+  mrStatsCount: {} as REPOSITORY.MRStatsCount,
   mrDetail: {},
   comments: [] as REPOSITORY.MrNote[],
   commitDetail: {} as REPOSITORY.CommitDetail,
@@ -582,6 +584,14 @@ const repoStore = createStore({
         ...payload,
       });
       update({ mrStats });
+    },
+    async getAppMRStatsCount({ call, update }) {
+      const appDetail = await getAppDetail();
+      const mrStatsCount = await call(getAppMRStatsCount, {
+        repoPrefix: appDetail.gitRepoAbbrev,
+      });
+
+      update({ mrStatsCount });
     },
     async createMR({ call }, payload: Omit<REPOSITORY.Mr, 'action'>) {
       const appDetail = await getAppDetail();

--- a/shell/app/modules/application/stores/repo.ts
+++ b/shell/app/modules/application/stores/repo.ts
@@ -39,7 +39,6 @@ import {
   getAvailableAddonList,
   createMR,
   getMRStats,
-  getAppMRStatsCount,
   getMRDetail,
   getAddonVersions,
   getAddonInstanceList,
@@ -121,7 +120,7 @@ export const getSubList = (info: Obj, { projectId, appId }: { projectId: string;
   ];
 };
 
-const getAppDetail: () => Promise<IApplication> = () =>
+export const getAppDetail: () => Promise<IApplication> = () =>
   new Promise((resolve) => {
     const [{ appId: appIdParams }, { applicationId: appIdQuery }] = routeInfoStore.getState((s) => [s.params, s.query]);
     let appDetail = appStore.getState((s) => s.detail);
@@ -149,7 +148,6 @@ const initState = {
   mr: {} as REPOSITORY.MRItem,
   mrList: [] as REPOSITORY.MRItem[],
   mrStats: {} as REPOSITORY.IMrStats,
-  mrStatsCount: {} as REPOSITORY.MRStatsCount,
   mrDetail: {},
   comments: [] as REPOSITORY.MrNote[],
   commitDetail: {} as REPOSITORY.CommitDetail,
@@ -584,14 +582,6 @@ const repoStore = createStore({
         ...payload,
       });
       update({ mrStats });
-    },
-    async getAppMRStatsCount({ call, update }) {
-      const appDetail = await getAppDetail();
-      const mrStatsCount = await call(getAppMRStatsCount, {
-        repoPrefix: appDetail.gitRepoAbbrev,
-      });
-
-      update({ mrStatsCount });
     },
     async createMR({ call }, payload: Omit<REPOSITORY.Mr, 'action'>) {
       const appDetail = await getAppDetail();

--- a/shell/app/modules/application/types/repo.d.ts
+++ b/shell/app/modules/application/types/repo.d.ts
@@ -194,6 +194,13 @@ declare namespace REPOSITORY {
     updatedAt: string;
   }
 
+  interface MRStatsCount {
+    stats: Array<{
+      state: MrState;
+      total: number;
+    }>;
+  }
+
   interface IBranch {
     id: string;
     name: string;


### PR DESCRIPTION
## What this PR does / why we need it:
display all MR types count in MR requests

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
before：
![image](https://user-images.githubusercontent.com/30014895/163800601-77b55eb0-fd29-4a0b-b0e3-b1fe46e31c68.png)


now: 
![image](https://user-images.githubusercontent.com/30014895/163800550-b300809b-d8b0-4daf-93db-d03961844005.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | display all MR types count in MR requests page |
| 🇨🇳 中文    |  合并请求页面中展示所有类型的数量  |


## Need cherry-pick to release versions?
❎ No

