### PR TITLE
feat(dop): app quality test list add column of code coverage

### DIFF
--- a/shell/app/modules/application/pages/test/test-list.tsx
+++ b/shell/app/modules/application/pages/test/test-list.tsx
@@ -69,6 +69,44 @@ const ExecuteResult = ({ totals }: { totals: { tests: number; statuses: TEST.Sta
   );
 };
 
+const CodeCoverage = ({ data }: { data: Array<{ value: number[] }> }) => {
+  let rowsTotal = 0;
+  let rowsCover = 0;
+
+  data.forEach((item) => {
+    rowsTotal += item.value[0] || 0;
+    rowsCover += item.value[9] || 0;
+  });
+
+  const percent = rowsTotal ? +((rowsCover * 100) / rowsTotal).toFixed(2) : 0;
+
+  const title = (
+    <>
+      <div>
+        {i18n.t('dop:Total number of rows')}: {rowsTotal}
+      </div>
+      <div>
+        {i18n.t('dop:Covering the number of rows')}: {rowsCover}
+      </div>
+      <div>
+        {i18n.t('dop:Line coverage')}: {percent}%
+      </div>
+    </>
+  );
+  return (
+    <Tooltip title={title} placement="right">
+      <Progress
+        percent={100}
+        success={{
+          percent: percent,
+        }}
+        strokeColor={themeColor['default-02']}
+        format={(_percent: number, successPercent: number) => `${Math.floor(successPercent)}%`}
+      />
+    </Tooltip>
+  );
+};
+
 const columns: Array<ColumnProps<TEST.RunTestItem>> = [
   {
     title: i18n.t('default:Name'),
@@ -107,6 +145,12 @@ const columns: Array<ColumnProps<TEST.RunTestItem>> = [
     width: 200,
     dataIndex: ['totals', 'tests'],
     render: (_text, record) => <ExecuteResult totals={record.totals} />,
+  },
+  {
+    title: i18n.t('dop:Code Coverage Statistics'),
+    width: 200,
+    dataIndex: 'coverageReport',
+    render: (text: Array<{ value: number[] }>) => <CodeCoverage data={text} />,
   },
 ];
 


### PR DESCRIPTION
## What this PR does / why we need it:
App quality test list add column of code coverage.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/168014389-997619e3-5ce3-4b22-a714-7c21f3992b57.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Application - Code Quality - Execution list adds a column of code coverage. |
| 🇨🇳 中文    |  应用-代码质量-执行列表增加代码覆盖率的列。  |


## Need cherry-pick to release versions?
❎ No

