### PR TITLE
fix: do not open issue detail when issue not found

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer/index.tsx
@@ -41,6 +41,7 @@ import { FIELD_WITH_OPTION } from 'org/common/config';
 import { produce } from 'immer';
 import issueFieldStore from 'org/stores/issue-field';
 import orgStore from 'app/org-home/stores/org';
+import { useUnmount } from 'react-use';
 import { templateMap } from 'project/common/issue-config';
 import IssueMetaFields from './meta-fields';
 import { IssueInclusion, IssueConnection } from '../issue-relation';
@@ -200,7 +201,6 @@ export const EditIssueDrawer = (props: IProps) => {
   React.useEffect(() => {
     if (visible) {
       if (id) {
-        getIssueDetail({ id });
         getIssueStreams({ type: issueType, id, pageNo: 1, pageSize: 100 });
         getCustomFields();
       }
@@ -835,4 +835,31 @@ export const EditIssueDrawer = (props: IProps) => {
   );
 };
 
-export default EditIssueDrawer;
+const EditIssueDrawerContainer = (props: IProps) => {
+  const { id, visible: propsVisible } = props;
+  const { getIssueDetail } = issueStore.effects;
+  const [visible, setVisible] = React.useState(false);
+  const [hasData, setHasData] = React.useState(false);
+
+  useUnmount(() => {
+    setHasData(false);
+  });
+  React.useEffect(() => {
+    id &&
+      getIssueDetail({ id: +id }).then(() => {
+        setHasData(true);
+      });
+  }, [id]);
+
+  React.useEffect(() => {
+    if (id) {
+      setVisible(propsVisible ? propsVisible && hasData : propsVisible);
+    } else {
+      setVisible(propsVisible);
+    }
+  }, [id, propsVisible, hasData]);
+
+  return <EditIssueDrawer {...props} visible={visible} />;
+};
+
+export default EditIssueDrawerContainer;


### PR DESCRIPTION
## What this PR does / why we need it:
fix: do not open issue detail when issue not found

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/15364706/167591936-a92d5fbf-bda2-40b4-88fe-38470babcb70.png)

to 
![image](https://user-images.githubusercontent.com/15364706/167592037-7f4f89ca-2050-42b9-847a-efd318a979e0.png)




## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: do not open issue detail when issue not found         |
| 🇨🇳 中文    |   fix: 事项查不到则不打开事项详情          |


## Need cherry-pick to release versions?
❎ No

