### PR TITLE
fix(common): log search params missing

### DIFF
--- a/shell/app/common/components/simple-log/__tests__/simple-log-search.test.tsx
+++ b/shell/app/common/components/simple-log/__tests__/simple-log-search.test.tsx
@@ -19,13 +19,16 @@ import SimpleLogSearch from '../simple-log-search';
 describe('SimpleLogSearch', () => {
   it('should work well', async () => {
     const setSearchFn = jest.fn();
-    const formData = { requestId: 'erda' };
+    const formData = { requestId: 'erda', applicationId: 123 };
     const result = render(<SimpleLogSearch setSearch={setSearchFn} />);
     fireEvent.change(result.getByRole('textbox'), { target: { value: formData.requestId } });
     fireEvent.click(result.container.querySelector('.log-search-btn')!);
     await flushPromises();
-    expect(setSearchFn).toHaveBeenLastCalledWith(formData);
+    expect(setSearchFn).toHaveBeenLastCalledWith({ requestId: formData.requestId });
     result.rerender(<SimpleLogSearch setSearch={setSearchFn} formData={formData} />);
     expect(result.getByRole('textbox').value).toBe(formData.requestId);
+    fireEvent.click(result.container.querySelector('.log-search-btn')!);
+    await flushPromises();
+    expect(setSearchFn).toHaveBeenLastCalledWith(formData);
   });
 });

--- a/shell/app/common/components/simple-log/__tests__/simple-log.test.tsx
+++ b/shell/app/common/components/simple-log/__tests__/simple-log.test.tsx
@@ -39,6 +39,8 @@ describe('SimpleLog', () => {
     fireEvent.change(result.getByRole('textbox'), { target: { value: 'cloud' } });
     fireEvent.click(result.container.querySelector('.log-search-btn')!);
     await flushPromises();
-    expect(result.container.querySelector('.props-query')?.innerHTML).toBe(JSON.stringify({ requestId: 'cloud' }));
+    expect(result.container.querySelector('.props-query')?.innerHTML).toBe(
+      JSON.stringify({ ...query, requestId: 'cloud' }),
+    );
   });
 });

--- a/shell/app/common/components/simple-log/simple-log-search.tsx
+++ b/shell/app/common/components/simple-log/simple-log-search.tsx
@@ -13,36 +13,44 @@
 
 import React from 'react';
 import { isEmpty } from 'lodash';
-import { Form, Input, Button } from 'antd';
+import { Button, Form, FormInstance, Input } from 'antd';
 import { ErdaIcon } from 'common';
 import './simple-log.scss';
 import i18n from 'i18n';
 
 const FormItem = Form.Item;
 
-class LogSearchForm extends React.Component {
-  formRef = React.createRef();
+interface IProps {
+  formData: {
+    requestId: string;
+    [key: string]: any;
+  };
+  setSearch: (data: IProps['formData']) => void;
+}
+
+class LogSearchForm extends React.Component<IProps, any> {
+  formRef = React.createRef<FormInstance>();
 
   componentDidMount = () => {
     this.setForm(this.props.formData);
   };
 
-  UNSAFE_componentWillReceiveProps({ formData }) {
+  UNSAFE_componentWillReceiveProps({ formData }: Readonly<IProps>) {
     if (formData !== this.props.formData) {
       this.setForm(formData);
     }
   }
 
-  setForm = (formData) => {
+  setForm = (formData: IProps['formData']) => {
     if (!isEmpty(formData)) {
-      this.formRef.current.setFieldsValue(formData);
+      this.formRef.current?.setFieldsValue(formData);
       // this.handleSubmit();
     }
   };
 
-  handleSubmit = (values) => {
-    const { setSearch } = this.props;
-    setSearch(this.formRef.current.getFieldsValue());
+  handleSubmit = () => {
+    const { setSearch, formData } = this.props;
+    setSearch({ ...formData, ...this.formRef.current?.getFieldsValue() });
   };
 
   render() {
@@ -64,4 +72,5 @@ class LogSearchForm extends React.Component {
     );
   }
 }
+
 export default LogSearchForm;

--- a/shell/app/config-page/components/table/v2/utils.tsx
+++ b/shell/app/config-page/components/table/v2/utils.tsx
@@ -33,7 +33,7 @@ export const convertTableData = (
   props?: CP_TABLE2.IProps,
   extra?: Extra,
 ) => {
-  const { columnsMap: pColumnsMap, pageSizeOptions } = props || {};
+  const { columnsMap: pColumnsMap, pageSizeOptions, tableProps } = props || {};
   const { table } = data || {};
   const { columns: dataColumns, rows, pageNo, pageSize, total } = table || {};
   const { columnsMap, merges, orders } = dataColumns || {};
@@ -82,7 +82,16 @@ export const convertTableData = (
     };
   }
 
-  return { dataSource, columns, rowSelection, rowKey: 'id', total, pageNo, pageSize, pageSizeOptions };
+  return {
+    dataSource,
+    columns,
+    rowSelection,
+    rowKey: tableProps?.rowKey ?? 'id',
+    total,
+    pageNo,
+    pageSize,
+    pageSizeOptions,
+  };
 };
 
 const getTitleRender = (column?: CP_TABLE2.ColumnItem) => {

--- a/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
+++ b/shell/app/modules/msp/env-overview/service-list/pages/transaction.tsx
@@ -232,6 +232,13 @@ const Transaction = () => {
               {},
             ),
             table: {
+              props: {
+                tableProps: {
+                  rowKey: (record: Required<IState>['recordItem']) => {
+                    return record.transactionName.data.text;
+                  },
+                },
+              },
               op: {
                 clickRow: openDetail,
               },

--- a/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search.tsx
+++ b/shell/app/modules/msp/monitor/trace-insight/pages/trace-querier/trace-search.tsx
@@ -198,6 +198,13 @@ const TraceSearch: React.FC<IProps> = ({ scope = 'trace' }) => {
               },
             },
             table: {
+              props: {
+                tableProps: {
+                  rowKey: (record: ITableRow) => {
+                    return record.traceId.data.text;
+                  },
+                },
+              },
               op: {
                 clickRow: (data: ITableRow) => {
                   update({


### PR DESCRIPTION
## What this PR does / why we need it:

fix missing query params in SimpleLogSearch

## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [【集成环境】错误分析-错误详情，查看日志页面，点击搜索报错](https://erda.cloud/erda/dop/projects/387/issues/all?id=306309&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxNl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1174&tab=BUG&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix missing query params in SimpleLogSearch |
| 🇨🇳 中文    | 修复日志搜索组件中查询参数缺失的问题 |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1-beta.4

