### PR TITLE
fix(build): change base image from bullseye to default slim tag(stretch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #!dice
-FROM registry.erda.cloud/retag/node:14.18.2-bullseye-slim
+FROM registry.erda.cloud/retag/node:14.18.2-slim
 
 # Set special timezone
 RUN echo "Asia/Shanghai" | tee /etc/timezone


### PR DESCRIPTION
## What this PR does / why we need it:
Tag `bullseye` is the future releases, unstable.
In some scenarios, `bullseye`  is less fault tolerant with the same version of NodeJS, causing the service to fail to start.

Error with bullseye image
<img width="990" alt="image" src="https://user-images.githubusercontent.com/31346321/174568088-961d5bd4-bd95-407e-9c03-1fa5ce2c0763.png">

Same machine with default slim tag image
<img width="808" alt="image" src="https://user-images.githubusercontent.com/31346321/174568393-4cba4ac2-045c-44ee-89c8-548b9265fb30.png">

@McDaddy 

## I have checked the following points:
- [ ] I18n is finished and updated by cli
- [ ] Form fields validation is added and length is limited
- [ ] Display normally on small screen
- [ ] Display normally when some data is empty or null
- [ ] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | change base image from bullseye to default slim tag(stretch)             |
| 🇨🇳 中文    |   替换基础构建镜像，从 bullseye 更换为默认 slim 的版本（stretch）           |


## Need cherry-pick to release versions?
✅ Yes(version is required)
❎ No

