### PR TITLE
fix: project report detail page jump bug

### DIFF
--- a/shell/app/modules/dop/pages/report/index.tsx
+++ b/shell/app/modules/dop/pages/report/index.tsx
@@ -308,7 +308,10 @@ const ProjectReport = () => {
           url: goTo.pages.issues,
           params: {
             projectId: detailData.projectID,
-            query: { tab: 'BUG', issueFilter__urlQuery: encode(`{"severities":["FATAL","SERIOUS"]}`) },
+            query: {
+              tab: 'BUG',
+              issueFilter__urlQuery: encode(`{"severities":["FATAL","SERIOUS"],"iterationIDs":[${selectIterations}]}`),
+            },
           },
           render: (text: number) =>
             text ? <Tooltip title={`${text * 100}%`}>{(text * 100).toFixed(2)}%</Tooltip> : '0',
@@ -327,7 +330,10 @@ const ProjectReport = () => {
           url: goTo.pages.issues,
           params: {
             projectId: detailData.projectID,
-            query: { tab: 'BUG', issueFilter__urlQuery: encode(`{"bugStages":["demandDesign"]}`) },
+            query: {
+              tab: 'BUG',
+              issueFilter__urlQuery: encode(`{"bugStages":["demandDesign"],"iterationIDs":[${selectIterations}]}`),
+            },
           },
           render: (text: number) =>
             text ? <Tooltip title={`${text * 100}%`}>{(text * 100).toFixed(2)}%</Tooltip> : '0',


### PR DESCRIPTION
## What this PR does / why we need it:
Fix project report detail page jump bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix project report detail page jump bug.  |
| 🇨🇳 中文    |   修复了项目报表详情页面跳转的bug。  |


## Need cherry-pick to release versions?
❎ No

