### PR TITLE
fix(msp): correct update time with edgeNow in dashboard list

### DIFF
--- a/shell/app/modules/cmp/common/custom-dashboard/index.tsx
+++ b/shell/app/modules/cmp/common/custom-dashboard/index.tsx
@@ -144,7 +144,7 @@ const CustomDashboardList = ({
     {
       title: i18n.t('Update time'),
       dataIndex: 'updatedAt',
-      render: (timestamp: number) => fromNow(timestamp),
+      render: (timestamp: number) => fromNow(timestamp, { edgeNow: true }),
     },
     {
       title: i18n.t('Creator'),


### PR DESCRIPTION
## What this PR does / why we need it:
correct update time with the edgeNow in dashboard list

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed the update time displayed in the custom dashboard list   |
| 🇨🇳 中文    |  修正自定义大盘列表中显示的更新时间  |


## Need cherry-pick to release versions?
❎ No

