### PR TITLE
fix: fix dataTask menu in 2.1

### DIFF
--- a/shell/app/modules/application/router.ts
+++ b/shell/app/modules/application/router.ts
@@ -151,6 +151,8 @@ function getAppRouter(): RouteConfigItem {
         routes: [
           {
             path: ':pipelineID',
+            tabs: APP_TABS,
+            alwaysShowTabKey: 'dataTask',
             getComp: (cb) => cb(import('application/pages/build/dataTask'), 'DataTask'),
           },
           {


### PR DESCRIPTION
## What this PR does / why we need it:
fix: fix dataTask menu in 2.1

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: fix dataTask menu in 2.1         |
| 🇨🇳 中文    |   fix: 修复数据任务菜单错误           |


## Need cherry-pick to release versions?
❎ No

