### PR TITLE
fix: project info edit labels bug

### DIFF
--- a/shell/app/modules/org/pages/projects/settings/info/index.tsx
+++ b/shell/app/modules/org/pages/projects/settings/info/index.tsx
@@ -471,7 +471,7 @@ const Info = () => {
 
       <FormModal
         onOk={({ labels, ...result }) => {
-          updatePrj({ ...result, labels: labels?.split(',') }).then(() => {
+          updatePrj({ ...result, labels: (Array.isArray(labels) ? labels : labels?.split(',')) || [] }).then(() => {
             updater.projectInfoEditVisible(false);
             updater.projectInfoSaveDisabled(true);
           });

--- a/shell/app/modules/project/common/components/section-info-edit.tsx
+++ b/shell/app/modules/project/common/components/section-info-edit.tsx
@@ -60,7 +60,9 @@ class SectionInfoEdit extends React.Component<IProps, IState> {
   };
 
   handleSubmit = ({ labels, ...rest }: Obj) => {
-    return Promise.resolve(this.props.updateInfo({ ...rest, labels: labels ? labels.split(',') : [] })).then(() => {
+    return Promise.resolve(
+      this.props.updateInfo({ ...rest, labels: (Array.isArray(labels) ? labels : labels?.split(',')) || [] }),
+    ).then(() => {
       this.toggleModal();
     });
   };


### PR DESCRIPTION
## What this PR does / why we need it:
Project info edit labels bug.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=533802&iterationID=12783&tab=BUG&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Project info edit labels bug.  |
| 🇨🇳 中文    |   项目信息编辑标签报错。   |


## Need cherry-pick to release versions?
❎ No

