### PR TITLE
fix: ai test add regenerate button

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -896,6 +896,7 @@
     "recertification": "recertification",
     "refresh": "refresh",
     "refuse": "refuse",
+    "regenerate": "regenerate",
     "regexp": "regexp",
     "reject": "reject",
     "related Client": "related Client",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -896,6 +896,7 @@
     "recertification": "重新认证",
     "refresh": "刷新",
     "refuse": "拒绝",
+    "regenerate": "重新生成",
     "regexp": "正则表达式",
     "reject": "拒绝",
     "related Client": "关联客户端",

--- a/shell/app/layout/pages/page-container/components/chat-GPT/functional-test-cases/desc-list.tsx
+++ b/shell/app/layout/pages/page-container/components/chat-GPT/functional-test-cases/desc-list.tsx
@@ -42,7 +42,7 @@ const DescList = ({ rows: _rows, testSetID }: { rows: IRow[]; testSetID: number 
     );
   }, [_rows]);
 
-  const getTestCase = async (items: IRow[]) => {
+  const getTestCase = async (items: IRow[], cb: (data: Case[]) => void) => {
     setLoading(true);
     const res = await getAddonList({
       userId,
@@ -53,7 +53,7 @@ const DescList = ({ rows: _rows, testSetID }: { rows: IRow[]; testSetID: number 
     });
 
     if (res.success) {
-      setCases(res.data || []);
+      cb?.(res.data);
     }
     setLoading(false);
   };
@@ -86,7 +86,7 @@ const DescList = ({ rows: _rows, testSetID }: { rows: IRow[]; testSetID: number 
     }
   };
 
-  const renderItem = (item: Obj, index: number) => {
+  const renderItem = (item: IRow, index: number) => {
     return (
       <div className="bg-white rounded-[4px] p-2 mb-4">
         <div className="flex-h-center">
@@ -106,13 +106,21 @@ const DescList = ({ rows: _rows, testSetID }: { rows: IRow[]; testSetID: number 
             }}
           />
         </div>
-        {(cases.length && (
+        {(cases[index] && (
           <>
             <Divider />
             <div className="flex-h-center">
               <ErdaIcon type="quexian" className="text-xl mr-1" />
               <div className="flex-1">{i18n.t('test case preview')}</div>
-              <Button>{i18n.t('apply')}</Button>
+              <Button
+                onClick={() =>
+                  getTestCase([item], (data) => {
+                    setCases(cases.map((item) => (item.requirementID === data[0]?.requirementID ? data[0] : item)));
+                  })
+                }
+              >
+                {i18n.t('regenerate')}
+              </Button>
             </div>
             <Divider />
             <div>
@@ -180,7 +188,9 @@ const DescList = ({ rows: _rows, testSetID }: { rows: IRow[]; testSetID: number 
               {i18n.t('default:test case description and preview')}
             </div>
             <div className="flex-none mb-2">
-              <Button onClick={() => getTestCase(rows)}>{i18n.t('default:batch generation')}</Button>
+              <Button onClick={() => getTestCase(rows, (data) => setCases(data || []))}>
+                {i18n.t('default:batch generation')}
+              </Button>
               <Button className="ml-1" onClick={() => apply()}>
                 {i18n.t('default:batch apply')}
               </Button>


### PR DESCRIPTION
## What this PR does / why we need it:
AI test add regenerate button.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | AI test add regenerate button.  |
| 🇨🇳 中文    |  AI测试新增重新生成按钮。   |


## Need cherry-pick to release versions?
❎ No

