### PR TITLE
fix: create mr target branch reset bug

### DIFF
--- a/shell/app/modules/application/pages/repo/components/source-target-select.tsx
+++ b/shell/app/modules/application/pages/repo/components/source-target-select.tsx
@@ -113,6 +113,7 @@ interface IState {
   sourceBranch?: string;
   targetBranch?: string;
   removeSourceBranch: boolean;
+  targetBranchHasChange: boolean;
 }
 class SourceTargetSelect extends React.Component<IProps, IState> {
   constructor(props: IProps) {
@@ -123,6 +124,7 @@ class SourceTargetSelect extends React.Component<IProps, IState> {
       sourceBranch,
       targetBranch,
       removeSourceBranch: props.defaultRemoveSourceBranch || false,
+      targetBranchHasChange: false,
     };
     const changed = {} as any;
     if (sourceBranch) {
@@ -153,9 +155,15 @@ class SourceTargetSelect extends React.Component<IProps, IState> {
 
   handleChange = (key: 'sourceBranch' | 'targetBranch') => (value: string) => {
     // @ts-ignore
-    this.setState({ [key as 'sourceBranch' | 'targetBranch']: value }, () => {
-      this.triggerCompare();
-    });
+    this.setState(
+      {
+        [key as 'sourceBranch' | 'targetBranch']: value,
+        targetBranchHasChange: key === 'targetBranch' ? true : this.state.targetBranchHasChange,
+      },
+      () => {
+        this.triggerCompare();
+      },
+    );
     this.triggerChange({ [key]: value }, true);
   };
 
@@ -169,7 +177,7 @@ class SourceTargetSelect extends React.Component<IProps, IState> {
     // Should provide an event to pass value to Form.
     const { onChange } = this.props;
     const newValue = { ...this.state, ...changedValue };
-    if (Reflect.has(changedValue, 'sourceBranch')) {
+    if (Reflect.has(changedValue, 'sourceBranch') && !this.state.targetBranchHasChange) {
       const sourceBranch = changedValue['sourceBranch'];
       const targetPolicy = this.props.branchPolicies.find(({ branch }) => {
         const branches = branch.split(',');


### PR DESCRIPTION
## What this PR does / why we need it:
Fix create mr target branch reset bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=371277&iterationID=1580&type=TASK)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix bug of target branch reset after target branch changed when creating mr.  |
| 🇨🇳 中文    |  修复了创建mr时，目标分支在目标分支改变之后重置的bug。  |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.3

