### PR TITLE
fix:(cli): keep pnpm version to 6.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY scheduler ./scheduler
 WORKDIR /usr/src/app/scheduler
 ENV NODE_ENV=production
 
-RUN npm i pnpm -g
+RUN npm i pnpm@6.x -g
 RUN pnpm i --unsafe-perm --reporter append-only
 RUN npm run build
 

--- a/cli/lib/init-online.ts
+++ b/cli/lib/init-online.ts
@@ -25,7 +25,7 @@ export default async () => {
   isCwdInRoot({ currentPath: currentDir, alert: true });
 
   let spinner = ora('[1/2] Installing pnpm globally...').start();
-  const { stdout: msg } = await execa('npm', ['i', '-g', '--force', 'pnpm']);
+  const { stdout: msg } = await execa('npm', ['i', '-g', '--force', 'pnpm@6.x']);
   logInfo(msg);
   logSuccess('Successfully Installed pnpm globally😁');
   spinner.stop();

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erda-ui/cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Command line interface for rapid Erda UI development",
   "bin": {
     "erda-ui": "dist/bin/erda.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erda-ui/cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Command line interface for rapid Erda UI development",
   "bin": {
     "erda-ui": "dist/bin/erda.js"


### PR DESCRIPTION
## What this PR does / why we need it:
keep pnpm version to 6.x because 7.x has released and it requires node v14.19 but erda pipeline not support yet


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     keep pnpm version to 6.x         |
| 🇨🇳 中文    |    固定pnpm版本为6.x          |


## Need cherry-pick to release versions?
❎ No

