### PR TITLE
fix(msp): fix fetch log params

### DIFF
--- a/shell/app/common/components/log-roller/index.tsx
+++ b/shell/app/common/components/log-roller/index.tsx
@@ -88,7 +88,7 @@ export class LogRoller extends React.Component<IProps, IState> {
       this.searchCount = 1;
       if (this.logRoller) {
         this.scrollToBottom();
-        this.rollingTimeout = setTimeout(() => this.fetchLog(Direction.forward), fetchPeriod);
+        this.rollingTimeout = setTimeout(() => this.forwardLog(), fetchPeriod);
       }
     });
   }
@@ -124,7 +124,7 @@ export class LogRoller extends React.Component<IProps, IState> {
         if (this.logRoller) {
           this.scrollToBottom();
           if (this.rollingTimeout !== undefined) {
-            this.rollingTimeout = setTimeout(() => this.fetchLog(Direction.forward), fetchPeriod);
+            this.rollingTimeout = setTimeout(() => this.forwardLog(), fetchPeriod);
           }
         }
       });
@@ -165,15 +165,15 @@ export class LogRoller extends React.Component<IProps, IState> {
       }
       reQuery.count = Number(size);
     } else if (Direction.backward === direction) {
+      reQuery.count = -1 * Number(size);
       if (searchContext && this.searchCount === 0) {
         reQuery.end = start;
       } else {
-        reQuery.start = 0;
+        reQuery.start = filter?.start ?? 0;
         const firstItem = first(content);
-        reQuery.end = firstItem ? firstItem.timestamp : Number(end) || getCurTimeNs();
+        reQuery.end = firstItem ? firstItem.timestamp : filter?.end || Number(end) || getCurTimeNs();
+        return { ...filter, ...reQuery, ...rest, logKey };
       }
-
-      reQuery.count = -1 * Number(size);
     }
     return { ...reQuery, ...filter, ...rest, logKey };
   };


### PR DESCRIPTION
## What this PR does / why we need it:


## I have checked the following points:
- [X] I18n is finished and updated by cli
- [X] Form fields validation is added and length is limited
- [X] Display normally on small screen
- [X] Display normally when some data is empty or null
- [X] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [【集成环境】容器日志，fluent-bit恢复后，补偿的日志顺序有错](https://erda.erda.cloud/erda/dop/projects/387/issues/all?id=305550&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEzMjkiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1190&tab=BUG&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix fetch log params |
| 🇨🇳 中文    | 修复获取日志参数 |


## Need cherry-pick to release versions?
❎ No

