### PR TITLE
fix: add missing params let cmp container download logs from apiserver

### DIFF
--- a/shell/app/modules/cmp/pages/cluster-container/cluster-terminal.tsx
+++ b/shell/app/modules/cmp/pages/cluster-container/cluster-terminal.tsx
@@ -147,7 +147,7 @@ export const K8sPodTerminalLog = (
     let end = start.valueOf() + duration * 60 * 1000;
     end = Math.min(end, now) * 1000000;
     const _start = start.valueOf() * 1000000; // ns
-    const logFile = `/api/orgCenter/logs/actions/download?clusterName=${clusterName}&end=${end}&id=${containerId}&source=container&start=${_start}`;
+    const logFile = `/api/orgCenter/logs/actions/download?clusterName=${clusterName}&end=${end}&id=${containerId}&source=container&start=${_start}&live=true&containerName=${containerName}&podName=${podName}&namespace=${namespace}&isFallBack=true`;
     window.open(setApiWithOrg(logFile));
     setDownloadVis(false);
   };


### PR DESCRIPTION
## What this PR does / why we need it:
add missing params let cmp container download logs from apiserver

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=438540&iterationID=-1&type=BUG)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add missing params let cmp container download logs from apiserver            |
| 🇨🇳 中文    |    修补缺少的参数让多云管理容器从k8s apiserver下载日志          |


## Need cherry-pick to release versions?
✅ Yes(version is required)
❎ No

