### PR TITLE
fix: delete noEditSuffix in i18n-easy-edit & rewrite overwrite-antd-input

### DIFF
--- a/shell/app/antd-overwrite/button/index.tsx
+++ b/shell/app/antd-overwrite/button/index.tsx
@@ -16,16 +16,9 @@ import AntdButton from 'antd/lib/button';
 import { allWordsFirstLetterUpper } from 'common/utils';
 
 const Button = React.forwardRef(({ children, ...props }: any, ref) => {
-  if (typeof children === 'string') {
-    return (
-      <AntdButton {...props} ref={ref}>
-        {allWordsFirstLetterUpper(children)}
-      </AntdButton>
-    );
-  }
   return (
     <AntdButton {...props} ref={ref}>
-      {children}
+      {allWordsFirstLetterUpper(children)}
     </AntdButton>
   );
 }) as unknown as typeof AntdButton;

--- a/shell/app/i18n-easy-edit/config.ts
+++ b/shell/app/i18n-easy-edit/config.ts
@@ -18,5 +18,5 @@ export default {
     key: 'i18n-edit-access',
     value: true,
   },
-  noEditSuffix: '*',
+  noEditSuffix: '',
 };


### PR DESCRIPTION
## What this PR does / why we need it:
delete noEditSuffix in i18n-easy-edit & rewrite overwrite-antd-input

## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      delete noEditSuffix in i18n-easy-edit & rewrite overwrite-antd-input        |
| 🇨🇳 中文    |       删除 i18n-easy-edit 后缀修饰符 &  重写overwrite-antd-input 去除冗余逻辑 |


## Need cherry-pick to release versions?
❎ No

