### PR TITLE
fix(msp): display notify method when edit strategy

### DIFF
--- a/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
+++ b/shell/app/modules/cmp/common/alarm-strategy/strategy-form.tsx
@@ -221,7 +221,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
     getNotifyChannelMethods.fetch();
   });
 
-  useMount(() => {
+  React.useEffect(() => {
     if (strategyId) {
       getAlertDetail(Number(strategyId)).then(
         ({ name, clusterNames, appIds, rules, notifies, triggerCondition }: COMMON_STRATEGY_NOTIFY.IAlertBody) => {
@@ -300,7 +300,7 @@ const StrategyForm = ({ scopeType, scopeId, commonPayload }: IProps) => {
         },
       ]);
     }
-  });
+  }, [alertTriggerConditionsContent]);
 
   React.useEffect(() => {
     if (alertTriggerConditions?.length) {


### PR DESCRIPTION
## What this PR does / why we need it:
display notify method when edit strategy

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | display notify method when editing strategy |
| 🇨🇳 中文    | 编辑策略时显示通知方式|


## Need cherry-pick to release versions?
✅ Yes(version is required)
/cherry-pick release/2.1

