### PR TITLE
fix: after formModal uploaded image, set ok-btn disabled to false

### DIFF
--- a/shell/app/modules/application/pages/settings/components/app-info.tsx
+++ b/shell/app/modules/application/pages/settings/components/app-info.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { ImageUpload, ConfirmDelete } from 'common';
-import { firstCharToUpper,allWordsFirstLetterUpper, goTo } from 'common/utils';
+import { firstCharToUpper, allWordsFirstLetterUpper, goTo } from 'common/utils';
 import { Button, Input, FormInstance } from 'antd';
 import { SectionInfoEdit } from 'project/common/components/section-info-edit';
 import { modeOptions } from 'application/common/config';
@@ -46,6 +46,7 @@ const PureAppInfo = (): JSX.Element => {
   const [confirmAppName, setConfirmAppName] = React.useState('');
   const permMap = usePerm((s) => s.app.setting);
   const gitRepo = `${protocol}//${appDetail.gitRepoNew}`;
+  const sectionInfoEditRef = React.useRef(null);
   const fieldsList = [
     {
       label: firstCharToUpper(i18n.t('dop:app name')),
@@ -100,7 +101,16 @@ const PureAppInfo = (): JSX.Element => {
       label: i18n.t('dop:app logo'),
       name: 'logo',
       required: false,
-      getComp: ({ form }: { form: FormInstance }) => <ImageUpload id="logo" form={form} showHint />,
+      getComp: ({ form }: { form: FormInstance }) => (
+        <ImageUpload
+          afterUpload={() => {
+            sectionInfoEditRef.current?.onValuesChange();
+          }}
+          id="logo"
+          form={form}
+          showHint
+        />
+      ),
       viewType: 'image',
     },
     // {
@@ -170,6 +180,7 @@ const PureAppInfo = (): JSX.Element => {
 
   return (
     <SectionInfoEdit
+      ref={sectionInfoEditRef}
       hasAuth={permMap.editApp.pass}
       data={{ ...appDetail, gitRepo, isPublic: `${appDetail.isPublic || 'false'}` }}
       fieldsList={fieldsList}

--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -51,7 +51,9 @@ interface IItemProps {
 const FormItem = Form.Item;
 class SectionInfoEdit extends React.Component<IProps, IState> {
   state = { modalVisible: false, saveDisabled: true };
-
+  onValuesChange = () => {
+    this.setState({ saveDisabled: false });
+  };
   toggleModal = () => {
     this.setState({ modalVisible: !this.state.modalVisible, saveDisabled: true });
     this.props.setCanGetClusterListAndResources?.(!this.state.modalVisible);
@@ -161,9 +163,7 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
           onCancel={this.toggleModal}
           modalProps={{ destroyOnClose: true }}
           okButtonState={saveDisabled}
-          onValuesChange={() => {
-            this.setState({ saveDisabled: false });
-          }}
+          onValuesChange={this.onValuesChange}
         />
       </React.Fragment>
     );


### PR DESCRIPTION
## What this PR does / why we need it:
fix: after formModal uploaded image, set ok-btn disabled to false


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [[Erda Cloud Issue Link](paste your link here](https://erda.cloud/erda/dop/projects/387/issues/all?id=318806&issueFilter__urlQuery=eyJhc3NpZ25lZUlEcyI6WyIxMDAzMTQ2Il19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1280&type=BUG))


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     after formModal uploaded image, set ok-btn disabled to false        |
| 🇨🇳 中文    |       上传图片后，设置按钮为可点击状态       |


## Need cherry-pick to release versions?
❎ No

