### PR TITLE
fix: msp alarm config add rule bug

### DIFF
--- a/shell/app/modules/cmp/common/custom-alarm/index.tsx
+++ b/shell/app/modules/cmp/common/custom-alarm/index.tsx
@@ -645,7 +645,7 @@ const CustomAlarm = ({ scopeType }: { scopeType: string }) => {
 
   const beforeSubmit = (data: any) => {
     return new Promise((resolve, reject) => {
-      if (isEmpty(editingFields)) {
+      if (selectedMetric && isEmpty(editingFields)) {
         message.warning(i18n.t('cmp:field rules are required'));
         return reject();
       }


### PR DESCRIPTION
## What this PR does / why we need it:
Msp alarm config add rule bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Msp alarm config add rule bug.  |
| 🇨🇳 中文    |   微服务告警配置创建规则的bug。   |


## Need cherry-pick to release versions?
❎ No

