### PR TITLE
fix: msp display bug when switch bug before refresh

### DIFF
--- a/shell/app/layout/stores/layout.ts
+++ b/shell/app/layout/stores/layout.ts
@@ -188,7 +188,9 @@ const layout = createStore({
       const { appList, currentApp, menusMap = {}, key } = (_payload as LAYOUT.IInitLayout) || {};
       const { user } = getGlobal('initData');
       if (key === 'sysAdmin' && !user.isSysAdmin) return;
-      let list = [...state.appList, ...(appList || [])];
+
+      const _applist = JSON.parse(JSON.stringify(state.appList));
+      let list = [..._applist, ...(appList || [])];
       // Some modules are loaded later, but in a fixed order
       const positionList = list.filter((item) => item.position);
       list = list.filter((item) => !item.position);


### PR DESCRIPTION
## What this PR does / why we need it:
Fix bug of msp display bug when switch bug before refresh.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix bug of msp display bug when switch bug before refresh.  |
| 🇨🇳 中文    |   修复了当切换组织后，刷新页面之前msp不展示的问题。  |


## Need cherry-pick to release versions?
❎ No

