### PR TITLE
fix: show iteration synchronously tip when update iteration success

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
@@ -436,9 +436,11 @@ export const EditIssueDrawer = (props: IProps) => {
                 savingRef.current = false;
               });
               // setHasEdited(false); // 更新后置为false
+              return true;
             })
             .catch(() => {
               savingRef.current = false;
+              return false;
             });
         } else {
           addFieldsToIssue(

--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer/meta-fields.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer/meta-fields.tsx
@@ -94,6 +94,7 @@ interface GetCompProps {
 }
 
 interface IterationExtraProps {
+  iterationChanged: boolean;
   force: boolean;
   visible: boolean;
   onCancel: () => void;
@@ -101,9 +102,10 @@ interface IterationExtraProps {
 }
 
 const IterationFiedExtra = (props: IterationExtraProps) => {
-  const { force, visible, onCancel, onOk } = props;
+  const { force, visible, onCancel, onOk, iterationChanged } = props;
   const data = getIssueRelation.useData();
-  if (!data?.include?.length) {
+
+  if (!data?.include?.length || !iterationChanged) {
     return null;
   }
   const [title, btn] = force
@@ -231,6 +233,7 @@ const IssueMetaFields = React.forwardRef(
           }
         : null,
     );
+    const [iterationChanged, setIterationChanged] = React.useState(false);
     const [iterationUpdate, setIterationUpdate] = React.useState<{
       name: string;
       id: string;
@@ -466,8 +469,10 @@ const IssueMetaFields = React.forwardRef(
             });
 
             const res = setFieldCb({ ...v });
+            setIterationChanged(false);
             if (isPromise(res)) {
-              res.then(() => {
+              res.then((_suc) => {
+                setIterationChanged(_suc);
                 if (withChildrenIteration) {
                   updateIncludeIssue({
                     issueId: formData.id,
@@ -503,6 +508,7 @@ const IssueMetaFields = React.forwardRef(
           ),
           extraContent: (
             <IterationFiedExtra
+              iterationChanged={iterationChanged}
               onCancel={() => {
                 setIterationUpdate((prev) => ({ ...prev, visible: false }));
               }}


### PR DESCRIPTION
## What this PR does / why we need it:
fix: show iteration synchronously tip when update iteration success

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=307105&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDM5MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTAwfQ%3D%3D&iterationID=-1&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: show iteration synchronously tip when update iteration success         |
| 🇨🇳 中文    |   fix: 在修改事项成功后显示同步迭代的提示           |


## Need cherry-pick to release versions?
❎ No

