### PR TITLE
fix(dop): don't query pipeline detail when pipelineId is 0

### DIFF
--- a/shell/app/modules/project/common/components/workflow/steps/pipeline.tsx
+++ b/shell/app/modules/project/common/components/workflow/steps/pipeline.tsx
@@ -50,9 +50,9 @@ const Pipeline: React.FC<IProps> = ({ data, projectID }) => {
 
   React.useEffect(() => {
     setPipelineInfo(pipelineStepInfos);
-    const queryQueue = (pipelineStepInfos ?? []).map((item) =>
-      getPipelineDetail({ pipelineID: item.pipelineID }).then((res) => res.data),
-    );
+    const queryQueue = (pipelineStepInfos ?? [])
+      .filter((item) => !!item.pipelineID)
+      .map((item) => getPipelineDetail({ pipelineID: item.pipelineID }).then((res) => res.data));
     Promise.all(queryQueue ?? []).then((pipelineDetails) => {
       const taskMap = {};
       pipelineDetails.forEach((pipelineDetail) => {
@@ -90,7 +90,7 @@ const Pipeline: React.FC<IProps> = ({ data, projectID }) => {
       <div className="workflow-step-pipeline">
         {pipelineInfo?.length ? (
           pipelineInfo.map((item) => {
-            const { status, text } = ciStatusMap[item.status];
+            const { status, text } = ciStatusMap[item.status || 'Initializing'];
             return (
               <div key={item.pipelineID} className="flex justify-between items-center">
                 <div className="flex justify-start items-center flex-1 max-w-[200px]">
@@ -105,9 +105,11 @@ const Pipeline: React.FC<IProps> = ({ data, projectID }) => {
                       [{item.taskCount.finishTaskTotal}/{item.taskCount.taskTotal}]
                     </span>
                   ) : null}
-                  <a className="flex items-center ml-2" href={`${url}?pipelineID=${item.pipelineID}`} target="_blank">
-                    <ErdaIcon className="hover:text-purple-deep" type="share" />
-                  </a>
+                  {item.pipelineID ? (
+                    <a className="flex items-center ml-2" href={`${url}?pipelineID=${item.pipelineID}`} target="_blank">
+                      <ErdaIcon className="hover:text-purple-deep" type="share" />
+                    </a>
+                  ) : null}
                 </div>
               </div>
             );


### PR DESCRIPTION
## What this PR does / why we need it:

don't query pipeline detail when pipelineId is 0


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=313691&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=0&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | -  |
| 🇨🇳 中文    | - |


## Need cherry-pick to release versions?
❎ No

