### PR TITLE
fix(cmp): get useable k8s clusters interface optimization

### DIFF
--- a/shell/app/modules/cmp/stores/cluster.ts
+++ b/shell/app/modules/cmp/stores/cluster.ts
@@ -74,7 +74,7 @@ const cluster = createStore({
   name: 'org-cluster',
   state: initState,
   subscriptions({ listenRoute }: IStoreSubs) {
-    listenRoute(({ params, isIn, isLeaving }) => {
+    listenRoute(({ params, isIn, isEntering, isLeaving }) => {
       const { clusterName } = params;
       const [curDetail, chosenCluster] = cluster.getState((s) => [s.detail, s.chosenCluster]);
       if (isIn('clusterDetail') && curDetail?.name !== clusterName) {
@@ -83,7 +83,7 @@ const cluster = createStore({
       if (isLeaving('clusterDetail')) {
         cluster.reducers.clearClusterDetail('');
       }
-      if (isIn('cmp')) {
+      if (isEntering('cmp')) {
         cluster.effects.getUseableK8sCluster().then((k8sClusters: IUseableK8sClusters) => {
           const curChosenCluster = cluster.getState((s) => s.chosenCluster);
           const firstCluster = k8sClusters?.ready?.[0];


### PR DESCRIPTION
## What this PR does / why we need it:
Get useable k8s clusters interface optimization.


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   The available cluster interface, which was called on every page of the cloud platform, will be called once only when entering the cloud platform.  |
| 🇨🇳 中文    |  在云管平台每个页面都会调用的可用集群接口，改成只有进入云管平台时调用一次。   |


## Need cherry-pick to release versions?
❎ No

