### PR TITLE
fix: once dropdown labels, get latest labels

### DIFF
--- a/shell/app/modules/project/common/components/issue/edit-issue-drawer/meta-fields.tsx
+++ b/shell/app/modules/project/common/components/issue/edit-issue-drawer/meta-fields.tsx
@@ -769,7 +769,7 @@ const IssueMetaFields = React.forwardRef(
           },
           onDropdownVisibleChange: (visible: boolean) => {
             if (visible) {
-              !optionList.length && getLabels({ type: 'issue', projectID: Number(projectId) });
+              getLabels({ type: 'issue', projectID: Number(projectId) });
             }
           },
         },


### PR DESCRIPTION
## What this PR does / why we need it:
fix: once dropdown labels, get latest labels

## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=261637&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE2LDQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2XSwiYXNzaWduZWVJRHMiOlsiMTAwMzE0NiJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=-1&type=REQUIREMENT)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: once dropdown labels, get latest labels         |
| 🇨🇳 中文    |        项目协同中每次下拉标签时，拉取最新的标签      |


## Need cherry-pick to release versions?
❎ No

