### PR TITLE
fix(common): tags tooltip background color optimization

### DIFF
--- a/shell/app/common/components/tags-row/index.scss
+++ b/shell/app/common/components/tags-row/index.scss
@@ -40,7 +40,7 @@
     margin-bottom: 4px;
     padding-right: 6px;
     padding-left: 6px;
-    color: $white;
+    color: $color-default-4;
     font-size: 14px;
     line-height: 28px;
     border: 1px solid transparent;

--- a/shell/app/common/components/tags-row/index.scss
+++ b/shell/app/common/components/tags-row/index.scss
@@ -40,7 +40,7 @@
     margin-bottom: 4px;
     padding-right: 6px;
     padding-left: 6px;
-    color: $color-default-4;
+    color: $gray;
     font-size: 14px;
     line-height: 28px;
     border: 1px solid transparent;

--- a/shell/app/common/components/tags/index.scss
+++ b/shell/app/common/components/tags/index.scss
@@ -43,7 +43,7 @@
     margin-bottom: 4px;
     padding-right: 6px;
     padding-left: 6px;
-    color: $color-default-4;
+    color: $gray;
     font-size: 14px;
     line-height: 28px;
     border-radius: $radius;

--- a/shell/app/common/components/tags/index.scss
+++ b/shell/app/common/components/tags/index.scss
@@ -43,7 +43,7 @@
     margin-bottom: 4px;
     padding-right: 6px;
     padding-left: 6px;
-    color: $white;
+    color: $color-default-4;
     font-size: 14px;
     line-height: 28px;
     border-radius: $radius;
@@ -76,7 +76,11 @@
   }
 }
 
-.tags-row-tooltip {
+body .tags-row-tooltip {
   min-width: 300px;
   max-width: 800px;
+
+  div.ant-tooltip-inner {
+    background-color: $white;
+  }
 }

--- a/shell/app/common/components/tags/index.scss
+++ b/shell/app/common/components/tags/index.scss
@@ -76,6 +76,7 @@
   }
 }
 
+// .body is used to add weight to the style
 body .tags-row-tooltip {
   min-width: 300px;
   max-width: 800px;


### PR DESCRIPTION
## What this PR does / why we need it:
Tags tooltip background color optimization.


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=306279&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1174&type=TASK)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/163908089-ca4f95c1-be8b-4873-9695-9c6ae330da7f.png)
![image](https://user-images.githubusercontent.com/82502479/163908224-00736166-a1a0-425c-8c0b-28ffef88f329.png)
->
![image](https://user-images.githubusercontent.com/82502479/163908144-5b9eaa53-d0bc-44d5-8665-99c6397e2520.png)
![image](https://user-images.githubusercontent.com/82502479/163939162-e4d5eaea-c8b5-4d35-8b81-96bbbc075cd7.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Change the background of the label float layer to white. |
| 🇨🇳 中文    |  标签浮层的背景改成白色。  |


## Need cherry-pick to release versions?
❎ No

