### PR TITLE
fix: fix land sysAdmin page without admin access

### DIFF
--- a/shell/app/App.tsx
+++ b/shell/app/App.tsx
@@ -92,7 +92,7 @@ const start = (userData: ILoginUser, orgs: ORG.IOrg[], curOrg: ORG.IOrg, orgAcce
     // get the organization info first, or will get org is undefined when need org info (like issueStore)
     const orgName = get(location.pathname.split('/'), '[1]');
     if (orgName) {
-      await orgStore.effects.getOrgByDomain({ orgName });
+      await orgStore.effects.getOrgByDomain({ orgName, userData });
     }
     [
       import('layout/entry'),

--- a/shell/app/org-home/stores/org.tsx
+++ b/shell/app/org-home/stores/org.tsx
@@ -21,7 +21,6 @@ import permStore from 'user/stores/permission';
 import breadcrumbStore from 'app/layout/stores/breadcrumb';
 import { intersection, map } from 'lodash';
 import announcementStore from 'org/stores/announcement';
-
 interface IState {
   currentOrg: ORG.IOrg;
   curPathOrg: string;
@@ -91,8 +90,12 @@ const org = createStore({
       await org.effects.getJoinedOrgs({ force: true });
       update({ currentOrg });
     },
-    async getOrgByDomain({ call, update, select }, payload: { orgName: string }) {
+    async getOrgByDomain({ call, update, select }, payload: { orgName: string; userData?: ILoginUser }) {
+      const { orgName, userData } = payload;
       if (isAdminRoute()) {
+        if (userData && !userData.isSysAdmin) {
+          goTo(goTo.pages.landPage);
+        }
         update({ initFinish: true });
         return;
       }
@@ -100,7 +103,6 @@ const org = createStore({
       if (domain.startsWith('local')) {
         domain = domain.split('.').slice(1).join('.');
       }
-      const { orgName } = payload;
       const [orgs, currentOrg] = select((s) => [s.orgs, s.currentOrg]); // get joined orgs
       const orgPermData = permStore.getState((s) => s.org);
 


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix land sysAdmin page whitout admin access

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: fix land sysAdmin page without admin access            |
| 🇨🇳 中文    |  fix: 修复无管理员权限但能访问管理员页面          |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.1

