### PR TITLE
chore(build): use `npm ci` when build enterprise-ui

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -61,7 +61,7 @@ stages:
           version: "1.0"
           params:
             build_cmd:
-              - cd ${{ dirs.erda-ui-enterprise }}/admin && npm i
+              - cd ${{ dirs.erda-ui-enterprise }}/admin && npm ci
               - npm run build
               - cp -r ${{ dirs.erda-ui-enterprise }}/{public,server} $WORKDIR
             node_version: 14


### PR DESCRIPTION
## What this PR does / why we need it:

use `npm ci` when build enterprise-ui


## Which issue(s) this PR fixes:
Fixes #

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=620211&iterationID=12783&type=TASK)


## Does this PR introduce a user interface change?
<!--
Delete the unchosen one
-->
❎ No


## ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    use `npm ci` when build enterprise-ui          |
| 🇨🇳 中文    |    构建 enterprise-ui 时使用 `npm ci`           |


## Need cherry-pick to release versions?
❎ No

