### PR TITLE
feat: issue detail backlog list add date select

### DIFF
--- a/shell/app/modules/project/pages/backlog/issue-item.scss
+++ b/shell/app/modules/project/pages/backlog/issue-item.scss
@@ -66,6 +66,25 @@
       background-color: $platinum;
     }
   }
+
+  .issue-item-date-picker input {
+    color: $color-default-6 !important;
+
+    &::-webkit-input-placeholder {
+      color: $color-default-6 !important;
+    }
+    &:-ms-input-placeholder {
+      color: $color-default-6 !important;
+    }
+    &:-moz-placeholder {
+      color: $color-default-6 !important;
+      opacity: 1;
+    }
+    &::-moz-placeholder {
+      color: $color-default-6 !important;
+      opacity: 1;
+    }
+  }
 }
 
 .issue-item-member-selector {

--- a/shell/app/modules/project/pages/backlog/issue-item.tsx
+++ b/shell/app/modules/project/pages/backlog/issue-item.tsx
@@ -12,7 +12,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 /* eslint-disable react-hooks/exhaustive-deps */
-import { Button, Dropdown, Input, Menu, Modal, Select } from 'antd';
+import { Button, Dropdown, Input, Menu, Modal, Select, DatePicker } from 'antd';
 import { useUpdate } from 'app/common/use-hooks';
 import orgStore from 'app/org-home/stores/org';
 import { Ellipsis, ErdaIcon, Icon as CustomIcon, MemberSelector, EmptyHolder } from 'common';
@@ -215,7 +215,18 @@ export const IssueItem = (props: IIssueProps) => {
     planFinishedAt: {
       Comp: (
         <span key="planFinishedAt" className="mr-6 w-20 truncate">
-          {data.planFinishedAt ? moment(data.planFinishedAt).format('YYYY/MM/DD') : i18n.t('dop:Unspecified')}
+          <DatePicker
+            bordered={false}
+            value={data.planFinishedAt ? moment(data.planFinishedAt) : null}
+            suffixIcon={false}
+            allowClear={false}
+            format={'YYYY/MM/DD'}
+            placeholder={i18n.t('dop:Unspecified')}
+            className="p-0 issue-item-date-picker"
+            onChange={(date) => {
+              updateIssueRecord({ ...data, planFinishedAt: moment(date).format('YYYY-MM-DDTHH:mm:ss') + 'Z' });
+            }}
+          />
         </span>
       ),
       show: true,


### PR DESCRIPTION
## What this PR does / why we need it:
Issue detail backlog list add date select.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=371277&iterationID=1628&type=TASK)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/229699572-3aa45c35-9ae8-461c-8317-c61ef66703e1.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Issue detail backlog list add date select.  |
| 🇨🇳 中文    |  事项详情待办列表增加日期选择。  |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.3

