### PR TITLE
fix(cmp): overview services table pageSize change bug

### DIFF
--- a/shell/app/modules/dcos/pages/cluster-dashboard/instance-list.tsx
+++ b/shell/app/modules/dcos/pages/cluster-dashboard/instance-list.tsx
@@ -247,10 +247,6 @@ IProps) => {
         columns={[...instanceTypeColMap[instanceType], ...cols] as Array<ColumnProps<any>>}
         dataSource={instanceMap[instanceType]}
         loading={loading}
-        pagination={{
-          pageSize: PAGINATION.pageSize,
-        }}
-        scroll={{ x: '100%' }}
       />
       <Copy selector=".for-copy-image" />
       {drawer}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix overview services table pageSize change bug.



## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=309976&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1190&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed cloud management platform - Cluster Overview - Service catalog switching single page is invalid.   |
| 🇨🇳 中文    | 修复了云管平台-集群总览-服务目录切换单页条数无效的问题。 |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1
