### PR TITLE
fix: delete cmp report history pagination

### DIFF
--- a/shell/app/interface/global.d.ts
+++ b/shell/app/interface/global.d.ts
@@ -360,6 +360,7 @@ type ROUTE_MARK =
   | 'ecp'
   | 'testCase'
   | 'testPlan'
+  | 'cmpReport'
   | 'gallery';
 
 type ROUTE_TO_MARK = 'orgIndex' | 'mspDetail';

--- a/shell/app/modules/cmp/pages/alarm-report/report-records/index.tsx
+++ b/shell/app/modules/cmp/pages/alarm-report/report-records/index.tsx
@@ -16,7 +16,7 @@ import moment, { Moment } from 'moment';
 import { isEmpty, map, get, set, values } from 'lodash';
 import classnames from 'classnames';
 import { useMount, useUnmount } from 'react-use';
-import { Spin, Pagination, DatePicker } from 'antd';
+import { Spin, DatePicker } from 'antd';
 import { Holder, Icon as CustomIcon, BoardGrid } from 'common';
 import { useUpdate } from 'common/use-hooks';
 import { getTimeRanges } from 'common/utils';
@@ -116,7 +116,7 @@ const ReportRecords = () => {
   }, [activedRecord, clearReportTaskRecord, getReportTaskRecord]);
 
   const handleChange = (no: number, dates?: Array<undefined | Moment>) => {
-    let payload = { pageNo: no, pageSize } as any;
+    let payload = { pageNo: no, pageSize: 1000 } as any;
     if (dates) {
       payload = {
         ...payload,
@@ -168,15 +168,6 @@ const ReportRecords = () => {
                   </li>
                 ))}
               </ul>
-              {total && (
-                <Pagination
-                  className="text-center mt-3"
-                  simple
-                  defaultCurrent={1}
-                  total={total}
-                  onChange={(no) => handleChange(no)}
-                />
-              )}
             </Holder>
           </Spin>
         </div>

--- a/shell/app/modules/cmp/router.ts
+++ b/shell/app/modules/cmp/router.ts
@@ -267,10 +267,12 @@ function getCmpRouter(): RouteConfigItem[] {
         {
           path: 'report',
           breadcrumbName: i18n.t('O&M Report'),
+          mark: 'cmpReport',
           routes: [
             {
               path: ':taskId',
               breadcrumbName: '{opReportName}',
+              backToUp: 'cmpReport',
               layout: { fullHeight: true },
               getComp: (cb) => cb(import('app/modules/cmp/pages/alarm-report/report-records')),
             },


### PR DESCRIPTION
## What this PR does / why we need it:
fix: delete cmp report history pagination

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: delete cmp report history pagination         |
| 🇨🇳 中文    |   fix: 删除 运维报告历史翻页          |


## Need cherry-pick to release versions?
❎ No

