### PR TITLE
fix: pipeline history internationalization bug

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -79,6 +79,7 @@
     "CPU limit": "CPU limit",
     "CPU quota": "CPU quota",
     "Cancel": "Cancel",
+    "Canceling": "Canceling",
     "Certificate": "Certificate",
     "Channel name": "Channel name",
     "Channel type": "Channel type",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -79,6 +79,7 @@
     "CPU limit": "CPU 限制",
     "CPU quota": "CPU 配额",
     "Cancel": "取消",
+    "Canceling": "取消中",
     "Certificate": "证书",
     "Channel name": "渠道名称",
     "Channel type": "渠道类型",

--- a/shell/app/modules/application/pages/build-detail/config.tsx
+++ b/shell/app/modules/application/pages/build-detail/config.tsx
@@ -67,7 +67,7 @@ export const ciStatusMap = {
     status: 'warning',
   },
   Canceling: {
-    text: '取消中',
+    text: i18n.t('Canceling'),
     clolor: 'blue',
     status: 'processing',
   },

--- a/shell/app/modules/application/pages/obsoleted-pipeline/run-detail/config.tsx
+++ b/shell/app/modules/application/pages/obsoleted-pipeline/run-detail/config.tsx
@@ -67,7 +67,7 @@ export const ciStatusMap = {
     status: 'warning',
   },
   Canceling: {
-    text: '取消中',
+    text: i18n.t('Canceling'),
     clolor: 'blue',
     status: 'processing',
   },

--- a/shell/app/modules/project/common/components/pipeline-manage/run-detail/config.ts
+++ b/shell/app/modules/project/common/components/pipeline-manage/run-detail/config.ts
@@ -67,7 +67,7 @@ export const ciStatusMap = {
     status: 'warning',
   },
   Canceling: {
-    text: '取消中',
+    text: i18n.t('Canceling'),
     clolor: 'blue',
     status: 'processing',
   },

--- a/shell/app/modules/project/common/components/pipeline-new/config.tsx
+++ b/shell/app/modules/project/common/components/pipeline-new/config.tsx
@@ -69,7 +69,7 @@ export const ciStatusMap = {
     status: 'warning',
   },
   Canceling: {
-    text: '取消中',
+    text: i18n.t('Canceling'),
     clolor: 'blue',
     status: 'processing',
   },


### PR DESCRIPTION
## What this PR does / why we need it:
Pipeline history internationalization bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
![image](https://github.com/erda-project/erda-ui/assets/82502479/968616c7-2f46-4a29-b89e-40b48744c88c)


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Pipeline history internationalization bug.  |
| 🇨🇳 中文    |   流水线历史列表国际化bug。   |


## Need cherry-pick to release versions?
❎ No

