### PR TITLE
fix: image width not fit container width in markdown render

### DIFF
--- a/shell/app/common/components/markdown-render/__tests__/index.test.tsx
+++ b/shell/app/common/components/markdown-render/__tests__/index.test.tsx
@@ -126,9 +126,14 @@ describe('MarkdownRender', () => {
       window.dispatchEvent({ type: 'keydown', key: 'Escape', code: 'Escape' });
     });
     expect(result.container).isExist('.bg-desc', 0);
-    result.rerender(<MarkdownRender value={markdownContent} noWrapper />);
-    expect(result.container).isExist('.md-content', 0);
     off('md-img-loaded', imgLoadFn);
+  });
+  it('noWrapper should work well', () => {
+    const result = render(<MarkdownRender value={markdownContent} style={{ color: 'red' }} />);
+    expect(result.container.firstChild?.style?.color).toBe('red');
+    result.rerender(<MarkdownRender value={markdownContent} style={{ color: 'red' }} noWrapper />);
+    expect(result.container.firstChild?.style?.color).toBe('');
+    expect(result.container).isExist('.md-content', 1);
   });
   it('should MarkdownRender.toHtml work well', () => {
     expect(MarkdownRender.toHtml('### title')).toBe('<h3>title</h3>');

--- a/shell/app/common/components/markdown-render/index.tsx
+++ b/shell/app/common/components/markdown-render/index.tsx
@@ -117,6 +117,7 @@ interface IMdProps {
 export const MarkdownRender = ({ value, className, style, noWrapper, components }: IMdProps) => {
   const content = (
     <ReactMarkdown
+      className={`md-content ${className || ''}`}
       remarkPlugins={[remarkGfm, remarkBreaks]}
       components={{ img: ScalableImage, a: Link, pre, ...components }}
     >
@@ -126,11 +127,7 @@ export const MarkdownRender = ({ value, className, style, noWrapper, components 
   if (noWrapper) {
     return content;
   }
-  return (
-    <div style={style} className={`md-content ${className || ''}`}>
-      {content}
-    </div>
-  );
+  return <div style={style}>{content}</div>;
 };
 
 // have to overwrite img or other elements by extension


### PR DESCRIPTION
## What this PR does / why we need it:
image in markdown render not fit container width no matter zoom out or not.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode



## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
default:
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/3955437/171636286-6ba0bcc0-bc90-47ca-b48f-33fbff471f97.png">
scale:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/3955437/171636307-e12539fb-ec0e-49d3-84ea-e5a969c68de1.png">

->
default:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/3955437/171637089-36dc56f6-97a8-4d9b-8345-44dc51162cca.png">

scale:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/3955437/171636712-006d4aa6-9000-44ce-ac38-eaabee103a2f.png">




## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  image width not fit container width in markdown render    |
| 🇨🇳 中文    |    修复markdown 编辑器里图片看不全的问题          |


## Need cherry-pick to release versions?
❎ No

