### PR TITLE
feat(dop): runtime resource config scale add tip

### DIFF
--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -1827,6 +1827,7 @@
     "rule name": "rule name",
     "running resources": "running resources",
     "runtime-resource-config-form-tip": "The modification of this expansion configuration will take effect immediately. Note: But it will cause the resource configuration in erda.yml to become invalid (the expansion configuration has a higher priority)",
+    "runtime-resource-config-form-scale-tip": "If scaling to 0 succeeds, Scale displays the number of instances before scaling, rather than the current number of instances 0",
     "same field exists": "same field exists",
     "script deployment": "script deployment",
     "search": "search",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -1827,6 +1827,7 @@
     "rule name": "规则名称",
     "running resources": "运行资源",
     "runtime-resource-config-form-tip": "本次扩缩容配置的修改会立即生效，注意：但会导致 erda.yml 中的资源配置会失效（扩缩容配置优先级更高）",
+    "runtime-resource-config-form-scale-tip": "如果缩容为0成功，Scale 显示缩容前的实例数，而不是当前的实例数 0",
     "same field exists": "存在相同的字段",
     "script deployment": "脚本部署",
     "search": "查询",

--- a/shell/app/modules/runtime/pages/overview/components/resource-modal.tsx
+++ b/shell/app/modules/runtime/pages/overview/components/resource-modal.tsx
@@ -100,6 +100,8 @@ const ResourceModal = ({ visible, service, editDisabled, onOk, onCancel }: IProp
           lg: { span: 12 },
         },
       },
+      className: 'flex-1',
+      labelTip: i18n.t('dop:runtime-resource-config-form-scale-tip'),
     },
   ];
 


### PR DESCRIPTION
## What this PR does / why we need it:
Runtime resource config scale add tip.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=311054&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMjE0Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1190&tab=ALL&type=TASK)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/167533686-e50484ba-09e2-40cd-9c50-f31f4e399583.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  The workbench service capacity expansion or reduction prompt is complete. |
| 🇨🇳 中文    |   工作台服务扩缩容提示信息完善。   |


## Need cherry-pick to release versions?
❎ No

