### PR TITLE
fix: pipeline log height is not 100%

### DIFF
--- a/shell/app/modules/application/pages/obsoleted-pipeline/run-detail/build-log.scss
+++ b/shell/app/modules/application/pages/obsoleted-pipeline/run-detail/build-log.scss
@@ -1,0 +1,7 @@
+.log-content {
+  height: 100%;
+
+  .ant-tabs-content {
+    height: 100%;
+  }
+}

--- a/shell/app/modules/application/pages/obsoleted-pipeline/run-detail/build-log.tsx
+++ b/shell/app/modules/application/pages/obsoleted-pipeline/run-detail/build-log.tsx
@@ -19,6 +19,8 @@ import DeployLog from 'runtime/common/logs/components/deploy-log';
 import i18n from 'i18n';
 import commonStore from 'common/stores/common';
 
+import './build-log.scss';
+
 const linkMark = '##to_link:';
 
 const { TabPane } = Tabs;
@@ -177,8 +179,8 @@ export class PureBuildLog extends React.PureComponent<IProps, IState> {
       );
 
     const detailViewer = (
-      <div>
-        <Tabs>
+      <div className="h-full">
+        <Tabs className="log-content">
           {this.props.showLog && (
             <TabPane tab={i18n.s('execution log')} key="log">
               {logRollerComp}


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of pipeline log height is not 100%.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/ticket?id=373006&iterationID=-1&type=TICKET)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://user-images.githubusercontent.com/82502479/230856276-7cdb8cde-a901-4ccf-880a-ae6fda9e14e2.png)
->
![image](https://user-images.githubusercontent.com/82502479/230856184-b74eb615-f84d-4b64-9ac1-9e6b16cee656.png)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix bug of pipeline log height is not 100%. |
| 🇨🇳 中文    |  修复了流水线日志高度不是页面100%的问题。 |


## Need cherry-pick to release versions?
✅ Yes(version is required)
release/2.3
