### PR TITLE
fix: table sort not work

### DIFF
--- a/shell/app/common/components/details-panel/index.tsx
+++ b/shell/app/common/components/details-panel/index.tsx
@@ -137,7 +137,7 @@ const DetailsPanel = (props: IProps) => {
             ...titleProps,
           };
           return (
-            <div id={key} className="pt-3">
+            <div key={key} id={key} className="pt-3">
               <Content
                 crossLine={crossLine}
                 titleProps={_titleProps}

--- a/shell/app/common/components/table/__tests__/index.test.tsx
+++ b/shell/app/common/components/table/__tests__/index.test.tsx
@@ -253,7 +253,7 @@ describe('ErdaTable', () => {
       column: { title: 'count', sorter: true, dataIndex: 'count' },
       columnKey: 'count',
       field: 'count',
-      order: 'Ascending',
+      order: 'ascend',
     });
     fireEvent.click(result.getByText('Descending').closest('li')!);
     expect(tableChangeFn).toHaveBeenCalledTimes(2);
@@ -261,7 +261,7 @@ describe('ErdaTable', () => {
       column: { title: 'count', sorter: true, dataIndex: 'count' },
       columnKey: 'count',
       field: 'count',
-      order: 'Descending',
+      order: 'descend',
     });
     fireEvent.click(result.getByText('Unsort').closest('li')!);
     expect(tableChangeFn).toHaveBeenCalledTimes(3);

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -205,7 +205,7 @@ function WrappedTable<T extends object = any>({
         };
         if (order && columnSorter?.compare) {
           sortCompareRef.current = (a: T, b: T) => {
-            if (order === 'ascend') {
+            if (order === SORT_ORDER.ASC) {
               return columnSorter?.compare?.(a, b);
             } else {
               return columnSorter?.compare?.(b, a);
@@ -213,7 +213,7 @@ function WrappedTable<T extends object = any>({
           };
         } else if (order && typeof columnSorter === 'function') {
           sortCompareRef.current = (a: T, b: T) => {
-            if (order === 'ascend') {
+            if (order === SORT_ORDER.ASC) {
               return columnSorter?.(a, b);
             } else {
               return columnSorter?.(b, a);
@@ -230,15 +230,15 @@ function WrappedTable<T extends object = any>({
           <Menu.Item key={'0'} onClick={() => onSort()}>
             <span className="fake-link mr-1">{i18n.t('Unsort')}</span>
           </Menu.Item>
-          <Menu.Item key={'ascend'} onClick={() => onSort(SORT_ORDER.ASC)}>
+          <Menu.Item key={SORT_ORDER.ASC} onClick={() => onSort(SORT_ORDER.ASC)}>
             <span className="fake-link mr-1">
-              <ErdaIcon type="ascend" className="relative top-0.5 mr-1" />
+              <ErdaIcon type={SORT_ORDER.ASC} className="relative top-0.5 mr-1" />
               {i18n.t('Ascending')}
             </span>
           </Menu.Item>
-          <Menu.Item key={'descend'} onClick={() => onSort(SORT_ORDER.DESC)}>
+          <Menu.Item key={SORT_ORDER.DESC} onClick={() => onSort(SORT_ORDER.DESC)}>
             <span className="fake-link mr-1">
-              <ErdaIcon type="descend" className="relative top-0.5 mr-1" />
+              <ErdaIcon type={SORT_ORDER.DESC} className="relative top-0.5 mr-1" />
               {i18n.t('Descending')}
             </span>
           </Menu.Item>

--- a/shell/app/common/components/table/index.tsx
+++ b/shell/app/common/components/table/index.tsx
@@ -60,9 +60,13 @@ interface ColumnsConfig {
   };
 }
 
+const enum SORT_ORDER {
+  ASC = 'ascend',
+  DESC = 'descend',
+}
 const sortIcon = {
-  ascend: <ErdaIcon type="ascend" size={16} />,
-  descend: <ErdaIcon type="descend" size={16} />,
+  ascend: <ErdaIcon type={SORT_ORDER.ASC} size={16} />,
+  descend: <ErdaIcon type={SORT_ORDER.DESC} size={16} />,
 };
 
 const alignMap = {
@@ -194,7 +198,7 @@ function WrappedTable<T extends object = any>({
         columnKey: column.dataIndex,
         field: column.dataIndex,
       } as SorterResult<T>;
-      const onSort = (order?: 'ascend' | 'descend') => {
+      const onSort = (order?: SORT_ORDER) => {
         setSort({ ...sorter, order });
         const { sorter: columnSorter } = column as {
           sorter: { compare: (a: T, b: T) => number } | ((a: T, b: T) => number);
@@ -226,13 +230,13 @@ function WrappedTable<T extends object = any>({
           <Menu.Item key={'0'} onClick={() => onSort()}>
             <span className="fake-link mr-1">{i18n.t('Unsort')}</span>
           </Menu.Item>
-          <Menu.Item key={'ascend'} onClick={() => onSort('Ascending')}>
+          <Menu.Item key={'ascend'} onClick={() => onSort(SORT_ORDER.ASC)}>
             <span className="fake-link mr-1">
               <ErdaIcon type="ascend" className="relative top-0.5 mr-1" />
               {i18n.t('Ascending')}
             </span>
           </Menu.Item>
-          <Menu.Item key={'descend'} onClick={() => onSort('Descending')}>
+          <Menu.Item key={'descend'} onClick={() => onSort(SORT_ORDER.DESC)}>
             <span className="fake-link mr-1">
               <ErdaIcon type="descend" className="relative top-0.5 mr-1" />
               {i18n.t('Descending')}


### PR DESCRIPTION
## What this PR does / why we need it:
table sorter key is misUpdated by i18n fix;

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: table sort not work  |
| 🇨🇳 中文    |      修复表格排序失效的问题        |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1

