### PR TITLE
fix(shell): add finish time for stop service pod

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -189,6 +189,7 @@
     "Field": "Field",
     "File": "File",
     "Filter": "Filter",
+    "Finish Time": "Finish Time",
     "First Contentful Paint Time": "First Contentful Paint Time",
     "First Paint Time": "First Paint Time",
     "For cluster resource information corresponding to each environment, the concept and settings of specific clusters, please see": "For cluster resource information corresponding to each environment, the concept and settings of specific clusters, please see",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -189,6 +189,7 @@
     "Field": "字段",
     "File": "文件",
     "Filter": "过滤",
+    "Finish Time": "结束时间",
     "First Contentful Paint Time": "首屏时间",
     "First Paint Time": "白屏时间",
     "For cluster resource information corresponding to each environment, the concept and settings of specific clusters, please see": "各环境对应的集群资源信息，具体集群的概念和设置请参考",

--- a/shell/app/modules/runtime/pages/overview/components/service-card.tsx
+++ b/shell/app/modules/runtime/pages/overview/components/service-card.tsx
@@ -680,6 +680,13 @@ const StopedPods = ({
       render: (text: string) => moment(text).format('YYYY-MM-DD HH:mm:ss'),
     },
     {
+      title: i18n.t('Finish Time'),
+      width: 176,
+      dataIndex: 'finishedAt',
+      className: 'th-time nowrap',
+      render: (text: string) => moment(text).format('YYYY-MM-DD HH:mm:ss'),
+    },
+    {
       title: i18n.t('Operations'),
       dataIndex: 'Operations',
       render: (_, record: RUNTIME.ServicePod) => {


### PR DESCRIPTION
## What this PR does / why we need it:

Add finish time for stop pod

## I have checked the following points:
- [ x ] I18n is finished and updated by cli
- [ x ] Form fields validation is added and length is limited
- [ x ] Display normally on small screen
- [ x ] Display normally when some data is empty or null
- [ x ] Display normally in english mode


## Which issue(s) this PR fixes:
Fixes #

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)
https://erda.cloud/erda/dop/projects/387/issues/all?id=553572&iterationID=12783&tab=TASK&type=TASK

## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
✅ Yes(screenshot is required)

![image](https://github.com/erda-project/erda-ui/assets/2928664/212aaff5-1264-4fb9-adc4-9ef71a3c26f1)



## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      new feature, no break change        |
| 🇨🇳 中文    |      完全兼容        |



## Need cherry-pick to release versions?
❎ No

