### PR TITLE
feat: remove viewport meta to force show pc layout in mobile

### DIFF
--- a/shell/app/views/index.ejs
+++ b/shell/app/views/index.ejs
@@ -7,7 +7,7 @@
   <title>Erda</title>
   <meta name="description" content="云上，应用协同开发平台">
   <link rel="shortcut icon" href="/static/favicon.ico">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- <meta name="viewport" content="width=device-width, initial-scale=1"> disable auto scale for mobile -->
   <!--  dice  -->
   <link class='icon-style dice-icon' rel="stylesheet" href="//at.alicdn.com/t/font_500774_kzpe8fzg3t.css">
   <style type="text/css">

--- a/shell/index.html
+++ b/shell/index.html
@@ -17,7 +17,8 @@
       /* vite static dir is root */
     }
     body {
-      margin: 0 font-family: "Roboto-Regular";
+      margin: 0;
+      font-family: "Roboto-Regular";
       background-color:#f3f2f4;
     }
 

--- a/shell/index.html
+++ b/shell/index.html
@@ -7,7 +7,7 @@
   <title>Erda</title>
   <meta name="description" content="云上，应用协同开发平台">
   <link rel="shortcut icon" href="/favicon.ico">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- <meta name="viewport" content="width=device-width, initial-scale=1"> disable auto scale for mobile -->
   <!--  dice  -->
   <link class='icon-style dice-icon' rel="stylesheet" href="//at.alicdn.com/t/font_500774_kzpe8fzg3t.css">
   <style type="text/css">


### PR DESCRIPTION
## What this PR does / why we need it:
Try the simplest way to solve mobile operate problem.
There are two ways:

### 1. auto calculate scale size by window.width
have to write mobile responsive style for every page, and some is not easy such as top-button-group.
<img width="345" alt="image" src="https://user-images.githubusercontent.com/3955437/168587175-7c24ca60-b9c5-46b6-a26b-4f0dbf1ea119.png">

<img width="353" alt="image" src="https://user-images.githubusercontent.com/3955437/168586881-2b201511-6a79-4099-9b89-63103cdf279d.png">

### 2. when remove viewport meta, mobile will show as 
no code change, just show pc layout
<img width="336" alt="image" src="https://user-images.githubusercontent.com/3955437/168587491-e8836917-244a-4b05-84ae-3781c5ffa827.png">

zoom in:
<img width="353" alt="image" src="https://user-images.githubusercontent.com/3955437/168587936-69c054a8-f7ab-439a-8183-a69e204f4017.png">



## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
as above


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  force show pc layout in mobile  |
| 🇨🇳 中文    |     强制移动端展示 pc 版页面布局   |


## Need cherry-pick to release versions?
❎ No

