### PR TITLE
fix: project level custom fields interface add params name

### DIFF
--- a/shell/app/modules/org/pages/projects/issue-field-setting-modal.tsx
+++ b/shell/app/modules/org/pages/projects/issue-field-setting-modal.tsx
@@ -50,7 +50,7 @@ export const IssueFieldSettingModal = ({ visible, issueType = 'EPIC', closeModal
     getFieldOptions({
       propertyIssueType: 'COMMON',
       orgID,
-      ...(projectId ? { scopeType: 'project', scopeID: projectId } : {}),
+      ...(projectId ? { scopeType: 'project', scopeID: projectId, onlyProject: true } : {}),
     }).then(({ data }) => {
       updater.filedOptions(data || []);
     });

--- a/shell/app/modules/org/stores/issue-field.ts
+++ b/shell/app/modules/org/stores/issue-field.ts
@@ -51,7 +51,7 @@ const issueFieldStore = createStore({
     },
     async getFieldsByIssue({ call, update, getParams }, payload: ISSUE_FIELD.IFieldsByIssueQuery) {
       const { projectId } = getParams();
-      const fieldList = await call(getFieldsByIssue, addProjectId(projectId)(payload));
+      const fieldList = await call(getFieldsByIssue, addProjectId(projectId)({ ...payload, onlyProject: true }));
       update({ fieldList: fieldList || [] });
       return fieldList || [];
     },


### PR DESCRIPTION
## What this PR does / why we need it:
Project level custom fields interface add params name.

## I have checked the following points:
- [x] I18n is finished and updated by cli
- [x] Form fields validation is added and length is limited
- [x] Display normally on small screen
- [x] Display normally when some data is empty or null
- [x] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Project level custom fields interface add params name.  |
| 🇨🇳 中文    |   项目级自定义字段接口增加参数。 |


## Need cherry-pick to release versions?
❎ No

