### PR TITLE
[draft] Replace preinstall hook to pnpm devPreinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "init": "erda-ui init",
     "build-online": "erda-ui build --online",
     "i18n": "erda-ui i18n",
-    "postinstall": "pnpm run build:noDeclare --filter @erda-ui/components && pnpm run build --filter @erda-ui/cli"
+    "preinstall": "npx only-allow pnpm",
+    "pnpm:devPreinstall": "pnpm run build:noDeclare --filter @erda-ui/components && pnpm run build --filter @erda-ui/cli"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build-online": "erda-ui build --online",
     "i18n": "erda-ui i18n",
     "preinstall": "npx only-allow pnpm",
-    "pnpm:devPreinstall": "pnpm run build:noDeclare --filter @erda-ui/components && pnpm run build --filter @erda-ui/cli"
+    "pnpm:devPreinstall": "mkdir -p ./cli/dist/bin && touch ./cli/dist/bin/erda.js",
+    "postinstall": "pnpm run build:noDeclare --filter @erda-ui/components && pnpm run build --filter @erda-ui/cli"
   },
   "repository": {
     "type": "git",

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -49,8 +49,6 @@ stages:
               - cd ${{ dirs.erda-ui }}/shell && npm run extra-logic
               - cd ${{ dirs.erda-ui }}
               - npm i -g --force pnpm@6.x
-              - mkdir -p ./cli/dist/bin
-              - touch ./cli/dist/bin/erda.js
               - pnpm i --frozen-lockfile --no-optional --unsafe-perm
               - pnpm run build-online
               - cp -r ${{ dirs.erda-ui }}/{public,scheduler} $WORKDIR


### PR DESCRIPTION
## What this PR does / why we need it:
add pnpm life cycle hook
it only works after pnpm v 6.21.x, so make sure your local pnpm is  v6.21.x or higher


## I have checked the following points:
- [ ] I18n is finished and updated by cli
- [ ] Form fields validation is added and length is limited
- [ ] Display normally on small screen
- [ ] Display normally when some data is empty or null
- [ ] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes # preinstall is not work after npm v7

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     -         |
| 🇨🇳 中文    |      -      |


## Need cherry-pick to release versions?
✅ Yes(version is required)
❎ No

