### PR TITLE
fix: runtime log format conversion regex bug

### DIFF
--- a/shell/app/common/components/pure-log-roller/__tests__/log-utils.test.tsx
+++ b/shell/app/common/components/pure-log-roller/__tests__/log-utils.test.tsx
@@ -15,12 +15,13 @@ import { regLog } from '../log-util';
 
 describe('log-util', () => {
   it('regLog.LOGSTART should work well', () => {
-    const str = '2021-06-29T11:05:45.713Z INFO - [content]';
+    const str = '2021-06-29T11:05:45.713Z INFO [content] - [thread]';
     expect(regLog.LOGSTART.test(str)).toBeTruthy();
     const result = regLog.LOGSTART.exec(str) || [];
-    const [, time, level, params] = result;
+    const [, time, level, params, thread] = result;
     expect(time).toBe('2021-06-29T11:05:45.713Z');
     expect(level).toBe('INFO');
     expect(params).toBe('content');
+    expect(thread).toBe('thread');
   });
 });

--- a/shell/app/common/components/pure-log-roller/log-util.ts
+++ b/shell/app/common/components/pure-log-roller/log-util.ts
@@ -16,5 +16,5 @@
 // 容器日志中，匹配以上格式的，需要给requestID添加链接，时间和level需要单独取出来标色。
 export const regLog = {
   LOGSTART:
-    /^((?:\d\d){1,2}-(?:0?[1-9]|1[0-2])-(?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9])[T ](?:2[0123]|[01]?[0-9]):?(?:[0-5][0-9])(?::?(?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?))?(?:Z|[+-](?:2[0123]|[01]?[0-9])(?::?(?:[0-5][0-9])))?)(?:\s*)([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|[Nn]otice|NOTICE|[Ii]nfo|INFO|[Ww]arn?(?:ing)?|WARN?(?:ING)?|[Ee]rr?(?:or)?|ERR?(?:OR)?|[Cc]rit?(?:ical)?|CRIT?(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)(?:\s*)-?\s\[(\S*)\]/,
+    /^((?:\d\d){1,2}-(?:0?[1-9]|1[0-2])-(?:(?:0[1-9])|(?:[12][0-9])|(?:3[01])|[1-9])[T ](?:2[0123]|[01]?[0-9]):?(?:[0-5][0-9])(?::?(?:(?:[0-5]?[0-9]|60)(?:[:.,][0-9]+)?))?(?:Z|[+-](?:2[0123]|[01]?[0-9])(?::?(?:[0-5][0-9])))?)(?:\s*)([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|[Nn]otice|NOTICE|[Ii]nfo|INFO|[Ww]arn?(?:ing)?|WARN?(?:ING)?|[Ee]rr?(?:or)?|ERR?(?:OR)?|[Cc]rit?(?:ical)?|CRIT?(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)(?:\s*)\s\[(\S*)\]\s-?\s\[(\S*)\]/,
 };

--- a/shell/app/modules/runtime/common/logs/components/container-log.tsx
+++ b/shell/app/modules/runtime/common/logs/components/container-log.tsx
@@ -29,17 +29,20 @@ const defaultLogName = 'all';
 
 const parseLinkInContent = (content: string, pushSlideComp?: (q: string) => void) => {
   if (regLog.LOGSTART.test(content)) {
-    const [parrent, time, level, params] = regLog.LOGSTART.exec(content);
+    const [parrent, time, level, params, thread] = regLog.LOGSTART.exec(content);
+
     const [serviceName, requestId, ...rest] = (params || '').split(',');
-    if (!requestId) return `[${serviceName}] ${content.split(parrent).join('')}`;
+    if (!requestId) return `[${serviceName}] - [${thread}] ${content.split(parrent).join('')}`;
     const logInfo = content.split(parrent);
     return (
       <React.Fragment>
         {'['}
         <a onClick={() => pushSlideComp && pushSlideComp(requestId)}>
-          <Tooltip title={rest.length ? `[${requestId},${rest}]` : `[${requestId}]`}>{serviceName}</Tooltip>
+          <Tooltip title={rest.length ? `[trace_id: ${requestId}, span_id: ${rest}]` : `[${requestId}]`}>
+            {serviceName}
+          </Tooltip>
         </a>
-        {`] ${logInfo[1]}`}
+        {`] - [${thread}] ${logInfo[1]}`}
       </React.Fragment>
     );
   } else {


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of runtime log format conversion regex.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=368545&iterationID=1580&tab=BUG&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/226278696-858243d5-f651-4bfe-831e-a9f1837632c5.png)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix bug of runtime log format conversion regex.  |
| 🇨🇳 中文    |  修复了runtime日志格式转换正则的问题、 |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.3

