### PR TITLE
fix: links duplicate & links translation miss "[]"

### DIFF
--- a/locales/zh.json
+++ b/locales/zh.json
@@ -151,7 +151,7 @@
     "Duration": "时长",
     "East China {num}": "华东{num}",
     "Edit": "编辑",
-    "Edit members and set member roles. See Role Permission Description for details.": "编辑成员，设置成员角色，相关角色权限请参考",
+    "Edit members and set member roles. See Role Permission Description for details.": "编辑成员，设置成员角色，相关角色权限请参考[角色权限说明]",
     "Email": "邮箱",
     "Enable": "启用",
     "Enable-open": "开启",

--- a/shell/app/modules/application/pages/settings/app-settings.tsx
+++ b/shell/app/modules/application/pages/settings/app-settings.tsx
@@ -54,9 +54,7 @@ export const PureAppSettings = () => {
       <div className="title font-medium">{i18n.t('{name} member management', { name: i18n.t('App') })}</div>
       <div className="desc">
         {replaceWithLink(
-          `${i18n.t('Edit members and set member roles. See Role Permission Description for details.')}[${i18n.t(
-            'role permissions description',
-          )}]`,
+          i18n.t('Edit members and set member roles. See Role Permission Description for details.'),
           goTo.resolve.perm({ scope: 'app' }),
         )}
       </div>

--- a/shell/app/modules/org/pages/projects/settings/member/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/member/index.tsx
@@ -42,9 +42,7 @@ const SettingsMember = () => {
         message={
           <>
             {replaceWithLink(
-              `${i18n.t('Edit members and set member roles. See Role Permission Description for details.')}[${i18n.t(
-                'role permissions description',
-              )}]`,
+              i18n.t('Edit members and set member roles. See Role Permission Description for details.'),
               goTo.resolve.perm({ scope: 'app' }),
             )}
           </>

--- a/shell/app/modules/org/pages/setting/org-setting.tsx
+++ b/shell/app/modules/org/pages/setting/org-setting.tsx
@@ -57,9 +57,7 @@ export const OrgSetting = () => {
                   desc: (
                     <div>
                       {replaceWithLink(
-                        `${i18n.t(
-                          'Edit members and set member roles. See Role Permission Description for details.',
-                        )}[${i18n.t('role permissions description')}]`,
+                        i18n.t('Edit members and set member roles. See Role Permission Description for details.'),
                         goTo.resolve.perm({ scope: 'app' }),
                       )}
                     </div>

--- a/shell/app/modules/project/pages/settings/components/project-settings.tsx
+++ b/shell/app/modules/project/pages/settings/components/project-settings.tsx
@@ -66,9 +66,7 @@ const ProjectSettings = () => {
                   desc: (
                     <div>
                       {replaceWithLink(
-                        `${i18n.t(
-                          'Edit members and set member roles. See Role Permission Description for details.',
-                        )}[${i18n.t('role permissions description')}]`,
+                        i18n.t('Edit members and set member roles. See Role Permission Description for details.'),
                         goTo.resolve.perm({ scope: 'app' }),
                       )}
                     </div>


### PR DESCRIPTION
## What this PR does / why we need it:
fix: links duplicate & links translation miss "[]"



## Which issue(s) this PR fixes:
Fixes #3434 

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes()
![image](https://user-images.githubusercontent.com/72543663/165875651-c3f9c98a-5505-4efd-b08a-13b199a3fe19.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      links duplicate & links translation miss "[]"        |
| 🇨🇳 中文    |       i18n 链接显示重复 & 链接中文翻译修改       |


## Need cherry-pick to release versions?
❎ No

