### PR TITLE
fix:(scheduler):fix health check api

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -38,7 +38,7 @@ services:
     health_check:
       http:
         port: 80
-        path: "/"
+        path: "/_api/health"
         duration: 120
   enterprise-ui:
     ports:

--- a/scheduler/src/proxy.ts
+++ b/scheduler/src/proxy.ts
@@ -41,11 +41,8 @@ export const createProxyService = (app: INestApplication) => {
     const reqMsg = `${req.url} to ${target}`;
     try {
       if (!res.writableEnded) {
-        res.writeHead(500, {
-          'Content-Type': 'text/plain',
-        });
         const errMsg = `Error occurred while proxying request ${reqMsg}: ${err.message}`;
-        res.end(errMsg);
+        res.end();
         logger.warn(errMsg, err);
       } else {
         logger.warn(`Response is ended before error handler while proxying request ${reqMsg}`);


### PR DESCRIPTION
## What this PR does / why we need it:
currently health check visit `/` and will get 302 error. Then it may restart server


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->




## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix health check wrong api          |
| 🇨🇳 中文    |    修复健康检查错误的api          |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.2-beta.1

