### PR TITLE
fix: markdown editor crash when nesting too many quotes

### DIFF
--- a/shell/app/common/components/edit-field/index.tsx
+++ b/shell/app/common/components/edit-field/index.tsx
@@ -126,7 +126,7 @@ export const EditMd = ({ value, onChange, onSave, disabled, originalValue, maxHe
             />
           </div>
           <div className="overflow-hidden" style={{ maxHeight: 'inherit', minHeight: '120px' }}>
-            <div ref={mdContentRef} className="md-content">
+            <div ref={mdContentRef}>
               <MarkdownRender noWrapper value={v} />
               <div
                 className={`absolute left-0 bottom-0 w-full h-16 bg-gradient-to-t from-white flex justify-center items-center ${

--- a/shell/app/common/components/markdown-editor/editor.tsx
+++ b/shell/app/common/components/markdown-editor/editor.tsx
@@ -89,7 +89,6 @@ const Editor = React.forwardRef((props: IProps, ref) => {
         'full-screen',
       ]}
       config={config}
-      htmlClass="md-content"
       renderHTML={(text: string) => <MarkdownRender value={text} />}
       onImageUpload={onImageUpload}
       imageAccept=".jpg, .jpeg, .png, .gif"

--- a/shell/app/common/components/markdown-editor/index.tsx
+++ b/shell/app/common/components/markdown-editor/index.tsx
@@ -137,6 +137,10 @@ const MarkdownEditor: React.ForwardRefRenderFunction<EC_MarkdownEditor, IProps> 
   }, [tempContent, updater, value]);
 
   const onChangeContent = (data: { html: string; text: string }) => {
+    if (data.text.match(/>{100,}/)) {
+      message.warn(i18n.t('common:The quotes (>) nesting level cannot exceed 100')); // will cause cursor jump, don't know why
+      return;
+    }
     let v = data.text;
     if (maxLength && data.text.length > maxLength) {
       message.warn(i18n.t('common:The maximum length is {limit}, please upload with attachment', { limit: maxLength }));

--- a/shell/app/locales/en.json
+++ b/shell/app/locales/en.json
@@ -712,6 +712,7 @@
     "The configuration cannot be restored after deletion. Continue": "The configuration cannot be restored after deletion. Continue",
     "The default value only takes effect in the generated form": "The default value only takes effect in the generated form",
     "The maximum length is {limit}, please upload with attachment": "The maximum length is {limit}, please upload with attachment",
+    "The quotes (>) nesting level cannot exceed 100": "The quotes (>) nesting level cannot exceed 100",
     "The user's original permissions will be overwritten after batch processing. Please be cautious.": "After batch processing user permissions, the user's original permissions will be overwritten, please operate with caution",
     "Upload File": "Upload File",
     "Upload Image": "Upload Image",

--- a/shell/app/locales/zh.json
+++ b/shell/app/locales/zh.json
@@ -712,6 +712,7 @@
     "The configuration cannot be restored after deletion. Continue": "配置删除后无法恢复，确认执行",
     "The default value only takes effect in the generated form": "默认值只在生成后的表单中生效",
     "The maximum length is {limit}, please upload with attachment": "最大长度为{limit}, 请使用附件上传",
+    "The quotes (>) nesting level cannot exceed 100": "引用(>)嵌套层级不能超过 100 个",
     "The user's original permissions will be overwritten after batch processing. Please be cautious.": "批量处理用户权限后，用户原有权限会被覆盖，请谨慎操作",
     "Upload File": "文件上传",
     "Upload Image": "图片上传",

--- a/shell/app/modules/project/common/components/issue/comment-box.tsx
+++ b/shell/app/modules/project/common/components/issue/comment-box.tsx
@@ -71,35 +71,38 @@ export const IssueCommentBox = (props: IProps) => {
     >
       <UserInfo.RenderWithAvatar avatarSize="default" id={loginUser.id} showName={false} className="mr-3" />
       {state.visible ? (
-        <div className="flex-1">
-          <MarkdownEditor
-            value={valueRef.current}
-            placeholder={i18n.t('dop:Comment ({meta} + Enter to send, Esc to collapse)', {
-              meta: isWin ? 'Shift' : 'Cmd',
-            })}
-            onFocus={() => {
-              focusRef.current = true;
-            }}
-            onBlur={() => {
-              focusRef.current = false;
-            }}
-            autoFocus
-            className="w-full issue-md-arrow"
-            onChange={(val: string) => {
-              valueRef.current = val;
-              updater.disableSave(!val.trim().length);
-            }}
-            style={{ height: '200px' }}
-            maxLength={3000}
-          />
+        <>
+          <span className="issue-md-arrow" />
+          <div className="flex-1 overflow-auto">
+            <MarkdownEditor
+              value={valueRef.current}
+              placeholder={i18n.t('dop:Comment ({meta} + Enter to send, Esc to collapse)', {
+                meta: isWin ? 'Shift' : 'Cmd',
+              })}
+              onFocus={() => {
+                focusRef.current = true;
+              }}
+              onBlur={() => {
+                focusRef.current = false;
+              }}
+              autoFocus
+              className="w-full"
+              onChange={(val: string) => {
+                valueRef.current = val;
+                updater.disableSave(!val.trim().length);
+              }}
+              style={{ height: '200px' }}
+              maxLength={3000}
+            />
 
-          <div className="mt-2">
-            <Button className="mr-3" type="primary" disabled={state.disableSave} onClick={() => submit()}>
-              {i18n.t('dop:Post')}
-            </Button>
-            <Button onClick={() => updater.visible(false)}>{i18n.t('dop:Collapse')}</Button>
+            <div className="mt-2">
+              <Button className="mr-3" type="primary" disabled={state.disableSave} onClick={() => submit()}>
+                {i18n.t('dop:Post')}
+              </Button>
+              <Button onClick={() => updater.visible(false)}>{i18n.t('dop:Collapse')}</Button>
+            </div>
           </div>
-        </div>
+        </>
       ) : (
         <div
           className="issue-comment-arrow h-8 leading-8 bg-default-04 rounded-sm cursor-pointer px-3 flex-1 hover:text-purple-deep"


### PR DESCRIPTION
## What this PR does / why we need it:
When nesting more than 2000 quotes, will throw Maximum call stack size exceeded error.
Set limit to 100.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix  markdown editor crash when nesting too many quotes  |
| 🇨🇳 中文    |        修复 markdown 编辑器里输入太多层引用时崩溃问题      |


## Need cherry-pick to release versions?
❎ No

