### PR TITLE
fix(dop): runtime detail breadcrumb bug

### DIFF
--- a/shell/app/locales/utils.ts
+++ b/shell/app/locales/utils.ts
@@ -47,6 +47,10 @@ export const ENV_MAP = {
   test: i18n.t('test environment'),
   staging: i18n.t('staging environment'),
   prod: i18n.t('prod environment'),
+  DEV: i18n.t('dev environment'),
+  TEST: i18n.t('test environment'),
+  STAGING: i18n.t('staging environment'),
+  PROD: i18n.t('prod environment'),
 };
 
 export const getTranslateAddonList = (addonList: ADDON.Instance[], key: string) =>

--- a/shell/app/locales/utils.ts
+++ b/shell/app/locales/utils.ts
@@ -47,10 +47,6 @@ export const ENV_MAP = {
   test: i18n.t('test environment'),
   staging: i18n.t('staging environment'),
   prod: i18n.t('prod environment'),
-  DEV: i18n.t('dev environment'),
-  TEST: i18n.t('test environment'),
-  STAGING: i18n.t('staging environment'),
-  PROD: i18n.t('prod environment'),
 };
 
 export const getTranslateAddonList = (addonList: ADDON.Instance[], key: string) =>

--- a/shell/app/modules/application/router.ts
+++ b/shell/app/modules/application/router.ts
@@ -209,7 +209,7 @@ function getAppRouter(): RouteConfigItem {
                 mark: 'appDeployRuntime',
                 breadcrumbName: ({ params }) => {
                   const { workspace } = params;
-                  return ENV_MAP[workspace];
+                  return ENV_MAP[workspace?.toLocaleLowerCase()];
                 },
                 getComp: (cb) => cb(import('app/modules/runtime/pages/overview')),
                 layout: {

--- a/shell/app/modules/project/router.tsx
+++ b/shell/app/modules/project/router.tsx
@@ -511,7 +511,7 @@ function getProjectRouter(): RouteConfigItem[] {
                   backToUp: 'projectDeployEnv',
                   breadcrumbName: ({ params }) => {
                     const { workspace } = params;
-                    return ENV_MAP[workspace];
+                    return ENV_MAP[workspace?.toLocaleLowerCase()];
                   },
                   mark: 'projectDeployRuntime',
                   getComp: (cb) => cb(import('app/modules/runtime/pages/overview')),


### PR DESCRIPTION
## What this PR does / why we need it:
Fix runtime detail breadcrumb bug.


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/167109030-bc7811e2-f4fa-4f81-8db2-96ab97d4e8fe.png)

## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fixed an issue where there was no back button in the runtime details page when jumping from pipeline. |
| 🇨🇳 中文    |  修复了从流水线跳转去runtime详情页中没有返回按钮的问题。  |


## Need cherry-pick to release versions?
❎ No

