### PR TITLE
fix: withdraw side menu item :before z-index=-1 & collaboration go to ticket and open modal

### DIFF
--- a/shell/app/common/utils/go-to.tsx
+++ b/shell/app/common/utils/go-to.tsx
@@ -248,7 +248,7 @@ export enum pages {
   taskList = '/{orgName}/dop/projects/{projectId}/issues/all?type=task',
   bugList = '/{orgName}/dop/projects/{projectId}/issues/all?type=bug',
   issueDetail = '/{orgName}/dop/projects/{projectId}/issues/{issueType}?id={issueId}&iterationID={iterationId}&type={issueType}',
-  ticketDetail = '/{orgName}/dop/projects/{projectId}/ticket?id={issueId}&pageNo=1',
+  ticketDetail = '/{orgName}/dop/projects/{projectId}/ticket?id={issueId}&pageNo=1&iterationID={iterationId}&type={issueType}',
   backlog = '/{orgName}/dop/projects/{projectId}/issues/backlog?id={issueId}&issueType={issueType}',
   project_test_autoTestPlanDetail = '/{orgName}/dop/projects/{projectId}/auto/testPlan/{id}',
   project_test_spaceDetail_apis = '/{orgName}/dop/projects/{projectId}/auto/testCase/{id}/apis',

--- a/shell/app/styles/util.scss
+++ b/shell/app/styles/util.scss
@@ -408,7 +408,3 @@
 :not(:root):-webkit-full-screen {
   height: 100%;
 }
-
-.ant-menu-item a::before {
-  z-index: -1;
-}


### PR DESCRIPTION
## What this PR does / why we need it:
fix: withdraw side menu item :before z-index=-1 & Collaboration go to ticket and open modal

## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       fix: withdraw side menu item :before z-index=-1 & collaboration go to ticket and open modal       |
| 🇨🇳 中文    |       解决侧边栏菜单的z-index导致点击失效 &     事项中关联的工单点击后跳转后打开 modal   |


## Need cherry-pick to release versions?
❎ No

